### PR TITLE
Remove archived dependency and add --version

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -16,7 +16,3 @@ shards:
     git: https://github.com/samueleaton/sentry.git
     version: 0.3.2+git.commit.e448ce83486f99ef016c311e10ec0cac805cded3
 
-  version_from_shard:
-    git: https://github.com/hugopl/version_from_shard.git
-    version: 1.2.5
-

--- a/shard.yml
+++ b/shard.yml
@@ -13,8 +13,6 @@ targets:
 dependencies:
   lsp:
     github: elbywan/crystal-lsp
-  version_from_shard:
-    github: hugopl/version_from_shard
   priority-queue:
     github: spider-gazelle/priority-queue
 

--- a/src/crystalline.cr
+++ b/src/crystalline.cr
@@ -1,4 +1,9 @@
 require "./crystalline/requires"
 require "./crystalline/*"
 
+if ARGV.includes?("--version")
+  puts(Crystalline::VERSION)
+  exit
+end
+
 Crystalline.init

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -2,11 +2,10 @@ require "log"
 require "lsp/server"
 require "./ext/*"
 require "./*"
-require "version_from_shard"
 
 module Crystalline
-  VersionFromShard.declare(__DIR__)
-
+  VERSION = {{ (`shards version #{__DIR__}`.strip + "+" +
+                system("git rev-parse --short HEAD || echo unknown").stringify).stringify.strip }}
   # Supported server capabilities.
   SERVER_CAPABILITIES = LSP::ServerCapabilities.new(
     text_document_sync: LSP::TextDocumentSyncKind::Incremental,


### PR DESCRIPTION
Hi,

`hugopl/version_from_shard` was archived by me, so I'm replacing it by a simple macro.
 
It get the version from shards.yml and add a build to it with a short git hash or "unknown" if it wasn't built from a git repository (e.g. tarballs).
    
So version 0.15.0 is now show as 0.15.0+f8aa5c6, i.e. the build part of the version will always present. If this isn't desired I can update the PR.

Then I also add a `--version` flag, so neovim (and probably other editors) can show crystalline version on UI, nowadays it can't:

![image](https://github.com/user-attachments/assets/2b9d75be-7f11-4ff2-9d67-81e998032e7e)

With this patch:

![image](https://github.com/user-attachments/assets/9504ab04-1042-421f-a494-d7674702317c)

