### PR TITLE
Fix stretching of demo gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ semantic checking) and ease development with any compatible code editor.**
 <hr/>
 
 <div align="center">
-<img src="assets/small_demo.gif" height="300" />
+<img src="assets/small_demo.gif" height="300" width="360"/>
 </div>
 
 ## Installation


### PR DESCRIPTION
Gif on readme looks stretched on safari
Before:
<img width="1018" alt="Screen Shot 2022-12-16 at 1 31 24 pm" src="https://user-images.githubusercontent.com/11003459/208029186-70010f24-5550-43a8-b7ba-3d33ba5fab75.png">

After:
<img width="1018" alt="Screen Shot 2022-12-16 at 1 32 21 pm" src="https://user-images.githubusercontent.com/11003459/208029270-5695e6f8-eac8-432b-ab3b-51f9e18cbfc3.png">
