### PR TITLE
Broken source fixer

### DIFF
--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -205,6 +205,12 @@ describe Crystalline::BrokenSourceFixer do
     CRYSTAL
 
   it_fixes <<-CRYSTAL, <<-CRYSTAL
+    call x {
+    CRYSTAL
+    call x {; }
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
     unless foo
     CRYSTAL
     unless foo; end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -1,0 +1,40 @@
+require "spec"
+require "../src/crystalline/broken_source_fixer"
+
+def it_fixes(from, to, file = __FILE__, line = __LINE__)
+  it(file: file, line: line) do
+    Crystalline::BrokenSourceFixer.fix(from).should eq(to)
+  end
+end
+
+describe Crystalline::BrokenSourceFixer do
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    if foo
+    CRYSTAL
+    if foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+    end
+    CRYSTAL
+    def foo
+      if bar; end
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+
+      puts 1
+    end
+    CRYSTAL
+    def foo
+      if bar
+      end
+      puts 1
+    end
+    CRYSTAL
+end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -126,11 +126,51 @@ describe Crystalline::BrokenSourceFixer do
 
   it_fixes <<-CRYSTAL, <<-CRYSTAL
     def foo
+      call(1) do |x|
+    end
+    CRYSTAL
+    def foo
+      call(1) do |x|; end
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call(1) do |x, y|
+    end
+    CRYSTAL
+    def foo
+      call(1) do |x, y|; end
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
       call(1) {
     end
     CRYSTAL
     def foo
       call(1) {; }
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call(1) { |x|
+    end
+    CRYSTAL
+    def foo
+      call(1) { |x|; }
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call(1) { |x, y|
+    end
+    CRYSTAL
+    def foo
+      call(1) { |x, y|; }
     end
     CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -353,4 +353,64 @@ describe Crystalline::BrokenSourceFixer do
     foo 1,
       bar do; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    begin
+      puts 1
+    CRYSTAL
+    begin
+      puts 1; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    begin
+      puts 1
+    rescue
+      puts 2
+    CRYSTAL
+    begin
+      puts 1
+    rescue
+      puts 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    begin
+      puts 1
+    rescue ex
+      puts 2
+    CRYSTAL
+    begin
+      puts 1
+    rescue ex
+      puts 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    begin
+      puts 1
+    ensure
+      puts 2
+    CRYSTAL
+    begin
+      puts 1
+    ensure
+      puts 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    begin
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3
+    CRYSTAL
+    begin
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -345,4 +345,12 @@ describe Crystalline::BrokenSourceFixer do
     )
       1; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    foo 1,
+      bar do
+    CRYSTAL
+    foo 1,
+      bar do; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -113,4 +113,14 @@ describe Crystalline::BrokenSourceFixer do
       def bar; end
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call(1) do
+    end
+    CRYSTAL
+    def foo
+      call(1) do; end
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -53,4 +53,44 @@ describe Crystalline::BrokenSourceFixer do
       puts 1
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    class Foo
+      def bar
+      end
+    CRYSTAL
+    class Foo
+      def bar
+      end; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    module Foo
+      def bar
+      end
+    CRYSTAL
+    module Foo
+      def bar
+      end; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    struct Foo
+      def bar
+      end
+    CRYSTAL
+    struct Foo
+      def bar
+      end; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    enum Foo
+      def bar
+      end
+    CRYSTAL
+    enum Foo
+      def bar
+      end; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -335,4 +335,14 @@ describe Crystalline::BrokenSourceFixer do
     CRYSTAL
     private abstract struct Foo; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo(
+    )
+      1
+    CRYSTAL
+    def foo(
+    )
+      1; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -146,6 +146,16 @@ describe Crystalline::BrokenSourceFixer do
 
   it_fixes <<-CRYSTAL, <<-CRYSTAL
     def foo
+      call do
+    end
+    CRYSTAL
+    def foo
+      call do; end
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
       call(1) {
     end
     CRYSTAL
@@ -171,6 +181,26 @@ describe Crystalline::BrokenSourceFixer do
     CRYSTAL
     def foo
       call(1) { |x, y|; }
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call {
+    end
+    CRYSTAL
+    def foo
+      call {; }
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call x {
+    end
+    CRYSTAL
+    def foo
+      call x {; }
     end
     CRYSTAL
 

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -413,4 +413,44 @@ describe Crystalline::BrokenSourceFixer do
     else
       puts 3; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      puts 1
+    rescue
+      puts 2
+    CRYSTAL
+    def foo
+      puts 1
+    rescue
+      puts 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3
+    CRYSTAL
+    def foo
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      puts 1
+    ensure
+      puts 2
+    CRYSTAL
+    def foo
+      puts 1
+    ensure
+      puts 2; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -453,4 +453,44 @@ describe Crystalline::BrokenSourceFixer do
     ensure
       puts 2; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    foo do |x|
+      puts 1
+    rescue
+      puts 2
+    CRYSTAL
+    foo do |x|
+      puts 1
+    rescue
+      puts 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    foo do |x|
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3
+    CRYSTAL
+    foo do |x|
+      puts 1
+    rescue
+      puts 2
+    else
+      puts 3; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    foo do |x|
+      puts 1
+    ensure
+      puts 2
+    CRYSTAL
+    foo do |x|
+      puts 1
+    ensure
+      puts 2; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -123,4 +123,14 @@ describe Crystalline::BrokenSourceFixer do
       call(1) do; end
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      call(1) {
+    end
+    CRYSTAL
+    def foo
+      call(1) {; }
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -103,4 +103,14 @@ describe Crystalline::BrokenSourceFixer do
       annotation Bar; end
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    class Foo
+      def bar
+    end
+    CRYSTAL
+    class Foo
+      def bar; end
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -37,4 +37,20 @@ describe Crystalline::BrokenSourceFixer do
       puts 1
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+        if baz
+
+      puts 1
+    end
+    CRYSTAL
+    def foo
+      if bar
+        if baz
+        end; end
+      puts 1
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -93,4 +93,14 @@ describe Crystalline::BrokenSourceFixer do
       def bar
       end; end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    class Foo
+      annotation Bar
+    end
+    CRYSTAL
+    class Foo
+      annotation Bar; end
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -173,4 +173,18 @@ describe Crystalline::BrokenSourceFixer do
       call(1) { |x, y|; }
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+        1
+      else
+    end
+    CRYSTAL
+    def foo
+      if bar
+        1
+      else; end
+    end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -175,6 +175,24 @@ describe Crystalline::BrokenSourceFixer do
     CRYSTAL
 
   it_fixes <<-CRYSTAL, <<-CRYSTAL
+    unless foo
+    CRYSTAL
+    unless foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    while foo
+    CRYSTAL
+    while foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    until foo
+    CRYSTAL
+    until foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
     def foo
       if bar
         1
@@ -183,6 +201,20 @@ describe Crystalline::BrokenSourceFixer do
     CRYSTAL
     def foo
       if bar
+        1
+      else; end
+    end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      unless bar
+        1
+      else
+    end
+    CRYSTAL
+    def foo
+      unless bar
         1
       else; end
     end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -269,4 +269,70 @@ describe Crystalline::BrokenSourceFixer do
       elsif bar; end
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private def foo
+    CRYSTAL
+    private def foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    protected def foo
+    CRYSTAL
+    protected def foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private class Foo
+    CRYSTAL
+    private class Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private struct Foo
+    CRYSTAL
+    private struct Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private module Foo
+    CRYSTAL
+    private module Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private enum Foo
+    CRYSTAL
+    private enum Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private annotation Foo
+    CRYSTAL
+    private annotation Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    abstract class Foo
+    CRYSTAL
+    abstract class Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private abstract class Foo
+    CRYSTAL
+    private abstract class Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    abstract struct Foo
+    CRYSTAL
+    abstract struct Foo; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    private abstract struct Foo
+    CRYSTAL
+    private abstract struct Foo; end
+    CRYSTAL
 end

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -219,4 +219,18 @@ describe Crystalline::BrokenSourceFixer do
       else; end
     end
     CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+        1
+      elsif bar
+    end
+    CRYSTAL
+    def foo
+      if bar
+        1
+      elsif bar; end
+    end
+    CRYSTAL
 end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -91,18 +91,4 @@ class Crystalline::BrokenSourceFixer
       nil
     end
   end
-
-  def self.check
-    last_info = stack.last?
-    if last_info && indent < last_info.indent
-      if keyword == "end" && indent == last_info.indent
-        # All good: an end is closing an opening keyword
-        stack.pop
-        next
-      end
-
-      lines[line_index - 1] = lines[line_index - 1] + "; end"
-      stack.pop
-    end
-  end
 end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -28,27 +28,23 @@ class Crystalline::BrokenSourceFixer
 
         closing_keyword = closing_keyword(last_info)
 
-        # Check if this line has less indent than the indent
-        # for the last opening keyword we found.
-        if wrong_indent?(indent, keyword, closing_keyword, last_info, line)
-          # If that's the case we fix the opening keyword by
-          # adding an "end" to it.
-          last_line = lines[line_index - 1]
+        # Nothing to fix unless there's a wrong indent
+        break unless wrong_indent?(indent, keyword, closing_keyword, last_info, line)
 
-          lines[line_index - 1] =
-            if last_line.blank?
-              # If the line is empty we can change it to an end
-              # and even use the correct indent.
-              "#{("  " * last_info.indent)}#{closing_keyword}"
-            else
-              "#{last_line}; #{closing_keyword}"
-            end
+        # We have a wrong indentation so we fix/close the opening keyword
+        # by adding an "end" (or "}") to it.
+        last_line = lines[line_index - 1]
 
-          stack.pop
-        else
-          # If that's not the case we are still keeping a good indent.
-          break
-        end
+        lines[line_index - 1] =
+          if last_line.blank?
+            # If the line is empty we can change it to an end
+            # and even use the correct indent.
+            "#{("  " * last_info.indent)}#{closing_keyword}"
+          else
+            "#{last_line}; #{closing_keyword}"
+          end
+
+        stack.pop
       end
 
       # If we found an "end" at exactly the indentation of the last

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -82,7 +82,19 @@ class Crystalline::BrokenSourceFixer
   end
 
   private def self.line_keyword(line : String) : String?
-    if line.starts_with?(/\s*(if|unless|while|until|def|class|struct|module|enum|annotation)\s/)
+    if line.starts_with?(/\s*
+      (
+        if |
+        unless |
+        while |
+        until |
+        ((private|protected)\s+)?def |
+        (private\s+)?(abstract\s+)?class |
+        (private\s+)?(abstract\s+)?struct |
+        (private\s+)?module |
+        (private\s+)?enum |
+        (private\s+)?annotation
+      )\s/x)
       $1
     elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
       "do"

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -56,7 +56,7 @@ class Crystalline::BrokenSourceFixer
       end
 
       # Push to the stack if we found an opening keyword.
-      if keyword && keyword != "end" && keyword != "}" && keyword != "else" && keyword != "elsif"
+      if keyword && !closing_keyword?(keyword)
         stack << LineInfo.new(
           line_index: line_index,
           indent: indent,
@@ -125,6 +125,10 @@ class Crystalline::BrokenSourceFixer
 
   private def self.closing_keyword(keyword : String)
     keyword == "{" ? "}" : "end"
+  end
+
+  private def self.closing_keyword?(keyword : String)
+    keyword.in?("end", "else", "elsif", "}")
   end
 
   private def self.wrong_indent?(

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -174,7 +174,7 @@ class Crystalline::BrokenSourceFixer
       return false
     end
 
-    if last_info.keyword == "begin" && keyword.in?("rescue", "ensure", "else")
+    if last_info.keyword.in?("begin", "def") && keyword.in?("rescue", "ensure", "else")
       return false
     end
 

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -83,7 +83,7 @@ class Crystalline::BrokenSourceFixer
   end
 
   private def self.line_keyword(line : String) : String?
-    if line.starts_with?(/\s*(if|def|class|struct|module|enum|annotation)\s/)
+    if line.starts_with?(/\s*(if|unless|while|until|def|class|struct|module|enum|annotation)\s/)
       $1
     elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
       "do"
@@ -118,6 +118,7 @@ class Crystalline::BrokenSourceFixer
 
     indent == last_info.indent &&
       keyword != closing_keyword &&
-      !(last_info.keyword == "if" && keyword == "else")
+      !(last_info.keyword == "if" && keyword == "else") &&
+      !(last_info.keyword == "unless" && keyword == "else")
   end
 end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -81,7 +81,7 @@ class Crystalline::BrokenSourceFixer
   end
 
   def self.line_keyword(line : String) : String?
-    if line.starts_with?(/\s*(if|def|class|struct|module|enum)\s/)
+    if line.starts_with?(/\s*(if|def|class|struct|module|enum|annotation)\s/)
       $1
     elsif line.starts_with?(/\s*end\s*$/)
       "end"

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -100,6 +100,8 @@ class Crystalline::BrokenSourceFixer
         (private\s+)?annotation
       )\s/x)
       $1
+    elsif line.matches?(/\s*begin\s*$/)
+      "begin"
     elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
       "do"
     elsif line.ends_with?(/\s*\)\s*{(\s*\|[^|]+\|)?\s*$/)
@@ -114,6 +116,10 @@ class Crystalline::BrokenSourceFixer
       "else"
     elsif line.starts_with?(/\s*elsif\s+/)
       "elsif"
+    elsif line.starts_with?(/\s*rescue(\b|\s)/)
+      "rescue"
+    elsif line.matches?(/\s*ensure\s*$/)
+      "ensure"
     else
       nil
     end
@@ -128,7 +134,7 @@ class Crystalline::BrokenSourceFixer
   end
 
   private def self.closing_keyword?(keyword : String)
-    keyword.in?("end", "else", "elsif", "}")
+    keyword.in?("end", "else", "elsif", "rescue", "ensure", "}")
   end
 
   private def self.wrong_indent?(
@@ -165,6 +171,10 @@ class Crystalline::BrokenSourceFixer
     end
 
     if last_info.keyword == "unless" && keyword == "else"
+      return false
+    end
+
+    if last_info.keyword == "begin" && keyword.in?("rescue", "ensure", "else")
       return false
     end
 

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -31,9 +31,9 @@ class Crystalline::BrokenSourceFixer
             if last_line.blank?
               # If the line is empty we can change it to an end
               # and even use the correct indent.
-              last_line = ("  " * last_info.indent) + closing_keyword
+              "#{("  " * last_info.indent)}#{closing_keyword}"
             else
-              last_line + "; " + closing_keyword
+              "#{last_line}; #{closing_keyword}"
             end
 
           stack.pop
@@ -62,7 +62,7 @@ class Crystalline::BrokenSourceFixer
     end
 
     while line_info = stack.pop?
-      lines[-1] = lines[-1] + "; " + closing_keyword(line_info)
+      lines[-1] = "#{lines[-1]}; #{closing_keyword(line_info)}"
     end
 
     lines.join("\n")

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -83,6 +83,8 @@ class Crystalline::BrokenSourceFixer
   def self.line_keyword(line : String) : String?
     if line.starts_with?(/\s*(if|def|class|struct|module|enum|annotation)\s/)
       $1
+    elsif line.ends_with?(/\s*do$/)
+      "do"
     elsif line.starts_with?(/\s*end\s*$/)
       "end"
     else

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -89,6 +89,8 @@ class Crystalline::BrokenSourceFixer
       "do"
     elsif line.ends_with?(/\s*\)\s*{(\s*\|[^|]+\|)?\s*$/)
       "{"
+    elsif line.ends_with?(/\s*[\w\d]\s*{(\s*\|[^|]+\|)?\s*$/)
+      "{"
     elsif line.matches?(/\s*end\s*$/)
       "end"
     elsif line.matches?(/\s*}\s*$/)

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -61,9 +61,8 @@ class Crystalline::BrokenSourceFixer
       end
     end
 
-    until stack.empty?
-      lines[-1] = lines[-1] + "; end"
-      stack.pop
+    while line_info = stack.pop?
+      lines[-1] = lines[-1] + "; " + closing_keyword(line_info)
     end
 
     lines.join("\n")

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -174,7 +174,7 @@ class Crystalline::BrokenSourceFixer
       return false
     end
 
-    if last_info.keyword.in?("begin", "def") && keyword.in?("rescue", "ensure", "else")
+    if last_info.keyword.in?("begin", "def", "do") && keyword.in?("rescue", "ensure", "else")
       return false
     end
 

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -1,0 +1,108 @@
+class Crystalline::BrokenSourceFixer
+  record LineInfo,
+    line_index : Int32,
+    indent : Int32,
+    keyword : String
+
+  def self.fix(source : String) : String
+    stack = [] of LineInfo
+
+    lines = source.lines
+    lines.each_with_index do |line, line_index|
+      next if line.blank?
+
+      keyword = line_keyword(line)
+      indent = line_indent(line)
+
+      while true
+        last_info = stack.last?
+        # Check if this line has less indent than the indent
+        # for the last opening keyword we found.
+        if last_info &&
+           (indent < last_info.indent ||
+           indent == last_info.indent && keyword != "end")
+          # If that's the case we fix the opening keyword by
+          # adding an "end" to it.
+          last_line = lines[line_index - 1]
+
+          lines[line_index - 1] =
+            if last_line.blank?
+              # If the line is empty we can change it to an end
+              # and even use the correct indent.
+              last_line = ("  " * last_info.indent) + "end"
+            else
+              last_line + "; end"
+            end
+
+          stack.pop
+        else
+          # If that's not the case we are still keeping a good indent.
+          break
+        end
+      end
+
+      # If we found an "end" at exactly the indentation of the last
+      # opening keyword, remove it from the stack.
+      if keyword == "end" && indent == last_info.try(&.indent)
+        # all good: an end is closing an opening keyword
+        stack.pop
+        next
+      end
+
+      # Push to the stack if we found an opening keyword.
+      if keyword && keyword != "end"
+        stack << LineInfo.new(
+          line_index: line_index,
+          indent: indent,
+          keyword: keyword
+        )
+      end
+    end
+
+    until stack.empty?
+      lines[-1] = lines[-1] + "; end"
+      stack.pop
+    end
+
+    lines.join("\n")
+  end
+
+  def self.line_indent(line : String) : Int32?
+    non_whitespace_char_index = line.each_char_with_index do |char, i|
+      next if char.whitespace?
+      break i
+    end
+
+    if non_whitespace_char_index
+      non_whitespace_char_index // 2
+    else
+      0
+    end
+  end
+
+  def self.line_keyword(line : String) : String?
+    if line.starts_with?(/\s*if\s/)
+      "if"
+    elsif line.starts_with?(/\s*def\s/)
+      "def"
+    elsif line.starts_with?(/\s*end\s*$/)
+      "end"
+    else
+      nil
+    end
+  end
+
+  def self.check
+    last_info = stack.last?
+    if last_info && indent < last_info.indent
+      if keyword == "end" && indent == last_info.indent
+        # All good: an end is closing an opening keyword
+        stack.pop
+        next
+      end
+
+      lines[line_index - 1] = lines[line_index - 1] + "; end"
+      stack.pop
+    end
+  end
+end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -52,7 +52,7 @@ class Crystalline::BrokenSourceFixer
       end
 
       # Push to the stack if we found an opening keyword.
-      if keyword && keyword != "end" && keyword != "}" && keyword != "else"
+      if keyword && keyword != "end" && keyword != "}" && keyword != "else" && keyword != "elsif"
         stack << LineInfo.new(
           line_index: line_index,
           indent: indent,
@@ -95,6 +95,8 @@ class Crystalline::BrokenSourceFixer
       "}"
     elsif line.matches?(/\s*else\s*$/)
       "else"
+    elsif line.starts_with?(/\s*elsif\s+/)
+      "elsif"
     else
       nil
     end
@@ -119,6 +121,7 @@ class Crystalline::BrokenSourceFixer
     indent == last_info.indent &&
       keyword != closing_keyword &&
       !(last_info.keyword == "if" && keyword == "else") &&
+      !(last_info.keyword == "if" && keyword == "elsif") &&
       !(last_info.keyword == "unless" && keyword == "else")
   end
 end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -86,9 +86,9 @@ class Crystalline::BrokenSourceFixer
   def self.line_keyword(line : String) : String?
     if line.starts_with?(/\s*(if|def|class|struct|module|enum|annotation)\s/)
       $1
-    elsif line.ends_with?(/\s*do\s*$/)
+    elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
       "do"
-    elsif line.ends_with?(/\s*\)\s*{\s*$/)
+    elsif line.ends_with?(/\s*\)\s*{(\s*\|[^|]+\|)?\s*$/)
       "{"
     elsif line.starts_with?(/\s*end\s*$/)
       "end"

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -1,10 +1,18 @@
 class Crystalline::BrokenSourceFixer
+  # Keep track of opening and closing keywords, and their idents,
+  # as they happen in the code.
   record LineInfo,
     line_index : Int32,
     indent : Int32,
     keyword : String
 
+  # Try to fix a broken source code by adding missing "end" and "}"
+  # according to indentation.
   def self.fix(source : String) : String
+    # Keep a stack of opening keywords.
+    # We push to the stack when we find an opening keyword and
+    # we pop from the stack when we find a closing keyword,
+    # or when we find a wrong indentation.
     stack = [] of LineInfo
 
     lines = source.lines

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -70,7 +70,7 @@ class Crystalline::BrokenSourceFixer
     lines.join("\n")
   end
 
-  def self.line_indent(line : String) : Int32?
+  private def self.line_indent(line : String) : Int32?
     non_whitespace_char_index = line.each_char_with_index do |char, i|
       next if char.whitespace?
       break i
@@ -83,7 +83,7 @@ class Crystalline::BrokenSourceFixer
     end
   end
 
-  def self.line_keyword(line : String) : String?
+  private def self.line_keyword(line : String) : String?
     if line.starts_with?(/\s*(if|def|class|struct|module|enum|annotation)\s/)
       $1
     elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
@@ -99,11 +99,11 @@ class Crystalline::BrokenSourceFixer
     end
   end
 
-  def self.closing_keyword(line_info : LineInfo)
+  private def self.closing_keyword(line_info : LineInfo)
     closing_keyword(line_info.keyword)
   end
 
-  def self.closing_keyword(keyword : String)
+  private def self.closing_keyword(keyword : String)
     keyword == "{" ? "}" : "end"
   end
 end

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -81,10 +81,8 @@ class Crystalline::BrokenSourceFixer
   end
 
   def self.line_keyword(line : String) : String?
-    if line.starts_with?(/\s*if\s/)
-      "if"
-    elsif line.starts_with?(/\s*def\s/)
-      "def"
+    if line.starts_with?(/\s*(if|def|class|struct|module|enum)\s/)
+      $1
     elsif line.starts_with?(/\s*end\s*$/)
       "end"
     else

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -179,6 +179,8 @@ class Crystalline::Workspace
           file_overrides = Hash(String, String).new
           @opened_documents.each { |uri_str, text_document|
             contents = text_overrides.try(&.[uri_str]?) || text_document.contents
+            contents = fix_source(contents)
+
             if target_string == uri_str
               # If the entry point itself needs to be loaded from memory.
               sources = [
@@ -371,7 +373,7 @@ class Crystalline::Workspace
 
     # LSP::Log.info { "completion: #{trigger_character}"}
 
-    document_lines = text_document.contents.lines(chomp: false)
+    document_lines = fix_source(text_document.contents).lines(chomp: false)
     left_offset = 0
     right_offset = 0
     truncate_line = false
@@ -595,7 +597,7 @@ class Crystalline::Workspace
 
   def document_symbols(server : LSP::Server, file_uri : URI)
     @opened_documents[file_uri.to_s]?.try { |text_document|
-      parser = Crystal::Parser.new(text_document.contents)
+      parser = Crystal::Parser.new(fix_source(text_document.contents))
       parser.filename = file_uri.decoded_path
       parser.wants_doc = false
 
@@ -603,5 +605,16 @@ class Crystalline::Workspace
         parser.parse.accept(visitor)
       }.symbols
     }
+  end
+
+  private def fix_source(source : String) : String
+    LSP::Log.info { "Fixing source: #{source}" }
+    Crystal::Parser.parse(source)
+    LSP::Log.info { "No need to fix source!" }
+    source
+  rescue
+    fixed_source = BrokenSourceFixer.fix(source)
+    LSP::Log.info { "Fixed source: #{fixed_source}" }
+    fixed_source
   end
 end

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -608,13 +608,13 @@ class Crystalline::Workspace
   end
 
   private def fix_source(source : String) : String
-    LSP::Log.info { "Fixing source: #{source}" }
+    # LSP::Log.info { "Fixing source: #{source}" }
     Crystal::Parser.parse(source)
-    LSP::Log.info { "No need to fix source!" }
+    # LSP::Log.info { "No need to fix source!" }
     source
   rescue
     fixed_source = BrokenSourceFixer.fix(source)
-    LSP::Log.info { "Fixed source: #{fixed_source}" }
+    # LSP::Log.info { "Fixed source: #{fixed_source}" }
     fixed_source
   end
 end


### PR DESCRIPTION
This is for #55, but it's just a part of it.

This PR introduces a new type, `BrokenSourceFixer`. It tries to add missing "end" and closing curly braces based on the code's indentation. It assumes users will use two spaces of indentation and use the formatter so that everything is usually aligned except when they are typing an expression.

The idea then would be to run this code before feeing it to the parser, if the source code is actually broken (for that we could try to parse it and if it parses fine then there's nothing to fix.)

I didn't hook up the code yet because I wasn't sure exactly where to do that.

Edit: another thing is that the fixer tries not to add new lines. In that way any code that needs parse locations will still work fine, as the fixer only adds to the end of lines.