### PR TITLE
crystalline can be installed from homebrew on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ chmod u+x crystalline
 yay -S crystalline
 ```
 
-##### MacOS (x86_64)
+##### MacOS
+
+Install using [homebrew](https://brew.sh):
 
 ```sh
-curl -L https://github.com/elbywan/crystalline/releases/latest/download/crystalline_x86_64-apple-darwin.gz -o crystalline.gz &&\
-gzip -d crystalline.gz &&\
-chmod u+x crystalline
+brew install crystalline
 ```
 
 #### Specific release


### PR DESCRIPTION
crystalline is now available as homebrew [formula](https://formulae.brew.sh/formula/crystalline), solving cross-architecture distribution on macOS 

Closes #34, #68 and #37