### PR TITLE
chore: update for crystal 0.36

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Crystal
-        run: brew install openssl crystal && brew uninstall --ignore-dependencies llvm && brew install llvm@9
+        run: brew update && brew install openssl crystal && brew uninstall --ignore-dependencies llvm && brew install llvm@9
       - name: Install dependencies
         run: shards install --production
       - name: Build the binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as crystal-builder
+FROM alpine:3.13 as crystal-builder
 
 RUN \
   apk add --update --no-cache --force-overwrite \
@@ -35,7 +35,7 @@ RUN apk del -r --purge autoconf automake libtool
 
 # Download and install crystal.
 RUN \
-  wget -O /tmp/crystal.tar.gz https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz &&\
+  wget -O /tmp/crystal.tar.gz https://github.com/crystal-lang/crystal/releases/download/0.36.0/crystal-0.36.0-1-linux-x86_64.tar.gz &&\
   tar -xz -C /usr --strip-component=1  -f /tmp/crystal.tar.gz \
   --exclude */lib/crystal/lib \
   --exclude */share/crystal/src/llvm/ext/llvm_ext.o \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
 
 *Recommended method is to download and use pre-built binaries when possible. Building from source does take a long time.*
 
+### Compatibility
+
+Crystal     | Crystalline
+------------|------------
+**0.36.0**  | **0.2.X (latest)**
+0.35.1      | 0.1.X
+
 ### Pre-built binaries
 
 #### Latest Release
@@ -48,6 +55,10 @@ curl -L https://github.com/elbywan/crystalline/releases/latest/download/crystall
 gzip -d crystalline.gz &&\
 chmod u+x crystalline
 ```
+
+#### Specific release
+
+[See the releases page.](https://github.com/elbywan/crystalline/releases)
 
 #### Specific commit
 

--- a/shard.yml
+++ b/shard.yml
@@ -21,6 +21,6 @@ development_dependencies:
     github: samueleaton/sentry
     branch: master
 
-crystal: 0.35.1
+crystal: 0.36.0
 
 license: MIT

--- a/src/crystalline/ext/compiler.cr
+++ b/src/crystalline/ext/compiler.cr
@@ -80,7 +80,7 @@ module Crystal
       end
 
       node.raise "#{message}\n\n#{notes.join("\n")}"
-    rescue ex : Crystal::Exception
+    rescue ex : Crystal::CodeError
       node.raise "while requiring \"#{node.string}\"", ex
     rescue ex
       raise ::Exception.new("while requiring \"#{node.string}\"", ex)
@@ -100,7 +100,7 @@ module Crystal
 
   class Program
     property fail_slow = false
-    getter error_stack = Set(Crystal::Exception).new
+    getter error_stack = Set(Crystal::CodeError).new
 
     # Will not raise if the semantic analysis fails.
     def fail_slow_semantic(node : ASTNode, cleanup = true) : ASTNode
@@ -137,7 +137,7 @@ module Crystal
         end
 
         {result, self.error_stack.to_a}
-      rescue e : Crystal::Exception
+      rescue e : Crystal::CodeError
         program.error_stack << e
         # Returns a partially typed ast.
         node
@@ -182,7 +182,7 @@ module Crystal
         visitor.end_visit self
         visitor.end_visit_any self
       end
-    rescue e : Crystal::Exception
+    rescue e : Crystal::CodeError
       if !visitor.is_a?(Crystal::TopLevelVisitor) && visitor.responds_to? :program && visitor.program.fail_slow
         visitor.program.error_stack << e
       else

--- a/src/crystalline/lsp/log.cr
+++ b/src/crystalline/lsp/log.cr
@@ -12,7 +12,7 @@ module LSP
       message_type = case entry.severity
                      when ::Log::Severity::Info
                        LSP::MessageType::Info
-                     when ::Log::Severity::Warning
+                     when ::Log::Severity::Warn
                        LSP::MessageType::Warning
                      when ::Log::Severity::Error, ::Log::Severity::Fatal
                        LSP::MessageType::Error


### PR DESCRIPTION
#### Updates for crystal 0.36.0

- `Crystal::Exception` renamed to `Crystal::CodeError`
- `:Log::Severity::Warning` renamed to `:Log::Severity::Warn`
- Update the linux dockerfile