### PR TITLE
Fix link failure due to missing HashStringType

### DIFF
--- a/src/crystalline/classes/analysis/analysis.cr
+++ b/src/crystalline/classes/analysis/analysis.cr
@@ -210,7 +210,7 @@ module Crystalline::Analysis
     SubModuleVisitor.new(module_type).process_result(result)
   end
 
-  def self.context_at(result : Crystal::Compiler::Result, location : Crystal::Location) : Crystal::HashStringType?
+  def self.context_at(result : Crystal::Compiler::Result, location : Crystal::Location) : Hash(String, Crystal::Type)?
     Crystal::ContextVisitor.new(location).process(result).contexts.try &.last?
   end
 end


### PR DESCRIPTION
HashStringType was removed in the Crystal compiler in commit
b48f3a531167e671ae80c7b90a27f137ff783275.