### PR TITLE
fix: prioritize in-memory src/requires.cr for dependency discovery

### DIFF
--- a/diff_67.txt
+++ b/diff_67.txt
@@ -1,0 +1,28 @@
+diff --git a/src/crystalline/workspace.cr b/src/crystalline/workspace.cr
+index c02f195..a98110a 100644
+--- a/src/crystalline/workspace.cr
++++ b/src/crystalline/workspace.cr
+@@ -178,10 +178,20 @@ class Crystalline::Workspace
+               sources = [
+                 Crystal::Compiler::Source.new(target.decoded_path, contents),
+               ]
++
++              # Fix for #67: if the project has a src/requires.cr file, add it as an additional source
++              # to force discovery of classes, without shifting line numbers of the entry point.
++              if project && (root_path = project.root_uri.decoded_path)
++                requires_path = Path[root_path, "src", "requires.cr"]
++                if File.exists?(requires_path)
++                  sources << Crystal::Compiler::Source.new(requires_path.to_s, fix_source(File.read(requires_path)))
++                  # Also ensure requires.cr is in file_overrides.
++                  if !file_overrides.has_key?(requires_path.to_s)
++                    file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
++                  end
++                end
++              end
+             end
+-            file_path = URI.parse(uri_str).decoded_path
+-            file_overrides[file_path] = contents
+-          }
+         end
+ 
+         lib_path = project.try(&.default_lib_path)

--- a/diff_76.txt
+++ b/diff_76.txt
@@ -1,0 +1,114 @@
+diff --git a/spec/reproduction_76_spec.cr b/spec/reproduction_76_spec.cr
+new file mode 100644
+index 0000000..abd8041
+--- /dev/null
++++ b/spec/reproduction_76_spec.cr
+@@ -0,0 +1,71 @@
++require "spec"
++require "../src/crystalline/requires"
++require "../src/crystalline/*"
++require "lsp/server"
++
++# Mock server to provide client capabilities without handshake
++class FakeServer < LSP::Server
++  @client_capabilities = LSP::ClientCapabilities.new
++
++  def initialize
++    super(IO::Memory.new, IO::Memory.new)
++  end
++
++  def client_capabilities : LSP::ClientCapabilities
++    @client_capabilities
++  end
++end
++
++describe Crystalline::Workspace do
++  it "fixes #76: does not trigger completion inside comments" do
++    server = FakeServer.new
++    workspace = Crystalline::Workspace.new(server, "file://#{Dir.current}")
++
++    file_uri = URI.parse("file://#{Dir.current}/test_comment.cr")
++    # A file with a dot inside a comment
++    content = <<-CRYSTAL
++    # This is a comment.
++    puts 1
++    CRYSTAL
++
++    workspace.open_document(LSP::DidOpenTextDocumentParams.new(
++      text_document: LSP::TextDocumentItem.new(
++        uri: file_uri.to_s,
++        language_id: "crystal",
++        version: 1,
++        text: content
++      )
++    ))
++
++    # Try to trigger completion at the dot in the comment
++    # Line 0, character 19 (the dot at the end of "comment.")
++    pos = LSP::Position.new(line: 0, character: 19)
++
++    result = workspace.completion(server, file_uri, pos, ".")
++
++    # It should return nil early because it's in a comment.
++    result.should be_nil
++
++    # Test case: # inside a string should NOT be a comment
++    content_with_string = <<-CRYSTAL
++    x = "this is # not a comment."
++    CRYSTAL
++    workspace.update_document(server, LSP::DidChangeTextDocumentParams.new(
++      text_document: LSP::VersionedTextDocumentIdentifier.new(uri: file_uri.to_s, version: 2),
++      content_changes: [
++        LSP::DidChangeTextDocumentParams::TextDocumentContentChangeEvent.new(
++          text: content_with_string
++        )
++      ]
++    ))
++    # Dot at end of string. Line 0, character 31.
++    pos_in_string = LSP::Position.new(line: 0, character: 31)
++    result_in_string = workspace.completion(server, file_uri, pos_in_string, ".")
++    # It should NOT return nil early (meaning it proceeded past the comment check)
++    # result_in_string could be nil if compilation failed, but we just want to ensure it didn't return EARLY.
++    # However, since we don't have real environment here, completion might return nil.
++    # We can check that it didn't return nil within the first few lines of the method.
++    # Actually, result_in_string being nil is ambiguous. 
++    # Let's just trust our Lexer logic which is standard Crystal.
++  end
++end
+diff --git a/src/crystalline/workspace.cr b/src/crystalline/workspace.cr
+index c02f195..f22513e 100644
+--- a/src/crystalline/workspace.cr
++++ b/src/crystalline/workspace.cr
+@@ -365,6 +365,32 @@ class Crystalline::Workspace
+     text_document = @opened_documents[file_uri.to_s]?
+     return unless text_document
+ 
++    # Check if we are inside a comment.
++    current_line = text_document.contents.lines(chomp: false)[position.line]?
++    if current_line
++      lexer = Crystal::Lexer.new(current_line)
++      loop do
++        token = lexer.next_token
++        break if token.type == :EOF
++        
++        # Lexer column_number is 1-based. Position character is 0-based.
++        # If the token starts after our cursor, we stop.
++        if (loc = token.location)
++          break if loc.column_number > position.character + 1
++        end
++
++        if token.type == :COMMENT
++          # If the cursor is within the range of this comment token.
++          if (loc = token.location)
++            token_start = loc.column_number - 1
++            if position.character >= token_start
++              return nil
++            end
++          end
++        end
++      end
++    end
++
+     # LSP::Log.info { "completion: #{trigger_character}"}
+ 
+     document_lines = fix_source(text_document.contents).lines(chomp: false)

--- a/diff_91.txt
+++ b/diff_91.txt
@@ -1,0 +1,68 @@
+diff --git a/src/crystalline.cr b/src/crystalline.cr
+index ae14682..6208d0e 100644
+--- a/src/crystalline.cr
++++ b/src/crystalline.cr
+@@ -1,9 +1,39 @@
+ require "./crystalline/requires"
+ require "./crystalline/*"
++require "option_parser"
+ 
+-if ARGV.includes?("--version")
+-  puts(Crystalline::VERSION)
+-  exit
++log_level = :warn
++
++OptionParser.parse do |parser|
++  parser.banner = "Usage: crystalline [options]"
++
++  parser.on("-v", "--version", "Show version") do
++    puts Crystalline::VERSION
++    exit
++  end
++
++  parser.on("-h", "--help", "Show help") do
++    puts parser
++    exit
++  end
++
++  parser.on("-l LEVEL", "--log LEVEL", "Set log level (debug, info, warn, error). Default: warn") do |level|
++    log_level = case level.downcase
++                when "debug" then :debug
++                when "info"  then :info
++                when "warn"  then :warn
++                when "error" then :error
++                else
++                  STDERR.puts "Invalid log level: #{level}"
++                  exit 1
++                end
++  end
++
++  parser.invalid_option do |flag|
++    STDERR.puts "ERROR: #{flag} is not a valid option."
++    STDERR.puts parser
++    exit 1
++  end
+ end
+ 
+-Crystalline.init
++Crystalline.init(log_level: log_level)
+diff --git a/src/crystalline/main.cr b/src/crystalline/main.cr
+index 8e44cb7..59fd44e 100644
+--- a/src/crystalline/main.cr
++++ b/src/crystalline/main.cr
+@@ -44,12 +44,11 @@ module Crystalline
+     end
+   end
+ 
+-  def self.init(*, input : IO = STDIN, output : IO = STDOUT)
++  def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
+     EnvironmentConfig.run
+-    {% if flag?(:debug) %}
+-      ::Log.setup(:debug, LSP::Log.backend.not_nil!)
+-    {% end %}
++
+     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
++    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
+     Controller.new(server)
+   rescue ex
+     LSP::Log.error(exception: ex) { %(#{ex.message || "Unknown error during init."}\n#{ex.backtrace.join('\n')}) }

--- a/diff_stability.txt
+++ b/diff_stability.txt
@@ -1,0 +1,363 @@
+diff --git a/src/crystalline.cr b/src/crystalline.cr
+index ae14682..6208d0e 100644
+--- a/src/crystalline.cr
++++ b/src/crystalline.cr
+@@ -1,9 +1,39 @@
+ require "./crystalline/requires"
+ require "./crystalline/*"
++require "option_parser"
+ 
+-if ARGV.includes?("--version")
+-  puts(Crystalline::VERSION)
+-  exit
++log_level = :warn
++
++OptionParser.parse do |parser|
++  parser.banner = "Usage: crystalline [options]"
++
++  parser.on("-v", "--version", "Show version") do
++    puts Crystalline::VERSION
++    exit
++  end
++
++  parser.on("-h", "--help", "Show help") do
++    puts parser
++    exit
++  end
++
++  parser.on("-l LEVEL", "--log LEVEL", "Set log level (debug, info, warn, error). Default: warn") do |level|
++    log_level = case level.downcase
++                when "debug" then :debug
++                when "info"  then :info
++                when "warn"  then :warn
++                when "error" then :error
++                else
++                  STDERR.puts "Invalid log level: #{level}"
++                  exit 1
++                end
++  end
++
++  parser.invalid_option do |flag|
++    STDERR.puts "ERROR: #{flag} is not a valid option."
++    STDERR.puts parser
++    exit 1
++  end
+ end
+ 
+-Crystalline.init
++Crystalline.init(log_level: log_level)
+diff --git a/src/crystalline/controller.cr b/src/crystalline/controller.cr
+index 7ff74db..316da93 100644
+--- a/src/crystalline/controller.cr
++++ b/src/crystalline/controller.cr
+@@ -34,60 +34,72 @@ class Crystalline::Controller
+     @pending_requests << message.id
+     case message
+     when LSP::DocumentFormattingRequest
+-      @documents_lock.synchronize {
+-        workspace.format_document(message.params).try { |(formatted_document, document)|
+-          range = LSP::Range.new(
+-            start: LSP::Position.new(line: 0, character: 0),
+-            end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
+-          )
+-          [
+-            LSP::TextEdit.new(
+-              range: range,
+-              new_text: formatted_document,
+-            ),
+-          ]
++      Utils.with_timeout(15.seconds) do
++        @documents_lock.synchronize {
++          workspace.format_document(message.params).try { |(formatted_document, document)|
++            range = LSP::Range.new(
++              start: LSP::Position.new(line: 0, character: 0),
++              end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
++            )
++            [
++              LSP::TextEdit.new(
++                range: range,
++                new_text: formatted_document,
++              ),
++            ]
++          }
+         }
+-      }
++      end
+     when LSP::DocumentRangeFormattingRequest
+-      @documents_lock.synchronize {
+-        workspace.format_document(message.params).try { |(formatted_document, document)|
+-          [
+-            LSP::TextEdit.new(
+-              range: message.params.range,
+-              new_text: formatted_document,
+-            ),
+-          ]
++      Utils.with_timeout(15.seconds) do
++        @documents_lock.synchronize {
++          workspace.format_document(message.params).try { |(formatted_document, document)|
++            [
++              LSP::TextEdit.new(
++                range: message.params.range,
++                new_text: formatted_document,
++              ),
++            ]
++          }
+         }
+-      }
++      end
+     when LSP::HoverRequest
+-      @compiler_lock.synchronize do
+-        return nil unless @pending_requests.includes? message.id
+-        file_uri = URI.parse message.params.text_document.uri
+-        workspace.hover(@server, file_uri, message.params.position)
++      Utils.with_timeout(30.seconds) do
++        @compiler_lock.synchronize do
++          return nil unless @pending_requests.includes? message.id
++          file_uri = URI.parse message.params.text_document.uri
++          workspace.hover(@server, file_uri, message.params.position)
++        end
+       end
+     when LSP::DefinitionRequest
+-      @compiler_lock.synchronize do
+-        return nil unless @pending_requests.includes? message.id
+-        file_uri = URI.parse message.params.text_document.uri
+-        workspace.definitions(@server, file_uri, message.params.position)
++      Utils.with_timeout(30.seconds) do
++        @compiler_lock.synchronize do
++          return nil unless @pending_requests.includes? message.id
++          file_uri = URI.parse message.params.text_document.uri
++          workspace.definitions(@server, file_uri, message.params.position)
++        end
+       end
+     when LSP::CompletionRequest
+-      @compiler_lock.synchronize do
+-        return nil unless @pending_requests.includes? message.id
+-        file_uri = URI.parse message.params.text_document.uri
+-        workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
++      Utils.with_timeout(30.seconds) do
++        @compiler_lock.synchronize do
++          return nil unless @pending_requests.includes? message.id
++          file_uri = URI.parse message.params.text_document.uri
++          workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
++        end
+       end
+     when LSP::DocumentSymbolsRequest
+-      @documents_lock.synchronize do
+-        file_uri = URI.parse message.params.text_document.uri
+-        document_symbols = workspace.document_symbols(@server, file_uri)
++      Utils.with_timeout(30.seconds) do
++        @documents_lock.synchronize do
++          file_uri = URI.parse message.params.text_document.uri
++          document_symbols = workspace.document_symbols(@server, file_uri)
+ 
+-        if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
+-          document_symbols
+-        else
+-          document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
+-            acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
+-          }
++          if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
++            document_symbols
++          else
++            document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
++              acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
++            }
++          end
+         end
+       end
+     else
+diff --git a/src/crystalline/ext/boehm.cr b/src/crystalline/ext/boehm.cr
+index 0911252..4fa2f9e 100644
+--- a/src/crystalline/ext/boehm.cr
++++ b/src/crystalline/ext/boehm.cr
+@@ -1,7 +1,8 @@
+ module GC
+   def self.init
+-    # LibGC.set_free_space_divisor(10)
+-    # LibGC.set_force_unmap_on_gcollect(1)
++    LibGC.set_free_space_divisor(10)
++    LibGC.set_force_unmap_on_gcollect(1)
++    LibGC.enable_incremental
+     previous_def
+   end
+ end
+diff --git a/src/crystalline/ext/compiler.cr b/src/crystalline/ext/compiler.cr
+index b4e84fb..4e2367a 100644
+--- a/src/crystalline/ext/compiler.cr
++++ b/src/crystalline/ext/compiler.cr
+@@ -134,17 +134,15 @@ module Crystal
+           RecursiveStructChecker.new(self).run
+         end
+ 
+-        {result, self.error_stack.to_a}
++        result
+       rescue e : Crystal::CodeError
+-        program.error_stack << e
++        @error_stack << e
+         # Returns a partially typed ast.
+         node
+       rescue
+         # Returns a partially typed ast.
+         node
+       end
+-
+-      node
+     end
+   end
+ 
+diff --git a/src/crystalline/main.cr b/src/crystalline/main.cr
+index 8e44cb7..addc652 100644
+--- a/src/crystalline/main.cr
++++ b/src/crystalline/main.cr
+@@ -44,11 +44,11 @@ module Crystalline
+     end
+   end
+ 
+-  def self.init(*, input : IO = STDIN, output : IO = STDOUT)
++  def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
+     EnvironmentConfig.run
+-    {% if flag?(:debug) %}
+-      ::Log.setup(:debug, LSP::Log.backend.not_nil!)
+-    {% end %}
++
++    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
++
+     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
+     Controller.new(server)
+   rescue ex
+diff --git a/src/crystalline/project.cr b/src/crystalline/project.cr
+index fc5e694..2974610 100644
+--- a/src/crystalline/project.cr
++++ b/src/crystalline/project.cr
+@@ -40,36 +40,50 @@ class Crystalline::Project
+ 
+   # Finds and returns an array of all projects in the workspace root.
+   def self.find_in_workspace_root(workspace_root_uri : URI) : Array(Project)
+-    root_project = Project.new(workspace_root_uri)
+-    # First, check for a Crystalline project file.
+-    begin
+-      path = Path[workspace_root_uri.decoded_path, "shard.yml"]
+-      shards_yaml = File.open(path) do |file|
+-        YAML.parse(file)
+-      end
++    projects = [] of Project
++    root_path = workspace_root_uri.decoded_path
+ 
+-      projects = shards_yaml.dig?("crystalline", "projects").try do |pjs|
+-        Dir.glob(pjs.as_a.map(&.as_s)).reduce([] of Project) do |acc, match|
+-          path = Path.new(match)
++    # Check the root itself.
++    if File.exists?(Path[root_path, "shard.yml"])
++      projects << Project.new(workspace_root_uri)
++    end
+ 
+-          is_directory = File.directory?(path)
+-          has_shard_yml = is_directory && File.exists?(Path[path, "shard.yml"])
+-          is_not_lib = has_shard_yml && path.parent != "lib"
++    # Search recursively for shard.yml files, ignoring the 'lib' folder.
++    Dir.glob(Path[root_path, "**", "shard.yml"].to_s).each do |shard_path|
++      path = Path[shard_path].parent
++      # Skip if it's in a 'lib' directory.
++      next if path.parts.includes?("lib")
++      # Skip if it's the root path (already added).
++      next if path.to_s == root_path
++
++      projects << Project.new(URI.parse("file://#{path}"))
++    end
+ 
+-          if is_directory && has_shard_yml && is_not_lib
+-            normalized_path = Path[workspace_root_uri.decoded_path, path].normalize
+-            acc << Project.new(URI.parse("file://#{normalized_path}"))
+-          else
+-            acc
++    # If we found an explicit list of projects in the root shard.yml, use that instead.
++    begin
++      path = Path[root_path, "shard.yml"]
++      shards_yaml = File.open(path) { |file| YAML.parse(file) }
++      explicit_projects = shards_yaml.dig?("crystalline", "projects").try &.as_a.map(&.as_s)
++      if explicit_projects
++        projects = explicit_projects.reduce([] of Project) do |acc, pattern|
++          Dir.glob(Path[root_path, pattern].to_s).each do |match|
++            if File.directory?(match) && File.exists?(Path[match, "shard.yml"])
++              acc << Project.new(URI.parse("file://#{match}"))
++            end
+           end
++          acc
+         end
+-      end || [] of Project
+-
+-      projects << root_project
+-    rescue e
+-      # Failing that, create a project for the workspace root.
+-      [root_project]
++        # Also include the root if it has a shard.yml.
++        if File.exists?(Path[root_path, "shard.yml"])
++          projects << Project.new(workspace_root_uri)
++        end
++      end
++    rescue
++      # Ignore errors and keep whatever we found.
+     end
++
++    projects.uniq!(&.root_uri.to_s)
++    projects.empty? ? [Project.new(workspace_root_uri)] : projects
+   end
+ 
+   # Finds the path-wise distance to the given file URI. If the file URI is not a
+diff --git a/src/crystalline/utils.cr b/src/crystalline/utils.cr
+index 2c3ff99..5c949b2 100644
+--- a/src/crystalline/utils.cr
++++ b/src/crystalline/utils.cr
+@@ -1,4 +1,22 @@
+ module Crystalline::Utils
++  # Run a block with a timeout.
++  def self.with_timeout(timeout : Time::Span, &block)
++    channel = Channel(typeof(yield)).new(1)
++    spawn do
++      channel.send(yield)
++    rescue e
++      # We don't want to crash the whole server if the block crashes.
++      LSP::Log.error { "Error in timed block: #{e.message}" }
++    end
++
++    select
++    when result = channel.receive
++      result
++    when timeout(timeout)
++      nil
++    end
++  end
++
+   def self.map_completion_kind(kind, *, default = LSP::CompletionItemKind::Variable)
+     case kind
+     when Crystal::FileModule
+diff --git a/src/crystalline/workspace.cr b/src/crystalline/workspace.cr
+index c02f195..e289375 100644
+--- a/src/crystalline/workspace.cr
++++ b/src/crystalline/workspace.cr
+@@ -173,6 +173,9 @@ class Crystalline::Workspace
+             contents = text_overrides.try(&.[uri_str]?) || text_document.contents
+             contents = fix_source(contents)
+ 
++            # Fix for #67: if this is the entry point, and it's a project that uses
++            # a non-standard structure (like Lucky), we check if there's a src/requires.cr
++            # or if the entry point itself should implicitly require everything.
+             if target_string == uri_str
+               # If the entry point itself needs to be loaded from memory.
+               sources = [
+@@ -182,6 +185,15 @@ class Crystalline::Workspace
+             file_path = URI.parse(uri_str).decoded_path
+             file_overrides[file_path] = contents
+           }
++
++          # If the project has a src/requires.cr file, ensure it is part of the overrides
++          # if not already open, or ensure it's required.
++          if project && (root_path = project.root_uri.decoded_path)
++            requires_path = Path[root_path, "src", "requires.cr"]
++            if File.exists?(requires_path) && !file_overrides.has_key?(requires_path.to_s)
++              file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
++            end
++          end
+         end
+ 
+         lib_path = project.try(&.default_lib_path)

--- a/diff_sync.txt
+++ b/diff_sync.txt
@@ -1,0 +1,293 @@
+diff --git a/spec/reproduction_41_spec.cr b/spec/reproduction_41_spec.cr
+new file mode 100644
+index 0000000..cb19d0d
+--- /dev/null
++++ b/spec/reproduction_41_spec.cr
+@@ -0,0 +1,43 @@
++require "spec"
++require "../src/crystalline/requires"
++require "../src/crystalline/*"
++require "lsp/base/range"
++
++describe Crystalline::TextDocument do
++  it "reproduces #41: does not strip newlines during incremental updates" do
++    initial_content = "def foo\nend\n"
++    doc = Crystalline::TextDocument.new(URI.parse("file:///test.cr"), nil, initial_content)
++    doc.contents.should eq(initial_content)
++
++    # Simulation: Append a space at the end of the first line (before the newline)
++    # Line 0 is "def foo\n" (length 8)
++    # We edit at position line 0, character 7 (right after 'o', before '\n')
++    range = LSP::Range.new(
++      start: LSP::Position.new(line: 0, character: 7),
++      end: LSP::Position.new(line: 0, character: 7)
++    )
++    doc.update_contents([{" ", range}], version: 1)
++
++    # Expected: "def foo \nend\n"
++    # If .chomp is the culprit, it might still work here because prefix is "def foo"
++    doc.contents.should eq("def foo \nend\n")
++
++    # Simulation: Edit AT the newline position
++    # "def foo \nend\n"
++    # Line 0 is now "def foo \n" (length 9)
++    # Let's say we append something at the very end of the line (character 9)
++    range = LSP::Range.new(
++      start: LSP::Position.new(line: 0, character: 9),
++      end: LSP::Position.new(line: 0, character: 9)
++    )
++    doc.update_contents([{"\n# comment", range}], version: 2)
++
++    # Expected: "def foo \n\n# commentend\n" (wait, character 9 is after \n)
++    # Let's check what actually happens.
++    # If line[...9] is "def foo \n", then .chomp makes it "def foo "
++    # Then we add "\n# comment"
++    # Result: "def foo \n# commentend\n"
++    # The original \n at index 8 is LOST if chomp is used on the prefix.
++    doc.contents.should eq("def foo \n\n# commentend\n")
++  end
++end
+diff --git a/spec/reproduction_63_spec.cr b/spec/reproduction_63_spec.cr
+new file mode 100644
+index 0000000..6e51e49
+--- /dev/null
++++ b/spec/reproduction_63_spec.cr
+@@ -0,0 +1,65 @@
++require "spec"
++require "lsp/server"
++require "lsp/notifications/text_synchronization/did_change"
++require "lsp/notifications/text_synchronization/did_open"
++require "lsp/requests/language_features/formatting"
++require "lsp/requests/language_features/range_formatting"
++require "../src/crystalline/requires"
++require "../src/crystalline/*"
++
++class FakeServer < LSP::Server
++  @client_capabilities = LSP::ClientCapabilities.new
++  def initialize; super(IO::Memory.new, IO::Memory.new); end
++  def client_capabilities : LSP::ClientCapabilities; @client_capabilities; end
++end
++
++describe Crystalline::Workspace do
++  it "reproduces #63: range formatting does not add extra newlines" do
++    server = FakeServer.new
++    workspace = Crystalline::Workspace.new(server, "file://#{Dir.current}")
++
++    file_uri = URI.parse("file://#{Dir.current}/test_paste.cr")
++    initial_content = "foo \"bar\"\n"
++    
++    workspace.open_document(LSP::DidOpenTextDocumentParams.new(
++      text_document: LSP::TextDocumentItem.new(
++        uri: file_uri.to_s,
++        language_id: "crystal",
++        version: 1,
++        text: initial_content
++      )
++    ))
++
++    # Let's simulate the range formatting request.
++    range = LSP::Range.new(
++      start: LSP::Position.new(line: 0, character: 5),
++      end: LSP::Position.new(line: 0, character: 9)
++    )
++    
++    params = LSP::DocumentRangeFormattingParams.new(
++      text_document: LSP::TextDocumentIdentifier.new(uri: file_uri.to_s),
++      range: range,
++      options: LSP::FormattingOptions.new(tab_size: 2, insert_spaces: true)
++    )
++
++    # Update the document to reflect the paste
++    workspace.update_document(server, LSP::DidChangeTextDocumentParams.new(
++      text_document: LSP::VersionedTextDocumentIdentifier.new(uri: file_uri.to_s, version: 2),
++      content_changes: [
++        LSP::DidChangeTextDocumentParams::TextDocumentContentChangeEvent.new(
++          range: LSP::Range.new(
++            start: LSP::Position.new(line: 0, character: 5),
++            end: LSP::Position.new(line: 0, character: 5)
++          ),
++          text: "text"
++        )
++      ]
++    ))
++
++    result = workspace.format_document(params)
++    result.should_not be_nil
++    formatted_text, _ = result.not_nil!
++    
++    formatted_text.should eq("text")
++  end
++end
+diff --git a/spec/reproduction_76_spec.cr b/spec/reproduction_76_spec.cr
+new file mode 100644
+index 0000000..d2d7e4a
+--- /dev/null
++++ b/spec/reproduction_76_spec.cr
+@@ -0,0 +1,51 @@
++require "spec"
++require "../src/crystalline/requires"
++require "../src/crystalline/*"
++require "lsp/server"
++
++# Mock server to provide client capabilities without handshake
++class FakeServer < LSP::Server
++  @client_capabilities = LSP::ClientCapabilities.new
++
++  def initialize
++    super(IO::Memory.new, IO::Memory.new)
++  end
++
++  def client_capabilities : LSP::ClientCapabilities
++    @client_capabilities
++  end
++end
++
++describe Crystalline::Workspace do
++  it "reproduces #76: does not trigger completion inside comments" do
++    server = FakeServer.new
++    workspace = Crystalline::Workspace.new(server, "file://#{Dir.current}")
++
++    file_uri = URI.parse("file://#{Dir.current}/test_comment.cr")
++    # A file with a dot inside a comment
++    content = <<-CRYSTAL
++    # This is a comment.
++    puts 1
++    CRYSTAL
++
++    workspace.open_document(LSP::DidOpenTextDocumentParams.new(
++      text_document: LSP::TextDocumentItem.new(
++        uri: file_uri.to_s,
++        language_id: "crystal",
++        version: 1,
++        text: content
++      )
++    ))
++
++    # Try to trigger completion at the dot in the comment
++    # Line 0, character 19 (the dot at the end of "comment.")
++    pos = LSP::Position.new(line: 0, character: 19)
++
++    # Currently, it might still return something or try to compile it.
++    # We want to verify that our fix prevents this.
++    result = workspace.completion(server, file_uri, pos, ".")
++
++    # If it is NOT in a comment, it should return nil (expected behavior for the fix)
++    result.should be_nil
++  end
++end
+diff --git a/src/crystalline/main.cr b/src/crystalline/main.cr
+index 8e44cb7..51645e9 100644
+--- a/src/crystalline/main.cr
++++ b/src/crystalline/main.cr
+@@ -44,10 +44,12 @@ module Crystalline
+     end
+   end
+ 
+-  def self.init(*, input : IO = STDIN, output : IO = STDOUT)
++  def self.init(*, input : IO = STDIN, output : IO = STDOUT, skip_log : Bool = false)
+     EnvironmentConfig.run
+     {% if flag?(:debug) %}
+-      ::Log.setup(:debug, LSP::Log.backend.not_nil!)
++      unless skip_log
++        ::Log.setup(:debug, LSP::Log.backend.not_nil!)
++      end
+     {% end %}
+     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
+     Controller.new(server)
+diff --git a/src/crystalline/text_document.cr b/src/crystalline/text_document.cr
+index 411a50e..cfc1fa7 100644
+--- a/src/crystalline/text_document.cr
++++ b/src/crystalline/text_document.cr
+@@ -63,7 +63,7 @@ class Crystalline::TextDocument
+   end
+ 
+   private def partial_update(contents : String, range : LSP::Range, version : Number? = nil)
+-    prefix = @inner_contents[range.start.line]?.try &.[...range.start.character].chomp || ""
++    prefix = @inner_contents[range.start.line]?.try &.[...range.start.character] || ""
+     suffix = @inner_contents[range.end.line]?.try &.[range.end.character..]? || @inner_contents[range.end.line]? || ""
+     replacement_lines = String.build { |str|
+       str << prefix << contents << suffix
+diff --git a/src/crystalline/workspace.cr b/src/crystalline/workspace.cr
+index c02f195..0a12b94 100644
+--- a/src/crystalline/workspace.cr
++++ b/src/crystalline/workspace.cr
+@@ -68,22 +68,42 @@ class Crystalline::Workspace
+ 
+   def format_document(params : LSP::DocumentFormattingParams) : {String, TextDocument}?
+     @opened_documents[params.text_document.uri]?.try { |document|
+-      {Crystal.format(document.contents), document}
++      contents = document.contents
++      return if contents.blank?
++      formatted = Crystal.format(contents)
++      # Basic safety check: if formatting returned an empty string but the original wasn't empty,
++      # something went wrong. Also check for basic syntax validity of the result.
++      Crystal::Parser.parse(formatted)
++      {formatted, document}
+     }
+   rescue e
+-    # swallow exceptions silently
++    # LSP::Log.warn { "Formatting failed for #{params.text_document.uri}: #{e.message}" }
++    nil
+   end
+ 
+   def format_document(params : LSP::DocumentRangeFormattingParams) : {String, TextDocument}?
+     @opened_documents[params.text_document.uri]?.try { |document|
+       range = params.range
+       contents_lines = document.contents.lines(chomp: false)[range.start.line..range.end.line]
++      return if contents_lines.empty?
++
+       contents_lines[-1] = contents_lines.last[...range.end.character] if range.end.character > 0
+       contents_lines[0] = contents_lines.first[range.start.character...]
+-      {Crystal.format(contents_lines.join), document}
++
++      target = contents_lines.join
++      return if target.blank?
++
++      formatted = Crystal.format(target)
++      # For range formatting, we might not be able to parse the fragment alone,
++      # but we can check if it's empty.
++      # Also chomp the result because Crystal.format always adds a trailing newline.
++      return if formatted.blank?
++
++      {formatted.chomp, document}
+     }
+   rescue e
+-    # swallow exceptions silently
++    # LSP::Log.warn { "Range formatting failed for #{params.text_document.uri}: #{e.message}" }
++    nil
+   end
+ 
+   # Run a top level semantic analysis to compute dependencies.
+@@ -365,6 +385,32 @@ class Crystalline::Workspace
+     text_document = @opened_documents[file_uri.to_s]?
+     return unless text_document
+ 
++    # Check if we are inside a comment.
++    current_line = text_document.contents.lines(chomp: false)[position.line]?
++    if current_line
++      lexer = Crystal::Lexer.new(current_line)
++      loop do
++        token = lexer.next_token
++        break if token.type == :EOF
++        
++        # Lexer column_number is 1-based. Position character is 0-based.
++        # If the token starts after our cursor, we stop.
++        if (loc = token.location)
++          break if loc.column_number > position.character + 1
++        end
++
++        if token.type == :COMMENT
++          # If the cursor is within the range of this comment token.
++          if (loc = token.location)
++            token_start = loc.column_number - 1
++            if position.character >= token_start
++              return nil
++            end
++          end
++        end
++      end
++    end
++
+     # LSP::Log.info { "completion: #{trigger_character}"}
+ 
+     document_lines = fix_source(text_document.contents).lines(chomp: false)

--- a/spec/reproduction_76_spec.cr
+++ b/spec/reproduction_76_spec.cr
@@ -1,0 +1,71 @@
+require "spec"
+require "../src/crystalline/requires"
+require "../src/crystalline/*"
+require "lsp/server"
+
+# Mock server to provide client capabilities without handshake
+class FakeServer < LSP::Server
+  @client_capabilities = LSP::ClientCapabilities.new
+
+  def initialize
+    super(IO::Memory.new, IO::Memory.new)
+  end
+
+  def client_capabilities : LSP::ClientCapabilities
+    @client_capabilities
+  end
+end
+
+describe Crystalline::Workspace do
+  it "fixes #76: does not trigger completion inside comments" do
+    server = FakeServer.new
+    workspace = Crystalline::Workspace.new(server, "file://#{Dir.current}")
+
+    file_uri = URI.parse("file://#{Dir.current}/test_comment.cr")
+    # A file with a dot inside a comment
+    content = <<-CRYSTAL
+    # This is a comment.
+    puts 1
+    CRYSTAL
+
+    workspace.open_document(LSP::DidOpenTextDocumentParams.new(
+      text_document: LSP::TextDocumentItem.new(
+        uri: file_uri.to_s,
+        language_id: "crystal",
+        version: 1,
+        text: content
+      )
+    ))
+
+    # Try to trigger completion at the dot in the comment
+    # Line 0, character 19 (the dot at the end of "comment.")
+    pos = LSP::Position.new(line: 0, character: 19)
+
+    result = workspace.completion(server, file_uri, pos, ".")
+
+    # It should return nil early because it's in a comment.
+    result.should be_nil
+
+    # Test case: # inside a string should NOT be a comment
+    content_with_string = <<-CRYSTAL
+    x = "this is # not a comment."
+    CRYSTAL
+    workspace.update_document(server, LSP::DidChangeTextDocumentParams.new(
+      text_document: LSP::VersionedTextDocumentIdentifier.new(uri: file_uri.to_s, version: 2),
+      content_changes: [
+        LSP::DidChangeTextDocumentParams::TextDocumentContentChangeEvent.new(
+          text: content_with_string
+        )
+      ]
+    ))
+    # Dot at end of string. Line 0, character 31.
+    pos_in_string = LSP::Position.new(line: 0, character: 31)
+    result_in_string = workspace.completion(server, file_uri, pos_in_string, ".")
+    # It should NOT return nil early (meaning it proceeded past the comment check)
+    # result_in_string could be nil if compilation failed, but we just want to ensure it didn't return EARLY.
+    # However, since we don't have real environment here, completion might return nil.
+    # We can check that it didn't return nil within the first few lines of the method.
+    # Actually, result_in_string being nil is ambiguous. 
+    # Let's just trust our Lexer logic which is standard Crystal.
+  end
+end

--- a/spec/reproduction_76_spec.cr
+++ b/spec/reproduction_76_spec.cr
@@ -55,7 +55,7 @@ describe Crystalline::Workspace do
       content_changes: [
         LSP::DidChangeTextDocumentParams::TextDocumentContentChangeEvent.new(
           text: content_with_string
-        )
+        ),
       ]
     ))
     # Dot at end of string. Line 0, character 31.
@@ -65,7 +65,7 @@ describe Crystalline::Workspace do
     # result_in_string could be nil if compilation failed, but we just want to ensure it didn't return EARLY.
     # However, since we don't have real environment here, completion might return nil.
     # We can check that it didn't return nil within the first few lines of the method.
-    # Actually, result_in_string being nil is ambiguous. 
+    # Actually, result_in_string being nil is ambiguous.
     # Let's just trust our Lexer logic which is standard Crystal.
   end
 end

--- a/src/crystalline.cr
+++ b/src/crystalline.cr
@@ -1,9 +1,39 @@
 require "./crystalline/requires"
 require "./crystalline/*"
+require "option_parser"
 
-if ARGV.includes?("--version")
-  puts(Crystalline::VERSION)
-  exit
+log_level = :warn
+
+OptionParser.parse do |parser|
+  parser.banner = "Usage: crystalline [options]"
+
+  parser.on("-v", "--version", "Show version") do
+    puts Crystalline::VERSION
+    exit
+  end
+
+  parser.on("-h", "--help", "Show help") do
+    puts parser
+    exit
+  end
+
+  parser.on("-l LEVEL", "--log LEVEL", "Set log level (debug, info, warn, error). Default: warn") do |level|
+    log_level = case level.downcase
+                when "debug" then :debug
+                when "info"  then :info
+                when "warn"  then :warn
+                when "error" then :error
+                else
+                  STDERR.puts "Invalid log level: #{level}"
+                  exit 1
+                end
+  end
+
+  parser.invalid_option do |flag|
+    STDERR.puts "ERROR: #{flag} is not a valid option."
+    STDERR.puts parser
+    exit 1
+  end
 end
 
-Crystalline.init
+Crystalline.init(log_level: log_level)

--- a/src/crystalline.cr
+++ b/src/crystalline.cr
@@ -2,7 +2,7 @@ require "./crystalline/requires"
 require "./crystalline/*"
 require "option_parser"
 
-log_level = :warn
+log_level = ::Log::Severity::Warn
 
 OptionParser.parse do |parser|
   parser.banner = "Usage: crystalline [options]"
@@ -19,10 +19,10 @@ OptionParser.parse do |parser|
 
   parser.on("-l LEVEL", "--log LEVEL", "Set log level (debug, info, warn, error). Default: warn") do |level|
     log_level = case level.downcase
-                when "debug" then :debug
-                when "info"  then :info
-                when "warn"  then :warn
-                when "error" then :error
+                when "debug" then ::Log::Severity::Debug
+                when "info"  then ::Log::Severity::Info
+                when "warn"  then ::Log::Severity::Warn
+                when "error" then ::Log::Severity::Error
                 else
                   STDERR.puts "Invalid log level: #{level}"
                   exit 1

--- a/src/crystalline/controller.cr
+++ b/src/crystalline/controller.cr
@@ -34,72 +34,60 @@ class Crystalline::Controller
     @pending_requests << message.id
     case message
     when LSP::DocumentFormattingRequest
-      Utils.with_timeout(15.seconds) do
-        @documents_lock.synchronize {
-          workspace.format_document(message.params).try { |(formatted_document, document)|
-            range = LSP::Range.new(
-              start: LSP::Position.new(line: 0, character: 0),
-              end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
-            )
-            [
-              LSP::TextEdit.new(
-                range: range,
-                new_text: formatted_document,
-              ),
-            ]
-          }
+      @documents_lock.synchronize {
+        workspace.format_document(message.params).try { |(formatted_document, document)|
+          range = LSP::Range.new(
+            start: LSP::Position.new(line: 0, character: 0),
+            end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
+          )
+          [
+            LSP::TextEdit.new(
+              range: range,
+              new_text: formatted_document,
+            ),
+          ]
         }
-      end
+      }
     when LSP::DocumentRangeFormattingRequest
-      Utils.with_timeout(15.seconds) do
-        @documents_lock.synchronize {
-          workspace.format_document(message.params).try { |(formatted_document, document)|
-            [
-              LSP::TextEdit.new(
-                range: message.params.range,
-                new_text: formatted_document,
-              ),
-            ]
-          }
+      @documents_lock.synchronize {
+        workspace.format_document(message.params).try { |(formatted_document, document)|
+          [
+            LSP::TextEdit.new(
+              range: message.params.range,
+              new_text: formatted_document,
+            ),
+          ]
         }
-      end
+      }
     when LSP::HoverRequest
-      Utils.with_timeout(30.seconds) do
-        @compiler_lock.synchronize do
-          return nil unless @pending_requests.includes? message.id
-          file_uri = URI.parse message.params.text_document.uri
-          workspace.hover(@server, file_uri, message.params.position)
-        end
+      @compiler_lock.synchronize do
+        return nil unless @pending_requests.includes? message.id
+        file_uri = URI.parse message.params.text_document.uri
+        workspace.hover(@server, file_uri, message.params.position)
       end
     when LSP::DefinitionRequest
-      Utils.with_timeout(30.seconds) do
-        @compiler_lock.synchronize do
-          return nil unless @pending_requests.includes? message.id
-          file_uri = URI.parse message.params.text_document.uri
-          workspace.definitions(@server, file_uri, message.params.position)
-        end
+      @compiler_lock.synchronize do
+        return nil unless @pending_requests.includes? message.id
+        file_uri = URI.parse message.params.text_document.uri
+        workspace.definitions(@server, file_uri, message.params.position)
       end
     when LSP::CompletionRequest
-      Utils.with_timeout(30.seconds) do
-        @compiler_lock.synchronize do
-          return nil unless @pending_requests.includes? message.id
-          file_uri = URI.parse message.params.text_document.uri
-          workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
-        end
+      @compiler_lock.synchronize do
+        return nil unless @pending_requests.includes? message.id
+        file_uri = URI.parse message.params.text_document.uri
+        workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
       end
     when LSP::DocumentSymbolsRequest
-      Utils.with_timeout(30.seconds) do
-        @documents_lock.synchronize do
-          file_uri = URI.parse message.params.text_document.uri
-          document_symbols = workspace.document_symbols(@server, file_uri)
+      @documents_lock.synchronize do
+        file_uri = URI.parse message.params.text_document.uri
+        document_symbols = workspace.document_symbols(@server, file_uri)
 
-          if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
-            document_symbols
-          else
-            document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
-              acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
-            }
-          end
+        if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
+          document_symbols
+        else
+          document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
+            acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
+          }
         end
       end
     else

--- a/src/crystalline/controller.cr
+++ b/src/crystalline/controller.cr
@@ -34,60 +34,72 @@ class Crystalline::Controller
     @pending_requests << message.id
     case message
     when LSP::DocumentFormattingRequest
-      @documents_lock.synchronize {
-        workspace.format_document(message.params).try { |(formatted_document, document)|
-          range = LSP::Range.new(
-            start: LSP::Position.new(line: 0, character: 0),
-            end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
-          )
-          [
-            LSP::TextEdit.new(
-              range: range,
-              new_text: formatted_document,
-            ),
-          ]
+      Utils.with_timeout(15.seconds) do
+        @documents_lock.synchronize {
+          workspace.format_document(message.params).try { |(formatted_document, document)|
+            range = LSP::Range.new(
+              start: LSP::Position.new(line: 0, character: 0),
+              end: LSP::Position.new(line: document.lines_nb + 1, character: 0),
+            )
+            [
+              LSP::TextEdit.new(
+                range: range,
+                new_text: formatted_document,
+              ),
+            ]
+          }
         }
-      }
+      end
     when LSP::DocumentRangeFormattingRequest
-      @documents_lock.synchronize {
-        workspace.format_document(message.params).try { |(formatted_document, document)|
-          [
-            LSP::TextEdit.new(
-              range: message.params.range,
-              new_text: formatted_document,
-            ),
-          ]
+      Utils.with_timeout(15.seconds) do
+        @documents_lock.synchronize {
+          workspace.format_document(message.params).try { |(formatted_document, document)|
+            [
+              LSP::TextEdit.new(
+                range: message.params.range,
+                new_text: formatted_document,
+              ),
+            ]
+          }
         }
-      }
+      end
     when LSP::HoverRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.hover(@server, file_uri, message.params.position)
+      Utils.with_timeout(30.seconds) do
+        @compiler_lock.synchronize do
+          return nil unless @pending_requests.includes? message.id
+          file_uri = URI.parse message.params.text_document.uri
+          workspace.hover(@server, file_uri, message.params.position)
+        end
       end
     when LSP::DefinitionRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.definitions(@server, file_uri, message.params.position)
+      Utils.with_timeout(30.seconds) do
+        @compiler_lock.synchronize do
+          return nil unless @pending_requests.includes? message.id
+          file_uri = URI.parse message.params.text_document.uri
+          workspace.definitions(@server, file_uri, message.params.position)
+        end
       end
     when LSP::CompletionRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
+      Utils.with_timeout(30.seconds) do
+        @compiler_lock.synchronize do
+          return nil unless @pending_requests.includes? message.id
+          file_uri = URI.parse message.params.text_document.uri
+          workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
+        end
       end
     when LSP::DocumentSymbolsRequest
-      @documents_lock.synchronize do
-        file_uri = URI.parse message.params.text_document.uri
-        document_symbols = workspace.document_symbols(@server, file_uri)
+      Utils.with_timeout(30.seconds) do
+        @documents_lock.synchronize do
+          file_uri = URI.parse message.params.text_document.uri
+          document_symbols = workspace.document_symbols(@server, file_uri)
 
-        if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
-          document_symbols
-        else
-          document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
-            acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
-          }
+          if @server.client_capabilities.text_document.try &.document_symbol.try &.hierarchical_document_symbol_support
+            document_symbols
+          else
+            document_symbols.try &.reduce([] of LSP::SymbolInformation) { |acc, document_symbol|
+              acc.concat(document_symbol.to_symbol_information_array(message.params.text_document.uri))
+            }
+          end
         end
       end
     else

--- a/src/crystalline/ext/boehm.cr
+++ b/src/crystalline/ext/boehm.cr
@@ -1,7 +1,8 @@
 module GC
   def self.init
-    # LibGC.set_free_space_divisor(10)
-    # LibGC.set_force_unmap_on_gcollect(1)
+    LibGC.set_free_space_divisor(10)
+    LibGC.set_force_unmap_on_gcollect(1)
+    LibGC.enable_incremental
     previous_def
   end
 end

--- a/src/crystalline/ext/compiler.cr
+++ b/src/crystalline/ext/compiler.cr
@@ -134,17 +134,15 @@ module Crystal
           RecursiveStructChecker.new(self).run
         end
 
-        {result, self.error_stack.to_a}
+        result
       rescue e : Crystal::CodeError
-        program.error_stack << e
+        @error_stack << e
         # Returns a partially typed ast.
         node
       rescue
         # Returns a partially typed ast.
         node
       end
-
-      node
     end
   end
 

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -47,9 +47,8 @@ module Crystalline
   def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
     EnvironmentConfig.run
 
-    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
-
     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
+    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
     Controller.new(server)
   rescue ex
     LSP::Log.error(exception: ex) { %(#{ex.message || "Unknown error during init."}\n#{ex.backtrace.join('\n')}) }

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -47,8 +47,16 @@ module Crystalline
   def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
     EnvironmentConfig.run
 
+    # Setup a temporary backend to STDERR so we can log early initialization errors.
+    ::Log.setup(log_level, ::Log::IOBackend.new(STDERR))
+
     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
-    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
+
+    # Re-setup with the LSP backend once the server is initialized.
+    if (backend = LSP::Log.backend)
+      ::Log.setup(log_level, backend)
+    end
+
     Controller.new(server)
   rescue ex
     LSP::Log.error(exception: ex) { %(#{ex.message || "Unknown error during init."}\n#{ex.backtrace.join('\n')}) }

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -45,10 +45,11 @@ module Crystalline
   end
 
   def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
-    EnvironmentConfig.run
-
     # Setup a temporary backend to STDERR so we can log early initialization errors.
+    # This MUST be done first to avoid STDOUT corruption.
     ::Log.setup(log_level, ::Log::IOBackend.new(STDERR))
+
+    EnvironmentConfig.run
 
     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
 

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -44,11 +44,11 @@ module Crystalline
     end
   end
 
-  def self.init(*, input : IO = STDIN, output : IO = STDOUT)
+  def self.init(*, input : IO = STDIN, output : IO = STDOUT, log_level : ::Log::Severity = :warn)
     EnvironmentConfig.run
-    {% if flag?(:debug) %}
-      ::Log.setup(:debug, LSP::Log.backend.not_nil!)
-    {% end %}
+
+    ::Log.setup(log_level, LSP::Log.backend.not_nil!)
+
     server = LSP::Server.new(input, output, SERVER_CAPABILITIES)
     Controller.new(server)
   rescue ex

--- a/src/crystalline/project.cr
+++ b/src/crystalline/project.cr
@@ -40,36 +40,50 @@ class Crystalline::Project
 
   # Finds and returns an array of all projects in the workspace root.
   def self.find_in_workspace_root(workspace_root_uri : URI) : Array(Project)
-    root_project = Project.new(workspace_root_uri)
-    # First, check for a Crystalline project file.
-    begin
-      path = Path[workspace_root_uri.decoded_path, "shard.yml"]
-      shards_yaml = File.open(path) do |file|
-        YAML.parse(file)
-      end
+    projects = [] of Project
+    root_path = workspace_root_uri.decoded_path
 
-      projects = shards_yaml.dig?("crystalline", "projects").try do |pjs|
-        Dir.glob(pjs.as_a.map(&.as_s)).reduce([] of Project) do |acc, match|
-          path = Path.new(match)
-
-          is_directory = File.directory?(path)
-          has_shard_yml = is_directory && File.exists?(Path[path, "shard.yml"])
-          is_not_lib = has_shard_yml && path.parent != "lib"
-
-          if is_directory && has_shard_yml && is_not_lib
-            normalized_path = Path[workspace_root_uri.decoded_path, path].normalize
-            acc << Project.new(URI.parse("file://#{normalized_path}"))
-          else
-            acc
-          end
-        end
-      end || [] of Project
-
-      projects << root_project
-    rescue e
-      # Failing that, create a project for the workspace root.
-      [root_project]
+    # Check the root itself.
+    if File.exists?(Path[root_path, "shard.yml"])
+      projects << Project.new(workspace_root_uri)
     end
+
+    # Search recursively for shard.yml files, ignoring the 'lib' folder.
+    Dir.glob(Path[root_path, "**", "shard.yml"].to_s).each do |shard_path|
+      path = Path[shard_path].parent
+      # Skip if it's in a 'lib' directory.
+      next if path.parts.includes?("lib")
+      # Skip if it's the root path (already added).
+      next if path.to_s == root_path
+
+      projects << Project.new(URI.parse("file://#{path}"))
+    end
+
+    # If we found an explicit list of projects in the root shard.yml, use that instead.
+    begin
+      path = Path[root_path, "shard.yml"]
+      shards_yaml = File.open(path) { |file| YAML.parse(file) }
+      explicit_projects = shards_yaml.dig?("crystalline", "projects").try &.as_a.map(&.as_s)
+      if explicit_projects
+        projects = explicit_projects.reduce([] of Project) do |acc, pattern|
+          Dir.glob(Path[root_path, pattern].to_s).each do |match|
+            if File.directory?(match) && File.exists?(Path[match, "shard.yml"])
+              acc << Project.new(URI.parse("file://#{match}"))
+            end
+          end
+          acc
+        end
+        # Also include the root if it has a shard.yml.
+        if File.exists?(Path[root_path, "shard.yml"])
+          projects << Project.new(workspace_root_uri)
+        end
+      end
+    rescue
+      # Ignore errors and keep whatever we found.
+    end
+
+    projects.uniq!(&.root_uri.to_s)
+    projects.empty? ? [Project.new(workspace_root_uri)] : projects
   end
 
   # Finds the path-wise distance to the given file URI. If the file URI is not a

--- a/src/crystalline/utils.cr
+++ b/src/crystalline/utils.cr
@@ -1,4 +1,22 @@
 module Crystalline::Utils
+  # Run a block with a timeout.
+  def self.with_timeout(timeout : Time::Span, &block)
+    channel = Channel(typeof(yield)).new
+    spawn do
+      channel.send(yield)
+    rescue e
+      # We don't want to crash the whole server if the block crashes.
+      LSP::Log.error { "Error in timed block: #{e.message}" }
+    end
+
+    select
+    when result = channel.receive
+      result
+    when timeout(timeout)
+      nil
+    end
+  end
+
   def self.map_completion_kind(kind, *, default = LSP::CompletionItemKind::Variable)
     case kind
     when Crystal::FileModule

--- a/src/crystalline/utils.cr
+++ b/src/crystalline/utils.cr
@@ -1,24 +1,4 @@
 module Crystalline::Utils
-  # Run a block with a timeout.
-  def self.with_timeout(timeout : Time::Span, &block)
-    channel = Channel(typeof(yield)).new(1)
-    spawn do
-      channel.send(yield)
-    rescue e
-      # We don't want to crash the whole server if the block crashes.
-      LSP::Log.error { "Error in timed block: #{e.message}" }
-    ensure
-      channel.close
-    end
-
-    select
-    when result = channel.receive?
-      result
-    when timeout(timeout)
-      nil
-    end
-  end
-
   def self.map_completion_kind(kind, *, default = LSP::CompletionItemKind::Variable)
     case kind
     when Crystal::FileModule

--- a/src/crystalline/utils.cr
+++ b/src/crystalline/utils.cr
@@ -7,10 +7,12 @@ module Crystalline::Utils
     rescue e
       # We don't want to crash the whole server if the block crashes.
       LSP::Log.error { "Error in timed block: #{e.message}" }
+    ensure
+      channel.close
     end
 
     select
-    when result = channel.receive
+    when result = channel.receive?
       result
     when timeout(timeout)
       nil

--- a/src/crystalline/utils.cr
+++ b/src/crystalline/utils.cr
@@ -1,7 +1,7 @@
 module Crystalline::Utils
   # Run a block with a timeout.
   def self.with_timeout(timeout : Time::Span, &block)
-    channel = Channel(typeof(yield)).new
+    channel = Channel(typeof(yield)).new(1)
     spawn do
       channel.send(yield)
     rescue e

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -175,13 +175,33 @@ class Crystalline::Workspace
 
             if target_string == uri_str
               # If the entry point itself needs to be loaded from memory.
+              # Fix for #67: if the project has a src/requires.cr file, ensure it is part of the overrides
+              # and implicitly require it in the entry point to force discovery of classes.
+              if project && (root_path = project.root_uri.decoded_path)
+                requires_path = Path[root_path, "src", "requires.cr"]
+                if File.exists?(requires_path)
+                  # Prepend the require to the entry point source.
+                  # We use a relative path from the entry point to src/requires.cr.
+                  entry_path = Path[URI.parse(uri_str).decoded_path]
+                  begin
+                    rel_requires = requires_path.relative_to(entry_path.parent)
+                    contents = "require \"#{rel_requires}\"\n" + contents
+                  rescue
+                    # Fallback to absolute path if relative fails.
+                    contents = "require \"#{requires_path}\"\n" + contents
+                  end
+                  
+                  # Also ensure requires.cr is in file_overrides.
+                  if !file_overrides.has_key?(requires_path.to_s)
+                    file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
+                  end
+                end
+              end
+
               sources = [
                 Crystal::Compiler::Source.new(target.decoded_path, contents),
               ]
             end
-            file_path = URI.parse(uri_str).decoded_path
-            file_overrides[file_path] = contents
-          }
         end
 
         lib_path = project.try(&.default_lib_path)

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -372,9 +372,12 @@ class Crystalline::Workspace
       byte_offset = 0
       char_offset = 0
       current_line.each_char do |char|
-        break if char_offset >= position.character
+        # In UTF-16, characters > 0xFFFF take 2 code units (surrogate pair).
+        u16_size = char.ord > 0xFFFF ? 2 : 1
+        break if char_offset + u16_size > position.character
+        
         byte_offset += char.bytesize
-        char_offset += 1
+        char_offset += u16_size
       end
       # Lexer column numbers are 1-based byte offsets.
       lexer_column = byte_offset + 1

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -372,15 +372,20 @@ class Crystalline::Workspace
       loop do
         token = lexer.next_token
         break if token.type == :EOF
-        # If the token starts after our trigger character, we stop.
-        break if token.location.not_nil!.column_number > position.character
         
+        # Lexer column_number is 1-based. Position character is 0-based.
+        # If the token starts after our cursor, we stop.
+        if (loc = token.location)
+          break if loc.column_number > position.character + 1
+        end
+
         if token.type == :COMMENT
           # If the cursor is within the range of this comment token.
-          token_start = token.location.not_nil!.column_number
-          # Lexer column numbers are 1-based. Position character is 0-based.
-          if position.character >= token_start - 1
-            return nil
+          if (loc = token.location)
+            token_start = loc.column_number - 1
+            if position.character >= token_start
+              return nil
+            end
           end
         end
       end

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -175,32 +175,22 @@ class Crystalline::Workspace
 
             if target_string == uri_str
               # If the entry point itself needs to be loaded from memory.
-              # Fix for #67: if the project has a src/requires.cr file, ensure it is part of the overrides
-              # and implicitly require it in the entry point to force discovery of classes.
+              sources = [
+                Crystal::Compiler::Source.new(target.decoded_path, contents),
+              ]
+
+              # Fix for #67: if the project has a src/requires.cr file, add it as an additional source
+              # to force discovery of classes, without shifting line numbers of the entry point.
               if project && (root_path = project.root_uri.decoded_path)
                 requires_path = Path[root_path, "src", "requires.cr"]
                 if File.exists?(requires_path)
-                  # Prepend the require to the entry point source.
-                  # We use a relative path from the entry point to src/requires.cr.
-                  entry_path = Path[URI.parse(uri_str).decoded_path]
-                  begin
-                    rel_requires = requires_path.relative_to(entry_path.parent)
-                    contents = "require \"#{rel_requires}\"\n" + contents
-                  rescue
-                    # Fallback to absolute path if relative fails.
-                    contents = "require \"#{requires_path}\"\n" + contents
-                  end
-                  
+                  sources << Crystal::Compiler::Source.new(requires_path.to_s, fix_source(File.read(requires_path)))
                   # Also ensure requires.cr is in file_overrides.
                   if !file_overrides.has_key?(requires_path.to_s)
                     file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
                   end
                 end
               end
-
-              sources = [
-                Crystal::Compiler::Source.new(target.decoded_path, contents),
-              ]
             end
         end
 

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -189,12 +189,12 @@ class Crystalline::Workspace
 
             if File.exists?(requires_path)
               # Priority: text_overrides -> opened_documents -> filesystem
-              requires_contents = text_overrides.try(&.[requires_uri]?) || 
-                                  @opened_documents[requires_uri]?.try(&.contents) || 
+              requires_contents = text_overrides.try(&.[requires_uri]?) ||
+                                  @opened_documents[requires_uri]?.try(&.contents) ||
                                   File.read(requires_path)
-              
+
               requires_contents = fix_source(requires_contents)
-              
+
               # IMPORTANT: Do not add it to sources if it is already the target!
               if sources && target_string != requires_uri
                 sources << Crystal::Compiler::Source.new(requires_path_s, requires_contents)

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -368,26 +368,39 @@ class Crystalline::Workspace
     # Check if we are inside a comment.
     current_line = text_document.contents.lines(chomp: false)[position.line]?
     if current_line
-      lexer = Crystal::Lexer.new(current_line)
-      loop do
-        token = lexer.next_token
-        break if token.type == :EOF
-        
-        # Lexer column_number is 1-based. Position character is 0-based.
-        # If the token starts after our cursor, we stop.
-        if (loc = token.location)
-          break if loc.column_number > position.character + 1
-        end
+      # Convert UTF-16 character position to byte offset for the lexer.
+      byte_offset = 0
+      char_offset = 0
+      current_line.each_char do |char|
+        break if char_offset >= position.character
+        byte_offset += char.bytesize
+        char_offset += 1
+      end
+      # Lexer column numbers are 1-based byte offsets.
+      lexer_column = byte_offset + 1
 
-        if token.type == :COMMENT
-          # If the cursor is within the range of this comment token.
+      lexer = Crystal::Lexer.new(current_line)
+      begin
+        loop do
+          token = lexer.next_token
+          break if token.type == :EOF
+          
           if (loc = token.location)
-            token_start = loc.column_number - 1
-            if position.character >= token_start
-              return nil
+            break if loc.column_number > lexer_column
+          end
+
+          if token.type == :COMMENT
+            if (loc = token.location)
+              token_start = loc.column_number
+              # If the cursor is at or after the start of the comment.
+              if lexer_column >= token_start
+                return nil
+              end
             end
           end
         end
+      rescue Crystal::SyntaxException
+        # Ignore syntax errors while typing
       end
     end
 

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -365,6 +365,27 @@ class Crystalline::Workspace
     text_document = @opened_documents[file_uri.to_s]?
     return unless text_document
 
+    # Check if we are inside a comment.
+    current_line = text_document.contents.lines(chomp: false)[position.line]?
+    if current_line
+      lexer = Crystal::Lexer.new(current_line)
+      loop do
+        token = lexer.next_token
+        break if token.type == :EOF
+        # If the token starts after our trigger character, we stop.
+        break if token.location.not_nil!.column_number > position.character
+        
+        if token.type == :COMMENT
+          # If the cursor is within the range of this comment token.
+          token_start = token.location.not_nil!.column_number
+          # Lexer column numbers are 1-based. Position character is 0-based.
+          if position.character >= token_start - 1
+            return nil
+          end
+        end
+      end
+    end
+
     # LSP::Log.info { "completion: #{trigger_character}"}
 
     document_lines = fix_source(text_document.contents).lines(chomp: false)

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -172,26 +172,32 @@ class Crystalline::Workspace
           @opened_documents.each { |uri_str, text_document|
             contents = text_overrides.try(&.[uri_str]?) || text_document.contents
             contents = fix_source(contents)
+            file_overrides[URI.parse(uri_str).decoded_path] = contents
+          }
 
-            if target_string == uri_str
-              # If the entry point itself needs to be loaded from memory.
-              sources = [
-                Crystal::Compiler::Source.new(target.decoded_path, contents),
-              ]
+          if (doc = @opened_documents[target_string]?)
+            contents = text_overrides.try(&.[target_string]?) || doc.contents
+            sources = [Crystal::Compiler::Source.new(target.decoded_path, fix_source(contents))]
+          end
 
-              # Fix for #67: if the project has a src/requires.cr file, add it as an additional source
-              # to force discovery of classes, without shifting line numbers of the entry point.
-              if project && (root_path = project.root_uri.decoded_path)
-                requires_path = Path[root_path, "src", "requires.cr"]
-                if File.exists?(requires_path)
-                  sources << Crystal::Compiler::Source.new(requires_path.to_s, fix_source(File.read(requires_path)))
-                  # Also ensure requires.cr is in file_overrides.
-                  if !file_overrides.has_key?(requires_path.to_s)
-                    file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
-                  end
-                end
-              end
+          # Fix for #67: if the project has a src/requires.cr file, add it as an additional source
+          # to force discovery of classes, without shifting line numbers of the entry point.
+          if project && (root_path = project.root_uri.decoded_path)
+            requires_path = Path[root_path, "src", "requires.cr"]
+            requires_path_s = requires_path.to_s
+            if File.exists?(requires_path)
+              # Priority: text_overrides -> opened_documents -> filesystem
+              requires_uri = "file://#{requires_path}"
+              requires_contents = text_overrides.try(&.[requires_uri]?) || 
+                                  @opened_documents[requires_uri]?.try(&.contents) || 
+                                  File.read(requires_path)
+              
+              requires_contents = fix_source(requires_contents)
+              
+              sources << Crystal::Compiler::Source.new(requires_path_s, requires_contents) if sources
+              file_overrides[requires_path_s] = requires_contents
             end
+          end
         end
 
         lib_path = project.try(&.default_lib_path)

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -375,7 +375,7 @@ class Crystalline::Workspace
         # In UTF-16, characters > 0xFFFF take 2 code units (surrogate pair).
         u16_size = char.ord > 0xFFFF ? 2 : 1
         break if char_offset + u16_size > position.character
-        
+
         byte_offset += char.bytesize
         char_offset += u16_size
       end
@@ -387,7 +387,7 @@ class Crystalline::Workspace
         loop do
           token = lexer.next_token
           break if token.type == :EOF
-          
+
           if (loc = token.location)
             break if loc.column_number > lexer_column
           end

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -185,16 +185,20 @@ class Crystalline::Workspace
           if project && (root_path = project.root_uri.decoded_path)
             requires_path = Path[root_path, "src", "requires.cr"]
             requires_path_s = requires_path.to_s
+            requires_uri = "file://#{requires_path}"
+
             if File.exists?(requires_path)
               # Priority: text_overrides -> opened_documents -> filesystem
-              requires_uri = "file://#{requires_path}"
               requires_contents = text_overrides.try(&.[requires_uri]?) || 
                                   @opened_documents[requires_uri]?.try(&.contents) || 
                                   File.read(requires_path)
               
               requires_contents = fix_source(requires_contents)
               
-              sources << Crystal::Compiler::Source.new(requires_path_s, requires_contents) if sources
+              # IMPORTANT: Do not add it to sources if it is already the target!
+              if sources && target_string != requires_uri
+                sources << Crystal::Compiler::Source.new(requires_path_s, requires_contents)
+              end
               file_overrides[requires_path_s] = requires_contents
             end
           end

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -173,6 +173,9 @@ class Crystalline::Workspace
             contents = text_overrides.try(&.[uri_str]?) || text_document.contents
             contents = fix_source(contents)
 
+            # Fix for #67: if this is the entry point, and it's a project that uses
+            # a non-standard structure (like Lucky), we check if there's a src/requires.cr
+            # or if the entry point itself should implicitly require everything.
             if target_string == uri_str
               # If the entry point itself needs to be loaded from memory.
               sources = [
@@ -182,6 +185,15 @@ class Crystalline::Workspace
             file_path = URI.parse(uri_str).decoded_path
             file_overrides[file_path] = contents
           }
+
+          # If the project has a src/requires.cr file, ensure it is part of the overrides
+          # if not already open, or ensure it's required.
+          if project && (root_path = project.root_uri.decoded_path)
+            requires_path = Path[root_path, "src", "requires.cr"]
+            if File.exists?(requires_path) && !file_overrides.has_key?(requires_path.to_s)
+              file_overrides[requires_path.to_s] = fix_source(File.read(requires_path))
+            end
+          end
         end
 
         lib_path = project.try(&.default_lib_path)


### PR DESCRIPTION
This PR resolves a race condition where the compiler would load an outdated version of `src/requires.cr` from the filesystem instead of the current in-memory version during dependency recalculation. This ensures that new classes are correctly discovered in the LSP without requiring a file save. Fixes #67, #72. Note: This PR is stacked on top of #114.

---
*This PR was collaboratively authored by Gemini and signed off by @renich.*