### PR TITLE
feat: Support multiple projects per workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ This can be extremely important to understand when you are writing a code librar
 require "./spec/**"
 ```
 
+### Multiple projects
+
+If you have multiple Crystal projects in a single folder (e.g. a monorepo), you can create a `.crystalline.yml` in the root, containing an array of paths to the individual Crystal projects:
+
+```yml
+projects:
+  - my_project_1
+  - my_project_2
+```
+
+Each of these projects should ideally contain the `shard.yml` containing the entry point as mentioned above. However, even if no shard.yml is present, `require`s will still be resolved relative to the project directory rather than the root directory.
+
 ## Features
 
 **Disclaimer: `Crystalline` is not as extensive in terms of features as other Language Servers but still provides very convenient tools.**

--- a/src/crystalline/classes/analysis/analysis.cr
+++ b/src/crystalline/classes/analysis/analysis.cr
@@ -5,19 +5,19 @@ require "./submodule_visitor"
 
 module Crystalline::Analysis
   # Compile a target *file_uri*.
-  def self.compile(server : LSP::Server, file_uri : URI, *, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false)
+  def self.compile(server : LSP::Server, file_uri : URI, *, lib_path : String? = nil, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false)
     if file_uri.scheme == "file"
       file = File.new file_uri.decoded_path
       sources = [
         Crystal::Compiler::Source.new(file_uri.decoded_path, file.gets_to_end),
       ]
       file.close
-      self.compile(server, sources, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level)
+      self.compile(server, sources, lib_path: lib_path, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level)
     end
   end
 
   # Compile an array of *sources*.
-  def self.compile(server : LSP::Server, sources : Array(Crystal::Compiler::Source), *, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false)
+  def self.compile(server : LSP::Server, sources : Array(Crystal::Compiler::Source), *, lib_path : String? = nil, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false)
     diagnostics = Diagnostics.new
     reply_channel = Channel(Crystal::Compiler::Result | Exception).new
 
@@ -34,6 +34,13 @@ module Crystalline::Analysis
         compiler.wants_doc = wants_doc
         compiler.stdout = dev_null
         compiler.stderr = dev_null
+
+        if lib_path_override = lib_path
+          path = Crystal::CrystalPath.default_path_without_lib.split(Process::PATH_DELIMITER)
+          path.insert(0, lib_path_override)
+          compiler.crystal_path = Crystal::CrystalPath.new(path.join(Process::PATH_DELIMITER))
+        end
+
         reply = begin
           if top_level
             # Top level only.

--- a/src/crystalline/classes/project.cr
+++ b/src/crystalline/classes/project.cr
@@ -1,0 +1,85 @@
+require "yaml"
+
+class Crystalline::Project
+  class ProjectFile
+    include YAML::Serializable
+
+    getter projects : Array(String) = [] of String
+  end
+
+  # The project root filesystem uri.
+  getter root_uri : URI
+  # The dependencies of the project, meaning the list of files required by the compilation target (entry point).
+  property dependencies : Set(String) = Set(String).new
+  # Determines the project entry point.
+  getter? entry_point : URI? do
+    path = Path[root_uri.decoded_path, "shard.yml"]
+    shards_yaml = File.open(path) do |file|
+      YAML.parse(file)
+    end
+    shard_name = shards_yaml["name"].as_s
+    # If shard.yml has the `crystalline/main` key, use that.
+    relative_main = shards_yaml.dig?("crystalline", "main").try &.as_s
+    # Else if shard.yml has a `targets/[shard name]/main` key, use that.
+    relative_main ||= shards_yaml.dig?("targets", shard_name, "main").try &.as_s
+    if relative_main && File.exists? Path[root_uri.decoded_path, relative_main]
+      main_path = Path[root_uri.decoded_path, relative_main]
+      # Add the entry point as a dependency to itself.
+      dependencies << main_path.to_s
+      URI.parse("file://#{main_path}")
+    end
+  rescue e
+    nil
+  end
+
+  def initialize(@root_uri)
+  end
+
+  # Finds and returns an array of all projects in the workspace root.
+  def self.find_in_workspace_root(workspace_root_uri : URI) : Array(Project)
+    # First, check for a Crystalline project file.
+    begin
+      crystalline_path = Path[workspace_root_uri.decoded_path, ".crystalline.yml"]
+      crystalline_file = File.open(crystalline_path) do |file|
+        ProjectFile.from_yaml(file)
+      end
+
+      crystalline_file.projects.map do |p|
+        path = Path[workspace_root_uri.decoded_path, p].normalize
+        Project.new(URI.parse("file://#{path}"))
+      end
+    rescue e
+      # Failing that, create a project for the workspace root.
+      [Project.new(workspace_root_uri)]
+    end
+  end
+
+  # Finds the path-wise distance to the given file URI. If the file URI is not a
+  # dependency of this workspace's entry point, returns nil.
+  def distance_to_dependency(file_uri : URI) : Int32?
+    file_path = file_uri.decoded_path
+    return nil if !file_path.in?(dependencies)
+
+    relative = Path[file_uri.decoded_path].relative_to?(root_uri.decoded_path)
+    # If we can't get a relative path, give it the maximum distance possible, so
+    # it's the lowest priority.
+    return Int32::MAX if relative.nil?
+
+    relative.parts.size
+  end
+
+  # Path to the shards "lib" path for this project.
+  def default_lib_path
+    Path[@root_uri.decoded_path, "lib"].to_s
+  end
+
+  # Finds the best-fitting project to use for the given file.
+  def self.best_fit_for_file(projects : Array(Project), file_uri : URI) : Project?
+    project_distances = projects.compact_map do |p|
+      distance = p.distance_to_dependency(file_uri)
+      {p, distance} if distance
+    end
+
+    project_distances.sort_by(&.[1]).first?.try(&.[0])
+  end
+end

--- a/src/crystalline/classes/text_document.cr
+++ b/src/crystalline/classes/text_document.cr
@@ -1,14 +1,15 @@
 require "priority-queue"
 require "uri"
+require "./project"
 
 class Crystalline::TextDocument
   getter uri : URI
   @inner_contents : Array(String) = [] of String
   getter! version : Int32
   @pending_changes : Priority::Queue({String, LSP::Range}) = Priority::Queue({String, LSP::Range}).new
+  getter? project : Project?
 
-  def initialize(uri : String, contents : String)
-    @uri = URI.parse(uri)
+  def initialize(@uri, @project, contents : String)
     self.contents = contents
   end
 

--- a/src/crystalline/classes/workspace.cr
+++ b/src/crystalline/classes/workspace.cr
@@ -3,6 +3,7 @@ require "uri"
 require "yaml"
 require "./text_document"
 require "./progress"
+require "./project"
 require "./result_cache"
 
 class Crystalline::Workspace
@@ -12,38 +13,20 @@ class Crystalline::Workspace
   getter root_uri : URI?
   # A list of documents that are openened in the text editor.
   getter opened_documents = {} of String => TextDocument
-  # The dependencies of the workspace, meaning the list of files required by the compilation target (entry point).
-  getter dependencies : Set(String) = Set(String).new
-  # Determines the workspace entry point.
-  getter? entry_point : URI? do
-    root_uri.try { |uri|
-      path = Path[uri.decoded_path, "shard.yml"]
-      shards_yaml = File.open(path) do |file|
-        YAML.parse(file)
-      end
-      shard_name = shards_yaml["name"].as_s
-      # If shard.yml has the `crystalline/main` key, use that.
-      relative_main = shards_yaml.dig?("crystalline", "main").try &.as_s
-      # Else if shard.yml has a `targets/[shard name]/main` key, use that.
-      relative_main ||= shards_yaml.dig?("targets", shard_name, "main").try &.as_s
-      if relative_main && File.exists? relative_main
-        main_path = Path[uri.decoded_path, relative_main]
-        # Add the entry point as a dependency to itself.
-        dependencies << main_path.to_s
-        URI.parse("file://#{main_path}")
-      end
-    }
-  rescue e
-    nil
-  end
+  # A list of projects in this workspace
+  getter projects = [] of Project
 
   def initialize(server : LSP::Server, root_uri : String?)
-    @root_uri = root_uri.try &->URI.parse(String)
+    if @root_uri = root_uri.try &->URI.parse(String)
+      @projects = Project.find_in_workspace_root @root_uri.not_nil!
+    end
   end
 
   def open_document(params : LSP::DidOpenTextDocumentParams)
     raw_uri = params.text_document.uri
-    document = TextDocument.new(raw_uri, params.text_document.text)
+    uri = URI.parse(raw_uri)
+    project = Project.best_fit_for_file(@projects, uri)
+    document = TextDocument.new(uri, project, params.text_document.text)
     @opened_documents[raw_uri] = document
   end
 
@@ -54,19 +37,20 @@ class Crystalline::Workspace
         {change.text, change.range}
       }
       document.update_contents(content_changes, version: params.text_document.version)
+
+      document.project?.try(&.entry_point?).try { |entry|
+        @result_cache.invalidate(entry.to_s)
+      }
     }
     @result_cache.invalidate(file_uri)
-    entry_point?.try { |entry|
-      @result_cache.invalidate(entry.to_s)
-    } if inside_workspace?(URI.parse file_uri)
     # spawn self.compile(server, URI.parse(file_uri), in_memory: true )
   end
 
   def close_document(server : LSP::Server, params : LSP::DidCloseTextDocumentParams)
     file_uri = params.text_document.uri
-    @opened_documents.delete(params.text_document.uri)
+    document = @opened_documents.delete(params.text_document.uri)
     @result_cache.invalidate(file_uri)
-    Diagnostics.new.init_value(file_uri).publish(server) unless inside_workspace?(URI.parse file_uri)
+    Diagnostics.new.init_value(file_uri).publish(server) unless document.try(&.project?)
   end
 
   def save_document(server : LSP::Server, params : LSP::DidSaveTextDocumentParams)
@@ -94,16 +78,13 @@ class Crystalline::Workspace
     # swallow exceptions silently
   end
 
-  private def inside_workspace?(file_uri : URI)
-    entry_point? && dependencies.size > 0 && file_uri.decoded_path.in?(dependencies)
-  end
-
   # Run a top level semantic analysis to compute dependencies.
-  def recalculate_dependencies(server)
-    return unless target = entry_point?
+  def recalculate_dependencies(server, project)
+    return unless target = project.entry_point?
 
-    Analysis.compile(server, target, ignore_diagnostics: true, wants_doc: false, top_level: true).try { |result|
-      @dependencies = result.program.requires
+    lib_path = project.default_lib_path
+    Analysis.compile(server, target, lib_path: lib_path, ignore_diagnostics: true, wants_doc: false, top_level: true).try { |result|
+      project.dependencies = result.program.requires
     }
   rescue
     nil
@@ -115,7 +96,7 @@ class Crystalline::Workspace
   # Use the crystal compiler to typecheck the program.
   def compile(
     server : LSP::Server,
-    file_uri : URI? = nil,
+    file_uri : URI,
     *,
     in_memory = false,
     ignore_diagnostics = server.client_capabilities.ignore_diagnostics?,
@@ -127,27 +108,27 @@ class Crystalline::Workspace
     top_level = false,
     discard_nil_cached_result = false
   )
-    # We need a target.
-    return nil unless file_uri || entry_point?
+    @projects.each do |project|
+      # If the project has less than 1 dependency, it could mean that the last
+      # dependency calculation failed (likely because of a syntax error). So we
+      # try again.
+      recalculate_dependencies(server, project) if project.dependencies.size < 2
+    end
 
-    # If the workspace entry point has less than 1 dependency, it could mean that the last dependency calculation failed (likely because of a syntax error).
-    # So we try again.
-    recalculate_dependencies(server) if dependencies.size < 2
-
-    if external_file = file_uri.try { |uri| !inside_workspace?(uri) }
-      # If the file is not a workspace dependency.
+    project = Project.best_fit_for_file(@projects, file_uri)
+    if project && (entry_point = project.entry_point?)
+      target = entry_point
+      progress = Progress.new(
+        token: "workspace/compile",
+        title: "Building project",
+        message: target.decoded_path
+      )
+    else
+      # The file is not a project dependency.
       target = file_uri.not_nil!
       progress = Progress.new(
         token: "workspace/compile",
         title: "Building",
-        message: target.decoded_path
-      )
-    else
-      # File is a dependency.
-      target = entry_point?.not_nil!
-      progress = Progress.new(
-        token: "workspace/compile",
-        title: "Building workspace",
         message: target.decoded_path
       )
     end
@@ -189,7 +170,9 @@ class Crystalline::Workspace
             file_overrides[file_path] = contents
           }
         end
-        result = Analysis.compile(server, sources || target, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level)
+
+        lib_path = project.try(&.default_lib_path)
+        result = Analysis.compile(server, sources || target, lib_path: lib_path, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level)
         # Store the result in the cache, unless a client event invalided the previous cache.
         # For instance if a compilation is running, but the user saved the document in the meantime (before completion)
         # then we discard the result because it is already outdated.
@@ -198,9 +181,9 @@ class Crystalline::Workspace
         end
 
         if result
-          unless external_file
-            # Store the workspace dependencies.
-            @dependencies = result.program.requires
+          if project.try(&.entry_point?)
+            # Store the project dependencies.
+            project.not_nil!.dependencies = result.program.requires
           end
           "Completed successfully."
         else
@@ -213,7 +196,7 @@ class Crystalline::Workspace
       select
       when result = sync_channel.receive
         result
-        # Just in case…
+      # Just in case…
       when timeout 120.seconds
         progress.send_progress_end(server)
         nil

--- a/src/crystalline/controller.cr
+++ b/src/crystalline/controller.cr
@@ -20,7 +20,11 @@ class Crystalline::Controller
   def when_ready : Nil
     # Compile the workspace at once.
     spawn same_thread: true do
-      workspace.compile(@server)
+      workspace.projects.each do |p|
+        if entry_point = p.entry_point?
+          workspace.compile(@server, entry_point)
+        end
+      end
     end
   end
 

--- a/src/crystalline/ext/compiler.cr
+++ b/src/crystalline/ext/compiler.cr
@@ -200,4 +200,29 @@ module Crystal
       }
     end
   end
+
+  struct CrystalPath
+    # Adds functionality to get the CRYSTAL_PATH value, but without the default
+    # library directory.
+    def self.default_path_without_lib
+      parts = self.default_path.split(Process::PATH_DELIMITER)
+      parts.select(&.!=(DEFAULT_LIB_PATH)).join(Process::PATH_DELIMITER)
+    end
+  end
+
+  class Program
+    # Make it possible to use a custom library path.
+    setter crystal_path
+  end
+
+  class Compiler
+    # Make it possible to use a custom library path with the Program.
+    property crystal_path = Crystal::CrystalPath.new
+
+    private def new_program(sources)
+      program = previous_def
+      program.crystal_path = crystal_path
+      program
+    end
+  end
 end


### PR DESCRIPTION
This adds the ability to create a `.crystalline.yml` file in the workspace root containing a list of project folders. Entry points and `require`s will then all be resolved relative to the individual projects, rather than the root of the workspace.

I would appreciate some more testing! It seems to all work as expected, but I'm also an individual with a limited "project pool" to test on.