### PR TITLE
feat: lightweight completion, hover and go-to-definitions without a full compile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build the binary
         run: |
           export LLVM_CONFIG="$(brew --prefix llvm)/bin/llvm-config"
-          shards build crystalline --release --no-debug -Dpreview_mt --stats --progress --ignore-crystal-version
+          shards build crystalline --release --no-debug --stats --progress --ignore-crystal-version
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build the binary
         run: |
           export LLVM_CONFIG="$(brew --prefix llvm)/bin/llvm-config"
-          shards build crystalline --release --no-debug -Dpreview_mt --stats --progress --ignore-crystal-version
+          shards build crystalline --release --no-debug --stats --progress --ignore-crystal-version
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Building from source does take a long time._
 
 | Crystal   | Crystalline |
 | --------- | ----------- |
-| **1.21**  | **0.18**    |
+| **1.21**  | **0.19**    |
 | 1.20      | 0.18        |
 | 1.16      | 0.17        |
 | 1.15      | 0.16        |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Building from source does take a long time._
 
 | Crystal   | Crystalline |
 | --------- | ----------- |
-| **1.20**  | **0.18**    |
+| **1.21**  | **0.18**    |
+| 1.20      | 0.18        |
 | 1.16      | 0.17        |
 | 1.15      | 0.16        |
 | 1.14      | 0.15        |
@@ -135,8 +136,13 @@ Then:
 
 ```sh
 # Produces a binary at ./bin/crystalline
-shards build crystalline --release --no-debug --progress -Dpreview_mt
+shards build crystalline --release --no-debug --progress
 ```
+
+On Crystal 1.21+ the execution-contexts runtime is used by default and
+compilations run on a dedicated context, keeping the server responsive while
+building. On older versions, add `-Dpreview_mt` to build the legacy
+multithreaded runtime instead.
 
 #### Global install
 
@@ -145,7 +151,7 @@ git clone https://github.com/elbywan/crystalline
 cd crystalline
 shards install
 mkdir bin
-crystal build ./src/crystalline.cr  -o ./bin/crystalline --release --no-debug --progress -Dpreview_mt
+crystal build ./src/crystalline.cr  -o ./bin/crystalline --release --no-debug --progress
 ```
 
 #### Known Build Issues
@@ -181,7 +187,7 @@ declaration would solve the issue:
 # Prepend the command with this:
 env LLVM_CONFIG=/usr/local/opt/llvm/bin/llvm-config
 # For Example:
-env LLVM_CONFIG=/usr/local/opt/llvm/bin/llvm-config crystal build ./src/crystalline.cr  -o ./bin/crystalline --release --no-debug -Dpreview_mt
+env LLVM_CONFIG=/usr/local/opt/llvm/bin/llvm-config crystal build ./src/crystalline.cr  -o ./bin/crystalline --release --no-debug
 ```
 
 > Replace `env` by `export` on Debian and derived (Ubuntu, Mint, ...)
@@ -342,14 +348,18 @@ Each of these projects must contain the `shard.yml`, ideally with the entry poin
 
 ### Compilation flags
 
-To use specific compilation flags, you can add a `crystalline/flags` key in the `shard.yml` file:
+To use specific compilation flags, you can add a `crystalline/flags` key in the
+`shard.yml` file. They are passed to the compiler when type-checking the
+project:
 
 ```yml
 crystalline:
   flags:
-    - preview_mt
     - execution_context
 ```
+
+On Crystal 1.21+ the execution-contexts runtime is the default; `preview_mt`
+selects the legacy multithreaded runtime on older versions.
 
 ## Features
 
@@ -384,6 +394,13 @@ definition signature or the expanded macro.
 Fetch all the symbols in a given file, used in VSCode to populate the Outline
 view and the Breadcrumbs.
 
+#### Lightweight analysis
+
+Hover, completion and go-to definitions resolve from an incremental source
+index without waiting for the compiler — including on unsaved buffers —
+completion triggers while typing plain identifiers, and results are ranked
+closest-type-first. A background compile refines the results once it finishes.
+
 ## Limitations
 
 - Memory usage is high due to the boehm GC behaviour and the crystal compiler
@@ -391,10 +408,10 @@ view and the Breadcrumbs.
 
 - Due to Crystal having a wide type inference system (which is incredibly
   convenient and practical), compilation times can unfortunately be relatively
-  long for big projects and depending on the hardware. This means that the LSP
-  will be stuck waiting for the compiler to finish before being able to provide
-  a response. Crystalline tries to mitigate that by caching compilation outcome
-  when possible.
+  long for big projects and depending on the hardware. Crystalline mitigates
+  this by answering hover, completion and go-to requests immediately from a
+  lightweight source index while the full compile runs in the background, and
+  by caching compilation outcome when possible.
 
 - Methods that are not called anywhere will not be analyzed, as this is how the
   Crystal compiler works.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystalline
-version: 0.18.0
+version: 0.19.0
 
 authors:
   - Julien Elbaz <elbywan@hotmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -23,8 +23,4 @@ development_dependencies:
 
 crystal: ">= 1.20.0, < 2.0.0"
 
-crystalline:
-  flags:
-    - preview_mt
-
 license: MIT

--- a/spec/broken_source_fixer_spec.cr
+++ b/spec/broken_source_fixer_spec.cr
@@ -1,5 +1,27 @@
 require "spec"
+require "compiler/crystal/syntax"
 require "../src/crystalline/broken_source_fixer"
+
+# The real-source site tests read project files; specs run from the repo
+# root but resolve relative to this file to stay robust.
+SPEC_SRC_ROOT = File.expand_path("..", __DIR__)
+
+# The wave-15 sweep cuts a real source line at its last dot (the
+# in-progress-typing state) and requires the fixer to restore a parseable
+# program. Duplicated patterns use occurrence order (the sweep hit both
+# `LSP::CompletionItem.new(` sites).
+SITES = [
+  {"src/crystalline/lightweight/completion.cr", "LSP::CompletionItem.new(", 1, "CompletionItem cut"},
+  {"src/crystalline/lightweight/completion.cr", "text_edit: LSP::TextEdit.new(", 1, "nested TextEdit cut"},
+  {"src/crystalline/lightweight/completion.cr", "range: @context.completion_range(@line_number),", 1, "multi-level entering closers"},
+  {"src/crystalline/lightweight/completion.cr", "LSP::CompletionItem.new(", 2, "scoped type item cut"},
+  {"src/crystalline/lightweight/completion.cr", "text_edit: LSP::TextEdit.new(", 2, "nested TextEdit cut 2"},
+  {"src/crystalline/completion_context.cr", "spans << TokenSpan.new(", 1, "TokenSpan cut"},
+  {"src/crystalline/completion_context.cr", "tokens.each do |token|", 1, "do-block header cut"},
+  {"src/crystalline/workspace.cr", "start: LSP::Position.new(line: start_loc.line_number - 1, character: start_loc.column_number - 1),", 1, "three-level call cut"},
+  {"src/crystalline/controller.cr", "range: message.params.range,", 1, "array-in-blocks cut"},
+  {"src/crystalline/lightweight/index.cr", "record_info.methods << MethodInfo.new(", 1, "MethodInfo cut"},
+]
 
 def it_fixes(from, to, file = __FILE__, line = __LINE__)
   it(file: file, line: line) do
@@ -8,6 +30,39 @@ def it_fixes(from, to, file = __FILE__, line = __LINE__)
 end
 
 describe Crystalline::BrokenSourceFixer do
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    # a comment ending with a dot.
+    puts 1
+    CRYSTAL
+    # a comment ending with a dot.
+    puts 1
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    foo.
+    CRYSTAL
+    foo.placeholder
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    @documents_mutex.synchronize { @opened_documents[uri] = doc }
+    @
+    CRYSTAL
+    @documents_mutex.synchronize { @opened_documents[uri] = doc }
+    @placeholder
+    CRYSTAL
+
+  it "keeps one-line { } blocks intact when only a sigil needs fixing" do
+    source = <<-CRYSTAL
+      @documents_mutex.synchronize { @opened_documents[uri] = doc }
+      @
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    fixed.should eq("  @documents_mutex.synchronize { @opened_documents[uri] = doc }\n  @placeholder")
+    Crystal::Parser.parse(fixed)
+  end
+
   it_fixes <<-CRYSTAL, <<-CRYSTAL
     if foo
     CRYSTAL
@@ -493,4 +548,146 @@ describe Crystalline::BrokenSourceFixer do
     ensure
       puts 2; end
     CRYSTAL
+
+  # A blank line before a closing keyword is not a visual dedent: the real
+  # `end` closes the block, and a sibling block still needs its own end.
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      x = 1
+
+    end
+
+    def bar
+      y = 2
+    CRYSTAL
+    def foo
+      x = 1
+
+    end
+
+    def bar
+      y = 2; end
+    CRYSTAL
+
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+      if bar
+        1
+
+      else
+        2
+      end
+    CRYSTAL
+    def foo
+      if bar
+        1
+
+      else
+        2
+      end; end
+    CRYSTAL
+
+  # Comment-only lines must never be interpreted as keywords.
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+    # the end is near
+    x = 1
+    CRYSTAL
+    def foo
+    # the end is near
+    x = 1; end
+    CRYSTAL
+
+  # A word ending in "end" (e.g. `depend`) is not a closing keyword.
+  it_fixes <<-CRYSTAL, <<-CRYSTAL
+    def foo
+    depend = 1
+    CRYSTAL
+    def foo
+    depend = 1; end
+    CRYSTAL
+
+  # `case`/`when` and `macro` blocks must survive the balancing pass, and an
+  # `end` orphaned by deleting a block header is dropped without closing its
+  # opener.
+  it "balances case and macro blocks and drops orphaned ends" do
+    source = <<-CRYSTAL
+      class Foo
+        def severity_name(severity : Severity) : String
+          case severity
+          when Severity::Info
+            "info"
+          end
+        end
+
+        macro define_handler(name)
+          def {{name.id}}
+            {{block.body}}
+          end
+        end
+
+        def collect_ids : Array(Int32)
+          ids = [] of Int32
+          @events.
+          ids << key unless key == 0
+          end
+          ids
+        end
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    Crystal::Parser.parse(fixed)
+    fixed.should_not contain("end\n          end")
+    fixed.should_not contain("ids << key unless key == 0\n          end")
+  end
+
+  # The wave-15 sweep cuts a real source line at its last dot (the
+  # in-progress-typing state) and requires the fixer to restore a parseable
+  # program. Sites are located by content so line shifts fail loudly instead
+  # of silently testing the wrong line; duplicated patterns use occurrence
+  # order (the sweep hit both `LSP::CompletionItem.new(` sites).
+  describe "real cut sites from the lightweight sweep" do
+    SITES.each do |(rel, pattern, occurrence, label)|
+      it "repairs the #{label} (#{rel})" do
+        lines = File.read_lines(File.join(SPEC_SRC_ROOT, rel))
+        count = 0
+        li = nil
+        lines.each_with_index do |l, i|
+          if l.includes?(pattern)
+            count += 1
+            li = i if count == occurrence
+          end
+        end
+        raise "site not found: #{pattern} ##{occurrence} in #{rel}" unless li
+        line = lines[li.not_nil!]
+        last_dot = line.rindex('.')
+        raise "bad site: #{rel} line #{li.not_nil! + 1}" unless last_dot && last_dot > 0 && last_dot < line.size - 1
+
+        lines[li.not_nil!] = line[0, last_dot + 1]
+        fixed = Crystalline::BrokenSourceFixer.fix(lines.join("\n"))
+        Crystal::Parser.parse(fixed)
+      end
+    end
+
+    it "passes valid sources through unchanged" do
+      %w[src/crystalline/workspace.cr src/crystalline/controller.cr src/crystalline/lightweight/inference.cr].each do |rel|
+        source = File.read(File.join(SPEC_SRC_ROOT, rel))
+        Crystalline::BrokenSourceFixer.fix(source).rstrip('\n').should eq(source.rstrip('\n'))
+      end
+    end
+
+    it "leaves the fixer's own multi-line regex literal unparseable (known remaining)" do
+      lines = File.read_lines(File.join(SPEC_SRC_ROOT, "src/crystalline/broken_source_fixer.cr"))
+      li = lines.index { |l| l.lstrip.starts_with?("if line.starts_with?") }
+      raise "self-regex site not found" unless li
+      line = lines[li.not_nil!]
+      last_dot = line.rindex('.')
+      raise "bad site" unless last_dot
+
+      lines[li.not_nil!] = line[0, last_dot + 1]
+      fixed = Crystalline::BrokenSourceFixer.fix(lines.join("\n"))
+      expect_raises(Crystal::SyntaxException) { Crystal::Parser.parse(fixed) }
+    end
+  end
 end

--- a/spec/completion_context_spec.cr
+++ b/spec/completion_context_spec.cr
@@ -65,7 +65,6 @@ describe Crystalline::CompletionContext do
     context.analysis_column.should eq(3)
     context.replace_start.should eq(4)
     context.replace_end.should eq(6)
-    context.rewritten_line.should eq("foo")
   end
 
   it "detects namespace completion from a path fragment" do
@@ -77,19 +76,38 @@ describe Crystalline::CompletionContext do
     context.analysis_column.should eq(3)
     context.replace_start.should eq(5)
     context.replace_end.should eq(7)
-    context.rewritten_line.should eq("Foo")
   end
 
-  it "detects ivar completion and excludes the sigil from replacement" do
+  it "detects ivar completion and includes the sigil in replacement" do
     context = Crystalline::CompletionContext.detect("@iv", 3, nil)
     context.should_not be_nil
     context = context.not_nil!
 
     context.trigger_character.should eq("@")
     context.analysis_column.should eq(0)
-    context.replace_start.should eq(1)
+    context.replace_start.should eq(0)
     context.replace_end.should eq(3)
-    context.rewritten_line.should eq("")
+  end
+
+  it "detects a lone @ as ivar completion" do
+    context = Crystalline::CompletionContext.detect("    @", 5, nil)
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq("@")
+    context.analysis_column.should eq(4)
+    context.replace_start.should eq(4)
+    context.replace_end.should eq(5)
+  end
+
+  it "does not let a placeholder after the sigil widen the replace range" do
+    context = Crystalline::CompletionContext.detect("    @placeholder", 5, nil)
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq("@")
+    context.replace_start.should eq(4)
+    context.replace_end.should eq(5)
   end
 
   it "handles explicit dot triggers" do
@@ -101,6 +119,51 @@ describe Crystalline::CompletionContext do
     context.analysis_column.should eq(3)
     context.replace_start.should eq(4)
     context.replace_end.should eq(4)
-    context.rewritten_line.should eq("foo")
+  end
+
+  it "infers the dot trigger when the reported trigger is an identifier character" do
+    # Clients register the identifier characters as completion triggers:
+    # typing `foo.a` arrives with trigger "a", but the receiver analysis
+    # must still end at the dot or the method list is replaced by context
+    # items.
+    context = Crystalline::CompletionContext.detect("foo.a", 5, "a")
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq(".")
+    context.analysis_column.should eq(3)
+    context.replace_start.should eq(4)
+    context.replace_end.should eq(5)
+  end
+
+  it "infers the :: trigger from an identifier-character trigger" do
+    context = Crystalline::CompletionContext.detect("Foo::B", 6, "B")
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq(":")
+    context.analysis_column.should eq(3)
+    context.replace_start.should eq(5)
+    context.replace_end.should eq(6)
+  end
+
+  it "infers the sigil trigger from an identifier-character trigger" do
+    context = Crystalline::CompletionContext.detect("@docu", 5, "u")
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq("@")
+    context.analysis_column.should eq(0)
+    context.replace_start.should eq(0)
+    context.replace_end.should eq(5)
+  end
+
+  it "keeps plain-word completions in context mode for identifier triggers" do
+    context = Crystalline::CompletionContext.detect("  greeter", 9, "r")
+    context.should_not be_nil
+    context = context.not_nil!
+
+    context.trigger_character.should eq("r")
+    context.analysis_column.should eq(9)
   end
 end

--- a/spec/environment_config_spec.cr
+++ b/spec/environment_config_spec.cr
@@ -1,0 +1,45 @@
+require "spec"
+require "../src/crystalline/main"
+
+describe Crystalline::EnvironmentConfig do
+  describe ".unquote_env_value" do
+    it "passes unquoted values through" do
+      Crystalline::EnvironmentConfig.unquote_env_value("/usr/lib/crystal").should eq("/usr/lib/crystal")
+    end
+
+    it "strips simple single-quoted values" do
+      Crystalline::EnvironmentConfig.unquote_env_value("'-Dfoo'").should eq("-Dfoo")
+    end
+
+    it "decodes empty quoted values" do
+      Crystalline::EnvironmentConfig.unquote_env_value("''").should eq("")
+    end
+
+    it "decodes single quotes escaped as \"'\"" do
+      Crystalline::EnvironmentConfig.unquote_env_value(%q{'a'"'"'b'}).should eq("a'b")
+    end
+
+    it "keeps double quotes inside single-quoted values" do
+      Crystalline::EnvironmentConfig.unquote_env_value(%q{'a"b'}).should eq("a\"b")
+    end
+
+    it "leaves malformed quoting untouched" do
+      Crystalline::EnvironmentConfig.unquote_env_value("'unterminated").should eq("'unterminated")
+      Crystalline::EnvironmentConfig.unquote_env_value("unopened'").should eq("unopened'")
+    end
+  end
+
+  describe ".parse_crystal_env_output" do
+    it "keeps '=' characters inside env values" do
+      # A value containing '=' (e.g. `CRYSTAL_OPTS='-Dfoo=1'`) must not be
+      # truncated at the second '=': a truncated value would keep its
+      # opening quote, and the next `crystal env` run would re-escape it,
+      # growing the variable until subprocess spawning fails with E2BIG.
+      result = Crystalline::EnvironmentConfig.parse_crystal_env_output(
+        "CRYSTAL_PATH='/usr/lib/crystal'\nCRYSTAL_OPTS='-Dfoo=1'\n"
+      )
+      result["CRYSTAL_OPTS"].should eq("-Dfoo=1")
+      result["CRYSTAL_PATH"].should eq("/usr/lib/crystal")
+    end
+  end
+end

--- a/spec/lightweight/completion_spec.cr
+++ b/spec/lightweight/completion_spec.cr
@@ -1,0 +1,1265 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/completion_context"
+require "../../src/crystalline/lightweight/completion"
+
+private def build_lightweight_query(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-completion-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Query.new(
+      Crystalline::Lightweight::Index.from_program(result.program),
+      secondary: prelude_index,
+    )
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+private def prelude_index : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::PreludeIndex.ensure_loaded
+  until (index = Crystalline::Lightweight::PreludeIndex.get)
+    sleep 50.milliseconds
+  end
+  index
+end
+
+private def build_syntax_query(source : String)
+  index = Crystalline::Lightweight::Index.from_source(source)
+  raise "expected syntax index" unless index
+  Crystalline::Lightweight::Query.new(index)
+end
+
+describe Crystalline::Lightweight::Completion do
+  it "completes instance methods from inferred local receiver types" do
+    source = <<-CRYSTAL
+      class Greeter
+        def greet(name : String) : String
+          name
+        end
+
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter.gr
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("greeter.gr") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    items.map(&.insert_text).compact.should contain("greet")
+    items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes through a record getter whose return type is a bare name" do
+    # Mirrors `result.node.ac` where `result : Crystal::Compiler::Result`
+    # and `#node : ASTNode` is recorded as the bare name: the chain must
+    # resolve `ASTNode` against the method owner's namespace.
+    source = <<-CRYSTAL
+      module Compiler
+        class ASTNode
+          def accept(visitor)
+          end
+
+          def at : Location?
+            nil
+          end
+        end
+
+        record Result, program : Program, node : ASTNode
+
+        def demo(result : Result)
+          result.node.ac
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("result.node.ac") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    items.map(&.insert_text).compact.should contain("accept")
+    items.map(&.insert_text).compact.should contain("at")
+  end
+
+  it "completes bare identifiers with the current type's methods" do
+    # A bare `proc` inside a def is a self-call: the enclosing type's own
+    # methods and the methods of its included modules must be offered.
+    source = <<-CRYSTAL
+      module Mixin
+        def process_result(result)
+        end
+      end
+
+      class Visitor
+        include Mixin
+
+        def process_type(type)
+        end
+
+        def demo
+          proc
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "proc" }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    names = items.map(&.insert_text).compact
+    names.should contain("process_type")
+    names.should contain("process_result")
+  end
+
+  it "completes ivar receivers whose types carry unions" do
+    # `getter root_uri : URI?` seeds `@root_uri` with the raw union:
+    # receiver lookups must expand it before checking type knowledge.
+    source = <<-CRYSTAL
+      class URI
+        def path : String
+          ""
+        end
+
+        def to_s : String
+          ""
+        end
+      end
+
+      class Holder
+        getter root_uri : URI?
+        getter projects = [] of Project
+
+        def demo
+          @root_uri.pa
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("@root_uri.") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    names = items.map(&.insert_text).compact
+    names.should contain("path")
+    names.should contain("to_s")
+  end
+
+  it "completes class receivers through the synthesized new method" do
+    source = <<-CRYSTAL
+      class Greeter
+        def initialize(name : String)
+        end
+
+        def self.build : Greeter
+          new("x")
+        end
+      end
+
+      def demo
+        Greeter.bui
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Greeter.bui") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    names = items.map(&.insert_text).compact
+    names.should contain("new")
+    names.should contain("build")
+  end
+
+  it "completes module receivers with the module's methods" do
+    # A module's instance methods are callable on the module itself
+    # (`extend self`): `Helpers.` must offer them.
+    source = <<-CRYSTAL
+      module Helpers
+        extend self
+
+        def greet(name : String) : String
+          name
+        end
+
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        Helpers.gr
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Helpers.gr") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    names = items.map(&.insert_text).compact
+    names.should contain("greet")
+    names.should contain("shout")
+  end
+
+  it "completes class methods from constant receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def self.build(name : String) : Greeter
+          new
+        end
+      end
+
+      def demo
+        Greeter.bu
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Greeter.bu") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    items.map(&.insert_text).compact.should contain("build")
+  end
+
+  it "completes chained receivers using explicit return types" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo
+        factory = Factory.new
+        factory.build.sh
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("factory.build.sh") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes self and instance variable receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Wrapper
+        def initialize
+          @greeter = Greeter.new
+        end
+
+        def hello : String
+          "hi"
+        end
+
+        def demo
+          self.he
+          @greeter.sh
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    self_line_number = lines.index! { |item| item.includes?("self.he") }
+    self_context = Crystalline::CompletionContext.detect(lines[self_line_number], lines[self_line_number].size - 1, nil)
+    self_context.should_not be_nil
+
+    self_items = Crystalline::Lightweight::Completion.complete(
+      source,
+      self_line_number,
+      self_context.not_nil!,
+      query,
+    )
+
+    self_items.should_not be_nil
+    self_items.not_nil!.map(&.insert_text).compact.should contain("hello")
+
+    ivar_line_number = lines.index! { |item| item.includes?("@greeter.sh") }
+    ivar_context = Crystalline::CompletionContext.detect(lines[ivar_line_number], lines[ivar_line_number].size - 1, nil)
+    ivar_context.should_not be_nil
+
+    ivar_items = Crystalline::Lightweight::Completion.complete(
+      source,
+      ivar_line_number,
+      ivar_context.not_nil!,
+      query,
+    )
+
+    ivar_items.should_not be_nil
+    ivar_items.not_nil!.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes locals, top-level methods, self, instance variables, and types without dot triggers" do
+    source = <<-CRYSTAL
+      class Greeter
+      end
+
+      def top_level_name : String
+        "name"
+      end
+
+      class Wrapper
+        def initialize
+          @greeter = Greeter.new
+        end
+
+        def demo(local_name : String)
+          local_copy = local_name
+          loc
+          top_lev
+          sel
+          @gre
+          Gre
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    local_line_number = lines.index! { |item| item.strip == "loc" }
+    local_context = Crystalline::CompletionContext.detect(lines[local_line_number], lines[local_line_number].index("loc").not_nil! + 3, nil)
+    local_items = Crystalline::Lightweight::Completion.complete(source, local_line_number, local_context.not_nil!, query).not_nil!
+    local_items.map(&.insert_text).compact.should contain("local_copy")
+
+    method_line_number = lines.index! { |item| item.strip == "top_lev" }
+    method_context = Crystalline::CompletionContext.detect(lines[method_line_number], lines[method_line_number].index("top_lev").not_nil! + 7, nil)
+    method_items = Crystalline::Lightweight::Completion.complete(source, method_line_number, method_context.not_nil!, query).not_nil!
+    method_items.map(&.insert_text).compact.should contain("top_level_name")
+
+    self_line_number = lines.index! { |item| item.strip == "sel" }
+    self_context = Crystalline::CompletionContext.detect(lines[self_line_number], lines[self_line_number].index("sel").not_nil! + 3, nil)
+    self_items = Crystalline::Lightweight::Completion.complete(source, self_line_number, self_context.not_nil!, query).not_nil!
+    self_items.map(&.insert_text).compact.should contain("self")
+
+    ivar_line_number = lines.index! { |item| item.strip == "@gre" }
+    ivar_context = Crystalline::CompletionContext.detect(lines[ivar_line_number], lines[ivar_line_number].index("@gre").not_nil! + 4, nil)
+    ivar_items = Crystalline::Lightweight::Completion.complete(source, ivar_line_number, ivar_context.not_nil!, query).not_nil!
+    ivar_items.map(&.insert_text).compact.should contain("@greeter")
+
+    type_line_number = lines.index! { |item| item.strip == "Gre" }
+    type_context = Crystalline::CompletionContext.detect(lines[type_line_number], lines[type_line_number].index("Gre").not_nil! + 3, nil)
+    type_items = Crystalline::Lightweight::Completion.complete(source, type_line_number, type_context.not_nil!, query).not_nil!
+    type_items.map(&.insert_text).compact.should contain("Greeter")
+  end
+
+  it "completes narrowed receivers inside conditional branches" do
+    isa_source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil | Int32)
+        if candidate.is_a?(Greeter)
+          candidate.sh
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(isa_source)
+    isa_lines = isa_source.lines(chomp: false)
+    isa_line_number = isa_lines.index! { |item| item.includes?("candidate.sh") }
+    isa_context = Crystalline::CompletionContext.detect(isa_lines[isa_line_number], isa_lines[isa_line_number].size - 1, nil)
+    isa_items = Crystalline::Lightweight::Completion.complete(isa_source, isa_line_number, isa_context.not_nil!, query).not_nil!
+    isa_items.map(&.insert_text).compact.should contain("shout")
+
+    truthy_source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil)
+        if candidate
+          candidate.sh
+        end
+      end
+    CRYSTAL
+
+    truthy_query = build_lightweight_query(truthy_source)
+    truthy_lines = truthy_source.lines(chomp: false)
+    truthy_line_number = truthy_lines.index! { |item| item.includes?("candidate.sh") }
+    truthy_context = Crystalline::CompletionContext.detect(truthy_lines[truthy_line_number], truthy_lines[truthy_line_number].size - 1, nil)
+    truthy_items = Crystalline::Lightweight::Completion.complete(truthy_source, truthy_line_number, truthy_context.not_nil!, truthy_query).not_nil!
+    truthy_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes receivers inferred from logical or fallbacks" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil)
+        resolved = candidate || Greeter.new
+        resolved.sh
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("resolved.sh") }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query).not_nil!
+    items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes common helper and container receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil)
+        items = [Greeter.new]
+        items.first.sh
+        candidate.not_nil!.sh
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    first_line_number = lines.index! { |item| item.includes?("items.first.sh") }
+    first_context = Crystalline::CompletionContext.detect(lines[first_line_number], lines[first_line_number].size - 1, nil)
+    first_items = Crystalline::Lightweight::Completion.complete(source, first_line_number, first_context.not_nil!, query).not_nil!
+    first_items.map(&.insert_text).compact.should contain("shout")
+
+    not_nil_line_number = lines.index! { |item| item.includes?("candidate.not_nil!.sh") }
+    not_nil_context = Crystalline::CompletionContext.detect(lines[not_nil_line_number], lines[not_nil_line_number].size - 1, nil)
+    not_nil_items = Crystalline::Lightweight::Completion.complete(source, not_nil_line_number, not_nil_context.not_nil!, query).not_nil!
+    not_nil_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes methods in standalone syntax-only files" do
+    source = <<-CRYSTAL
+      class Clazz
+        def method1(num : Int32)
+          2
+        end
+      end
+
+      puts Clazz.new.method
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Clazz.new.method") }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query).not_nil!
+    items.map(&.insert_text).compact.should contain("method1")
+  end
+
+  it "completes block arguments for iterator helpers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        items = [Greeter.new]
+        items.each_with_index do |item, index|
+          item.sh
+          index.to_
+        end
+
+        Greeter.new.tap do |value|
+          value.sh
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    item_line_number = lines.index! { |item| item.includes?("item.sh") }
+    item_context = Crystalline::CompletionContext.detect(lines[item_line_number], lines[item_line_number].size - 1, nil)
+    item_items = Crystalline::Lightweight::Completion.complete(source, item_line_number, item_context.not_nil!, query).not_nil!
+    item_items.map(&.insert_text).compact.should contain("shout")
+
+    index_line_number = lines.index! { |item| item.includes?("index.to_") }
+    index_context = Crystalline::CompletionContext.detect(lines[index_line_number], lines[index_line_number].size - 1, nil)
+    index_items = Crystalline::Lightweight::Completion.complete(source, index_line_number, index_context.not_nil!, query).not_nil!
+    index_items.map(&.insert_text).compact.should contain("to_i")
+
+    value_line_number = lines.index! { |item| item.includes?("value.sh") }
+    value_context = Crystalline::CompletionContext.detect(lines[value_line_number], lines[value_line_number].size - 1, nil)
+    value_items = Crystalline::Lightweight::Completion.complete(source, value_line_number, value_context.not_nil!, query).not_nil!
+    value_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes tuple and named tuple derived receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        pair = {Greeter.new, 1}
+        pair.first.sh
+
+        named = {greeter: Greeter.new}
+        named.greeter.sh
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    tuple_line_number = lines.index! { |item| item.includes?("pair.first.sh") }
+    tuple_context = Crystalline::CompletionContext.detect(lines[tuple_line_number], lines[tuple_line_number].size - 1, nil)
+    tuple_items = Crystalline::Lightweight::Completion.complete(source, tuple_line_number, tuple_context.not_nil!, query).not_nil!
+    tuple_items.map(&.insert_text).compact.should contain("shout")
+
+    named_line_number = lines.index! { |item| item.includes?("named.greeter.sh") }
+    named_context = Crystalline::CompletionContext.detect(lines[named_line_number], lines[named_line_number].size - 1, nil)
+    named_items = Crystalline::Lightweight::Completion.complete(source, named_line_number, named_context.not_nil!, query).not_nil!
+    named_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes helper methods that preserve or refine collection receiver shapes" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(items : Array(Greeter), candidate : Greeter | Nil)
+        items.select.first?.not_nil!.sh
+        items.find.not_nil!.sh
+        candidate.try &.sh
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    select_line_number = lines.index! { |item| item.includes?("items.select.first?.not_nil!.sh") }
+    select_context = Crystalline::CompletionContext.detect(lines[select_line_number], lines[select_line_number].size - 1, nil)
+    select_items = Crystalline::Lightweight::Completion.complete(source, select_line_number, select_context.not_nil!, query).not_nil!
+    select_items.map(&.insert_text).compact.should contain("shout")
+
+    find_line_number = lines.index! { |item| item.includes?("items.find.not_nil!.sh") }
+    find_context = Crystalline::CompletionContext.detect(lines[find_line_number], lines[find_line_number].size - 1, nil)
+    find_items = Crystalline::Lightweight::Completion.complete(source, find_line_number, find_context.not_nil!, query).not_nil!
+    find_items.map(&.insert_text).compact.should contain("shout")
+
+    try_line_number = lines.index! { |item| item.includes?("candidate.try &.sh") }
+    try_context = Crystalline::CompletionContext.detect(lines[try_line_number], lines[try_line_number].size - 1, nil)
+    try_items = Crystalline::Lightweight::Completion.complete(source, try_line_number, try_context.not_nil!, query).not_nil!
+    try_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes richer hash and reducer helper flows" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        def word : String | Nil
+          "hi"
+        end
+      end
+
+      def demo
+        lookup = {"primary" => Greeter.new}
+        lookup.each do |key, value|
+          key.up
+          value.sh
+        end
+
+        numbers = [1, 2]
+        numbers.reduce do |memo, item|
+          memo.to_
+          item.to_
+        end
+
+        collected = lookup.values.each_with_object([] of String) do |collected_item, collected_memo|
+          collected_item.sh
+          collected_memo.fi
+        end
+        collected.first.up
+
+        mapped = lookup.values.map { |item| item.word.not_nil! }
+        mapped.first.up
+
+        flat_mapped = lookup.values.flat_map { |item| [item.word.not_nil!] }
+        flat_mapped.first.up
+
+        compacted = lookup.values.compact_map { |item| item.word }
+        compacted.first.up
+
+        indexed = lookup.values.index_by { |item| item.word.not_nil! }
+        indexed["primary"].sh
+
+        grouped = lookup.values.group_by { |item| item.word.not_nil! }
+        grouped["primary"].first.sh
+
+        found_value = lookup.values.find_value { |item| item.word }
+        found_value.not_nil!.up
+
+        resolved = lookup.values.first?.try { |item| item.word.not_nil! }
+        resolved.not_nil!.up
+
+        lookup.dig.sh
+
+        items = [Greeter.new]
+        items.find!.sh
+        items.comp
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+
+    key_line_number = lines.index! { |item| item.includes?("key.up") }
+    key_context = Crystalline::CompletionContext.detect(lines[key_line_number], lines[key_line_number].size - 1, nil)
+    key_items = Crystalline::Lightweight::Completion.complete(source, key_line_number, key_context.not_nil!, query).not_nil!
+    key_items.map(&.insert_text).compact.should contain("upcase")
+
+    value_line_number = lines.index! { |item| item.includes?("value.sh") }
+    value_context = Crystalline::CompletionContext.detect(lines[value_line_number], lines[value_line_number].size - 1, nil)
+    value_items = Crystalline::Lightweight::Completion.complete(source, value_line_number, value_context.not_nil!, query).not_nil!
+    value_items.map(&.insert_text).compact.should contain("shout")
+
+    memo_line_number = lines.index! { |item| item.includes?("memo.to_") }
+    memo_context = Crystalline::CompletionContext.detect(lines[memo_line_number], lines[memo_line_number].size - 1, nil)
+    memo_items = Crystalline::Lightweight::Completion.complete(source, memo_line_number, memo_context.not_nil!, query).not_nil!
+    memo_items.map(&.insert_text).compact.should contain("to_i")
+
+    item_line_number = lines.index! { |item| item.includes?("item.to_") }
+    item_context = Crystalline::CompletionContext.detect(lines[item_line_number], lines[item_line_number].size - 1, nil)
+    item_items = Crystalline::Lightweight::Completion.complete(source, item_line_number, item_context.not_nil!, query).not_nil!
+    item_items.map(&.insert_text).compact.should contain("to_i")
+
+    each_with_object_item_line_number = lines.index! { |item| item.includes?("collected_item.sh") }
+    each_with_object_item_context = Crystalline::CompletionContext.detect(lines[each_with_object_item_line_number], lines[each_with_object_item_line_number].size - 1, nil)
+    each_with_object_item_items = Crystalline::Lightweight::Completion.complete(source, each_with_object_item_line_number, each_with_object_item_context.not_nil!, query).not_nil!
+    each_with_object_item_items.map(&.insert_text).compact.should contain("shout")
+
+    each_with_object_memo_line_number = lines.index! { |item| item.includes?("collected_memo.fi") }
+    each_with_object_memo_context = Crystalline::CompletionContext.detect(lines[each_with_object_memo_line_number], lines[each_with_object_memo_line_number].size - 1, nil)
+    each_with_object_memo_items = Crystalline::Lightweight::Completion.complete(source, each_with_object_memo_line_number, each_with_object_memo_context.not_nil!, query).not_nil!
+    each_with_object_memo_items.map(&.insert_text).compact.should contain("first?")
+
+    collected_line_number = lines.index! { |item| item.includes?("collected.first.up") }
+    collected_context = Crystalline::CompletionContext.detect(lines[collected_line_number], lines[collected_line_number].size - 1, nil)
+    collected_items = Crystalline::Lightweight::Completion.complete(source, collected_line_number, collected_context.not_nil!, query).not_nil!
+    collected_items.map(&.insert_text).compact.should contain("upcase")
+
+    mapped_line_number = lines.index! { |item| item.includes?("mapped.first.up") }
+    mapped_context = Crystalline::CompletionContext.detect(lines[mapped_line_number], lines[mapped_line_number].size - 1, nil)
+    mapped_items = Crystalline::Lightweight::Completion.complete(source, mapped_line_number, mapped_context.not_nil!, query).not_nil!
+    mapped_items.map(&.insert_text).compact.should contain("upcase")
+
+    flat_mapped_line_number = lines.index! { |item| item.includes?("flat_mapped.first.up") }
+    flat_mapped_context = Crystalline::CompletionContext.detect(lines[flat_mapped_line_number], lines[flat_mapped_line_number].size - 1, nil)
+    flat_mapped_items = Crystalline::Lightweight::Completion.complete(source, flat_mapped_line_number, flat_mapped_context.not_nil!, query).not_nil!
+    flat_mapped_items.map(&.insert_text).compact.should contain("upcase")
+
+    compacted_line_number = lines.index! { |item| item.includes?("compacted.first.up") }
+    compacted_context = Crystalline::CompletionContext.detect(lines[compacted_line_number], lines[compacted_line_number].size - 1, nil)
+    compacted_items = Crystalline::Lightweight::Completion.complete(source, compacted_line_number, compacted_context.not_nil!, query).not_nil!
+    compacted_items.map(&.insert_text).compact.should contain("upcase")
+
+    indexed_line_number = lines.index! { |item| item.includes?("indexed[\"primary\"].sh") }
+    indexed_context = Crystalline::CompletionContext.detect(lines[indexed_line_number], lines[indexed_line_number].size - 1, nil)
+    indexed_items = Crystalline::Lightweight::Completion.complete(source, indexed_line_number, indexed_context.not_nil!, query).not_nil!
+    indexed_items.map(&.insert_text).compact.should contain("shout")
+
+    grouped_line_number = lines.index! { |item| item.includes?("grouped[\"primary\"].first.sh") }
+    grouped_context = Crystalline::CompletionContext.detect(lines[grouped_line_number], lines[grouped_line_number].size - 1, nil)
+    grouped_items = Crystalline::Lightweight::Completion.complete(source, grouped_line_number, grouped_context.not_nil!, query).not_nil!
+    grouped_items.map(&.insert_text).compact.should contain("shout")
+
+    found_value_line_number = lines.index! { |item| item.includes?("found_value.not_nil!.up") }
+    found_value_context = Crystalline::CompletionContext.detect(lines[found_value_line_number], lines[found_value_line_number].size - 1, nil)
+    found_value_items = Crystalline::Lightweight::Completion.complete(source, found_value_line_number, found_value_context.not_nil!, query).not_nil!
+    found_value_items.map(&.insert_text).compact.should contain("upcase")
+
+    resolved_line_number = lines.index! { |item| item.includes?("resolved.not_nil!.up") }
+    resolved_context = Crystalline::CompletionContext.detect(lines[resolved_line_number], lines[resolved_line_number].size - 1, nil)
+    resolved_items = Crystalline::Lightweight::Completion.complete(source, resolved_line_number, resolved_context.not_nil!, query).not_nil!
+    resolved_items.map(&.insert_text).compact.should contain("upcase")
+
+    dig_line_number = lines.index! { |item| item.includes?("lookup.dig.sh") }
+    dig_context = Crystalline::CompletionContext.detect(lines[dig_line_number], lines[dig_line_number].size - 1, nil)
+    dig_items = Crystalline::Lightweight::Completion.complete(source, dig_line_number, dig_context.not_nil!, query).not_nil!
+    dig_items.map(&.insert_text).compact.should contain("shout")
+
+    find_bang_line_number = lines.index! { |item| item.includes?("items.find!.sh") }
+    find_bang_context = Crystalline::CompletionContext.detect(lines[find_bang_line_number], lines[find_bang_line_number].size - 1, nil)
+    find_bang_items = Crystalline::Lightweight::Completion.complete(source, find_bang_line_number, find_bang_context.not_nil!, query).not_nil!
+    find_bang_items.map(&.insert_text).compact.should contain("shout")
+
+    inherited_line_number = lines.index! { |item| item.includes?("items.comp") }
+    inherited_context = Crystalline::CompletionContext.detect(lines[inherited_line_number], lines[inherited_line_number].size - 1, nil)
+    inherited_items = Crystalline::Lightweight::Completion.complete(source, inherited_line_number, inherited_context.not_nil!, query).not_nil!
+    inherited_items.map(&.insert_text).compact.should contain("compact_map")
+  end
+
+  it "scopes namespace completion to the receiver's nested types" do
+    source = <<-CRYSTAL
+      class Foo
+        class Inner; end
+      end
+      class Unrelated; end
+
+      def demo
+        Foo::In
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Foo::In") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    ).not_nil!
+
+    labels = items.map(&.label)
+    labels.should contain("Foo::Inner")
+    labels.should_not contain("Unrelated")
+
+    inner = items.find { |item| item.label == "Foo::Inner" }.not_nil!
+    inner.insert_text.should eq("Inner")
+  end
+
+  it "completes receivers from method calls with arguments" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build(name : String) : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo(factory : Factory)
+        Greeter.new("hi").sh
+        factory.build("hi").sh
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+
+    new_line_number = lines.index! { |item| item.strip == "Greeter.new(\"hi\").sh" }
+    new_context = Crystalline::CompletionContext.detect(lines[new_line_number], lines[new_line_number].size - 1, nil)
+    new_items = Crystalline::Lightweight::Completion.complete(source, new_line_number, new_context.not_nil!, query).not_nil!
+    new_items.map(&.insert_text).compact.should contain("shout")
+
+    build_line_number = lines.index! { |item| item.strip == "factory.build(\"hi\").sh" }
+    build_context = Crystalline::CompletionContext.detect(lines[build_line_number], lines[build_line_number].size - 1, nil)
+    build_items = Crystalline::Lightweight::Completion.complete(source, build_line_number, build_context.not_nil!, query).not_nil!
+    build_items.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "completes accessor macros and top-level locals from source" do
+    source = <<-CRYSTAL
+      class User
+        getter name : String
+      end
+
+      user = User.new
+      user.na
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+
+    accessor_line_number = lines.index! { |item| item.strip == "user.na" }
+    accessor_context = Crystalline::CompletionContext.detect(lines[accessor_line_number], lines[accessor_line_number].size - 1, nil)
+    accessor_items = Crystalline::Lightweight::Completion.complete(source, accessor_line_number, accessor_context.not_nil!, query).not_nil!
+    accessor_items.map(&.insert_text).compact.should contain("name")
+  end
+
+  it "completes ivar receivers from parsed source at the class body" do
+    source = <<-CRYSTAL
+      class Service
+        def ping : String
+          "pong"
+        end
+      end
+
+      class Controller
+        @service = Service.new
+
+        @service.
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    query = build_syntax_query(fixed)
+    # Locate the marker in the raw source: the fixer rewrites the line to
+    # `@service.placeholder` but keeps line positions intact.
+    line_number = source.lines.index! { |item| item.strip == "@service." }
+    fixed_lines = fixed.lines(chomp: false)
+    context = Crystalline::CompletionContext.detect(fixed_lines[line_number], fixed_lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(fixed, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("ping")
+  end
+
+  it "completes generic receivers against the secondary index" do
+    source = <<-CRYSTAL
+      class Controller
+        @pending : Set(String)
+
+        @pending.
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    primary = Crystalline::Lightweight::Index.from_source(fixed).not_nil!
+    secondary = Crystalline::Lightweight::Index.from_source("class Set(T)\n  def add(x : T) : Nil\n  end\nend\n").not_nil!
+    query = Crystalline::Lightweight::Query.new(primary, secondary: secondary)
+
+    line_number = source.lines.index! { |item| item.strip == "@pending." }
+    fixed_lines = fixed.lines(chomp: false)
+    context = Crystalline::CompletionContext.detect(fixed_lines[line_number], fixed_lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(fixed, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("add")
+  end
+
+  it "completes methods on a value typed as an alias" do
+    source = <<-CRYSTAL
+      class Greeter
+        def hello : String
+          "hi"
+        end
+      end
+
+      alias Greet = Greeter
+
+      def demo
+        greeter = Greet.new
+        greeter.he
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("greeter.he") }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("hello")
+  end
+
+  it "completes ivars from source when the buffer does not parse" do
+    source = <<-CRYSTAL
+      class Greeter
+        @pending : Int32
+
+        def demo
+          @p
+        end
+      end
+      x = "unclosed
+    CRYSTAL
+
+    # The query is built from the parsed state of the file; the buffer is
+    # the mid-edit version with an unclosed string that fails to parse.
+    query = build_syntax_query(source.sub(/\n[ \t]*x = "unclosed/, "\n"))
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "@p" }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size, "@").not_nil!
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context, query).not_nil!
+    items.map(&.insert_text).compact.should contain("@pending")
+  end
+
+  it "keeps the sigil in ivar completion items" do
+    source = <<-CRYSTAL
+      class Controller
+        @documents_lock = Mutex.new
+
+        def on_request
+          @documents_lock.synchronize do
+            @documents_
+          end
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "@documents_" }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    item = items.not_nil!.find { |i| i.filter_text == "@documents_lock" }
+    item.should_not be_nil
+    item = item.not_nil!
+    item.insert_text.should eq("@documents_lock")
+    text_edit = item.text_edit.not_nil!
+    text_edit.new_text.should eq("@documents_lock")
+    replaced = lines[line_number][text_edit.range.start.character...text_edit.range.end.character]
+    replaced.should eq("@documents_")
+  end
+
+  it "completes ivars after a lone @" do
+    source = <<-CRYSTAL
+      class Store
+        @documents_mutex = Mutex.new
+
+        def open(raw_uri : String)
+          @documents_mutex.synchronize { @opened_documents[raw_uri] = raw_uri }
+          @
+        end
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    query = build_syntax_query(fixed)
+    lines = fixed.lines(chomp: false)
+    line_number = source.lines.index! { |item| item.strip == "@" }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].index("@").not_nil! + 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(fixed, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    names = items.not_nil!.map(&.insert_text).compact
+    names.should contain("@documents_mutex")
+    names.should contain("@opened_documents")
+  end
+
+  it "completes locals assigned inside && conditions" do
+    source = <<-CRYSTAL
+      class Project
+        def entry_point? : Path?
+          nil
+        end
+      end
+
+      def demo(project : Project)
+        if project && (entry_point = project.entry_point?)
+          target = entry_point
+          target.
+        end
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    query = build_lightweight_query(fixed)
+    lines = fixed.lines(chomp: false)
+    line_number = source.lines.index! { |item| item.strip == "target." }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(fixed, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("dirname")
+  end
+
+  it "resolves constant receivers and class methods when inferring calls" do
+    source = <<-CRYSTAL
+      module Crystalline
+        class Project
+          def self.best_fit_for_file(projects, file_uri) : Project?
+            nil
+          end
+
+          def entry_point? : Path?
+            nil
+          end
+        end
+
+        class Workspace
+          def compile(server, file_uri)
+            project = Project.best_fit_for_file(@projects, file_uri)
+            if project && (entry_point = project.entry_point?)
+              target = entry_point
+              target.
+            end
+          end
+        end
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    query = build_lightweight_query(fixed)
+    lines = fixed.lines(chomp: false)
+    line_number = source.lines.index! { |item| item.strip == "target." }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(fixed, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("dirname")
+  end
+
+  it "keeps overloads with untyped args distinct from no-arg overloads" do
+    # `foo` and `foo(x)` (an untyped arg) must both complete: a dedup key
+    # built from restrictions alone joins both to the same empty signature
+    # and silently drops one overload.
+    source = <<-CRYSTAL
+      class Overloads
+        def foo : Int32
+          1
+        end
+
+        def foo(x) : String
+          "x"
+        end
+      end
+
+      def demo(overloads : Overloads)
+        overloads.fo
+      end
+    CRYSTAL
+
+    query = build_lightweight_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("overloads.fo") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    items = items.not_nil!
+    foos = items.select { |item| item.insert_text == "foo" }
+    foos.size.should eq(2)
+    foos.map(&.detail).compact.sort.should contain("Overloads#foo() : Int32")
+    foos.map(&.detail).compact.sort.should contain("Overloads#foo(x) : String")
+  end
+
+  it "completes ivar names after a bare sigil" do
+    source = <<-CRYSTAL
+      class Foo
+        @server : String
+        @cache = {} of String => Int32
+
+        def bar
+          @
+        end
+      end
+    CRYSTAL
+
+    # A lone sigil does not parse: the fixer appends the placeholder, and
+    # completion must still offer the ivars through the sigil trigger.
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    query = build_syntax_query(fixed)
+    lines = fixed.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "@placeholder" }
+    line = lines[line_number]
+    cursor = line.index('@').not_nil! + 1
+    context = Crystalline::CompletionContext.detect(line, cursor, "@")
+    context.should_not be_nil
+    # The analysis prefix ends at the sigil so the fragment stays empty.
+    context.not_nil!.analysis_column.should eq(cursor - 1)
+
+    items = Crystalline::Lightweight::Completion.complete(
+      fixed,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    names = items.not_nil!.map(&.insert_text).compact
+    names.should contain("@server")
+    names.should contain("@cache")
+  end
+
+  it "completes through a getter-with-initializer hash receiver" do
+    source = <<-CRYSTAL
+      class Store
+        getter cache = {} of String => Int32
+
+        def demo
+          cache.has_
+        end
+      end
+    CRYSTAL
+
+    index = Crystalline::Lightweight::Index.from_source(source)
+    raise "expected syntax index" unless index
+    query = Crystalline::Lightweight::Query.new(index, secondary: prelude_index)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("cache.has_") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(
+      source,
+      line_number,
+      context.not_nil!,
+      query,
+    )
+
+    items.should_not be_nil
+    # The getter's `of` clause names the shape: the receiver resolves to
+    # Hash(String, Int32), whose methods complete.
+    items.not_nil!.map(&.insert_text).compact.should contain("has_key?")
+  end
+end

--- a/spec/lightweight/definitions_spec.cr
+++ b/spec/lightweight/definitions_spec.cr
@@ -1,0 +1,256 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/definitions"
+
+private def build_definition_query(source : String)
+  index = Crystalline::Lightweight::Index.from_source(source)
+  raise "expected syntax index" unless index
+  Crystalline::Lightweight::Query.new(index)
+end
+
+private def build_program_definition_query(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-definitions-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Query.new(Crystalline::Lightweight::Index.from_program(result.program))
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe Crystalline::Lightweight::Definitions do
+  it "finds type definitions in standalone syntax-only files" do
+    source = <<-CRYSTAL
+      class Clazz
+      end
+
+      puts Clazz
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.includes?("puts Clazz") }
+    character = lines[line_number].rindex("Clazz").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(0)
+  end
+
+  it "finds method definitions for resolved receivers" do
+    source = <<-CRYSTAL
+      class Clazz
+        def method1(num : Int32)
+          2
+        end
+      end
+
+      puts Clazz.new.method1(num: 42)
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.includes?("Clazz.new.method1") }
+    character = lines[line_number].rindex("method1").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(1)
+  end
+
+  it "finds top-level method definitions" do
+    source = <<-CRYSTAL
+      def helper
+        1
+      end
+
+      helper
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.strip == "helper" }
+    character = lines[line_number].index("helper").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(0)
+  end
+
+  it "finds method definitions through richer helper chains" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil)
+        lookup = {"primary" => Greeter.new}
+        lookup.dig.shout
+
+        items = [Greeter.new]
+        items.find!.shout
+        items.compact_map
+        candidate.try &.shout
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_program_definition_query(source)
+    lines = source.lines(chomp: false)
+
+    dig_line_number = lines.index! { |line| line.strip == "lookup.dig.shout" }
+    dig_character = lines[dig_line_number].rindex("shout").not_nil! + 2
+    dig_locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, dig_line_number, dig_character, query)
+    dig_locations.should_not be_nil
+    dig_locations.not_nil!.first.range.start.line.should eq(1)
+
+    find_bang_line_number = lines.index! { |line| line.strip == "items.find!.shout" }
+    find_bang_character = lines[find_bang_line_number].rindex("shout").not_nil! + 2
+    find_bang_locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, find_bang_line_number, find_bang_character, query)
+    find_bang_locations.should_not be_nil
+    find_bang_locations.not_nil!.first.range.start.line.should eq(1)
+
+    inherited_line_number = lines.index! { |line| line.strip == "items.compact_map" }
+    inherited_character = lines[inherited_line_number].rindex("compact_map").not_nil! + 2
+    inherited_locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, inherited_line_number, inherited_character, query)
+    inherited_locations.should_not be_nil
+
+    try_line_number = lines.index! { |line| line.strip == "candidate.try &.shout" }
+    try_character = lines[try_line_number].rindex("shout").not_nil! + 2
+    try_locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, try_line_number, try_character, query)
+    try_locations.should_not be_nil
+    try_locations.not_nil!.first.range.start.line.should eq(1)
+  end
+
+  it "finds namespace-relative type definitions through the indexed location" do
+    source = <<-CRYSTAL
+      module Outer
+        class Inner
+        end
+
+        def demo
+          Inner.new
+        end
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.strip == "Inner.new" }
+    character = lines[line_number].rindex("Inner").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(1)
+  end
+
+  it "finds the declaration of an instance variable" do
+    source = <<-CRYSTAL
+      class Greeter
+        @server : String
+
+        def initialize(@server : String)
+        end
+
+        def demo
+          @server
+        end
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.strip == "@server" }
+    character = lines[line_number].rindex("@server").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(1)
+  end
+
+  it "jumps to the accessor macro for a bare getter self-call" do
+    source = <<-CRYSTAL
+      class Clazz
+        getter! workspace : Clazz
+
+        def demo
+          workspace
+        end
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.strip == "workspace" }
+    character = lines[line_number].index("workspace").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(1)
+  end
+
+  it "jumps to the first assignment for an undeclared ivar" do
+    source = <<-CRYSTAL
+      class Clazz
+        def initialize
+          @service = Service.new
+        end
+
+        def demo
+          @service
+        end
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.strip == "@service" }
+    character = lines[line_number].index("@service").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(2)
+  end
+
+  it "finds the shorthand ivar argument of initialize" do
+    source = <<-CRYSTAL
+      class Greeter
+        def initialize(@server : String)
+        end
+      end
+    CRYSTAL
+
+    file_uri = URI.parse("file:///tmp/standalone.cr")
+    query = build_definition_query(source)
+
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |line| line.includes?("initialize") }
+    character = lines[line_number].index("@server").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, file_uri, line_number, character, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.range.start.line.should eq(1)
+  end
+end

--- a/spec/lightweight/edge_cases_spec.cr
+++ b/spec/lightweight/edge_cases_spec.cr
@@ -1,0 +1,278 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/broken_source_fixer"
+require "../../src/crystalline/lightweight/query"
+require "../../src/crystalline/lightweight/definitions"
+require "../../src/crystalline/lightweight/completion"
+require "../../src/crystalline/completion_context"
+require "uri"
+
+private def fix_parses(source : String)
+  fixed = Crystalline::BrokenSourceFixer.fix(source)
+  Crystal::Parser.parse(fixed)
+  fixed
+end
+
+private def prelude_index : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::PreludeIndex.ensure_loaded
+  until (index = Crystalline::Lightweight::PreludeIndex.get)
+    sleep 50.milliseconds
+  end
+  index
+end
+
+private def syntax_query(source : String)
+  index = Crystalline::Lightweight::Index.from_source(source)
+  raise "expected syntax index" unless index
+  Crystalline::Lightweight::Query.new(index, secondary: prelude_index)
+end
+
+describe "lightweight edge cases" do
+  it "fixes a trailing dot inside a string interpolation" do
+    source = <<-CRYSTAL
+      def demo
+        "\#{foo.}"
+      end
+    CRYSTAL
+    fixed = fix_parses(source)
+    Crystal::Parser.parse(fixed)
+  end
+
+  it "fixes a trailing dot after a method call with nested closers" do
+    source = <<-CRYSTAL
+      class Demo
+        def run
+          factory.build("hi").
+        end
+      end
+    CRYSTAL
+    fixed = fix_parses(source)
+    fixed.should contain("placeholder")
+  end
+
+  it "keeps regex literals with parens intact when counting closers" do
+    source = <<-CRYSTAL
+      def demo
+        text = "a(b"
+        if text =~ /\\(/
+          puts "matched"
+        end
+        text.
+      end
+    CRYSTAL
+    fixed = fix_parses(source)
+    fixed.should contain("placeholder")
+  end
+
+  it "definitions resolve a method through a multi-line receiver" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter
+          .shout
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    uri = URI.parse("file:///tmp/demo.cr")
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == ".shout" }
+    character = lines[line_number].index("shout").not_nil! + 2
+
+    locations = Crystalline::Lightweight::Definitions.definitions(source, uri, line_number, character, query)
+    locations.should_not be_nil
+  end
+
+  it "completes a method through a multi-line receiver" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter
+          .shou
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?(".shou") }
+    line = lines[line_number]
+    cursor = line.index("shou").not_nil! + 4
+    context = Crystalline::CompletionContext.detect(line, cursor, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "definitions resolve a require to a real file" do
+    Crystalline::EnvironmentConfig.run
+    source = %(require "uri"\n)
+    query = syntax_query("class A\nend\n")
+    uri = URI.parse("file:///tmp/def_require.cr")
+    # Cursor on the string content.
+    locations = Crystalline::Lightweight::Definitions.definitions(source, uri, 0, 10, query)
+    locations.should_not be_nil
+    locations.not_nil!.first.uri.should contain("uri.cr")
+  end
+
+  it "resolves methods on stdlib receivers from the prelude" do
+    query = syntax_query("class A\nend\n")
+    names = query.methods_for("String").map(&.name)
+    names.should contain("upcase")
+    names.should contain("split")
+    names.should contain("size")
+  end
+
+  it "completes chained stdlib methods through locals" do
+    source = <<-CRYSTAL
+      def demo
+        names = %w(a b c)
+        names.map(&.upcase).fi
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?(".fi") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    names = items.not_nil!.map(&.insert_text).compact
+    names.should contain("first?")
+    names.should contain("find")
+  end
+
+  it "resolves hash receivers through [] lookups" do
+    source = <<-CRYSTAL
+      def demo
+        lookup = {} of String => Int32
+        lookup["x"].to_
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?(".to_") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    names = items.not_nil!.map(&.insert_text).compact
+    names.should contain("to_s")
+    names.should contain("to_i32")
+  end
+
+  it "resolves proc-typed locals through uninitialized declarations" do
+    source = <<-CRYSTAL
+      def demo
+        walker = uninitialized Proc(Int32, String)
+        walker.ca
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("walker.ca") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("call")
+  end
+
+  it "narrows case subjects by when-types" do
+    source = <<-CRYSTAL
+      class Node
+        def accept(v)
+        end
+      end
+
+      class DefNode < Node
+        def name : String
+          ""
+        end
+      end
+
+      def demo(node : Node)
+        case node
+        when DefNode
+          node.na
+        end
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "node.na" }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("name")
+  end
+
+  it "resolves range-slice receivers as the array, not the element" do
+    source = <<-CRYSTAL
+      def demo
+        arr = [1, 2, 3]
+        arr[1..].fi
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?(".fi") }
+    line = lines[line_number]
+    context = Crystalline::CompletionContext.detect(line, line.size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    # A slice returns the array: `first?`/`find` belong to the array, not
+    # to its Int32 element.
+    names = items.not_nil!.map(&.insert_text).compact
+    names.should contain("first?")
+    names.should contain("find")
+  end
+
+  it "resolves try-chains through nilable receivers" do
+    source = <<-CRYSTAL
+      class Config
+        def value : String?
+          "x"
+        end
+      end
+
+      def demo(config : Config)
+        config.value.try(&.upca)
+      end
+    CRYSTAL
+    query = syntax_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?(".upca") }
+    line = lines[line_number]
+    cursor = line.index(".upca").not_nil! + 4
+    context = Crystalline::CompletionContext.detect(line, cursor, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("upcase")
+  end
+end

--- a/spec/lightweight/hover_spec.cr
+++ b/spec/lightweight/hover_spec.cr
@@ -1,0 +1,711 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/hover"
+
+private def build_lightweight_hover_query(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-hover-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Query.new(Crystalline::Lightweight::Index.from_program(result.program), secondary: prelude_index)
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+private def hover_value(hover : LSP::Hover)
+  hover.contents.as(LSP::MarkupContent).value
+end
+
+private def build_syntax_hover_query(source : String)
+  index = Crystalline::Lightweight::Index.from_source(source)
+  raise "expected syntax index" unless index
+  Crystalline::Lightweight::Query.new(index)
+end
+
+private def prelude_index : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::PreludeIndex.ensure_loaded
+  until (index = Crystalline::Lightweight::PreludeIndex.get)
+    sleep 50.milliseconds
+  end
+  index
+end
+
+describe Crystalline::Lightweight::Hover do
+  it "hovers inferred local variable types" do
+    source = <<-CRYSTAL
+      class Greeter
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "greeter" }
+    column_number = lines[line_number].index("greeter").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("greeter : Greeter")
+  end
+
+  it "hovers instance methods from inferred local receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def greet(name : String) : String
+          name
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter.greet
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "greeter.greet" }
+    column_number = lines[line_number].rindex("greet").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("Greeter#greet(name : String) : String")
+  end
+
+  it "hovers class methods from constant receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def self.build(name : String) : Greeter
+          new
+        end
+      end
+
+      def demo
+        Greeter.build
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "Greeter.build" }
+    column_number = lines[line_number].rindex("build").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("Greeter.build(name : String) : Greeter")
+  end
+
+  it "hovers type names from the lightweight index" do
+    source = <<-CRYSTAL
+      # Greeter docs
+      class Greeter
+      end
+
+      def demo
+        Greeter
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "Greeter" }
+    column_number = lines[line_number].index("Greeter").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    value = hover_value(hover.not_nil!)
+    value.should contain("Greeter")
+  end
+
+  it "hovers chained receiver methods using explicit return types" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo
+        factory = Factory.new
+        factory.build.shout
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "factory.build.shout" }
+    column_number = lines[line_number].rindex("shout").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers self and instance variables from lightweight inference" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Wrapper
+        def initialize
+          @greeter = Greeter.new
+        end
+
+        def hello : String
+          "hi"
+        end
+
+        def demo
+          self
+          @greeter
+          self.hello
+          @greeter.shout
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    self_line_number = lines.index! { |item| item.strip == "self" }
+    self_column_number = lines[self_line_number].index("self").not_nil! + 1
+    self_hover = Crystalline::Lightweight::Hover.hover(source, self_line_number, self_column_number, query)
+    self_hover.should_not be_nil
+    hover_value(self_hover.not_nil!).should contain("self : Wrapper")
+
+    ivar_line_number = lines.index! { |item| item.strip == "@greeter" }
+    ivar_column_number = lines[ivar_line_number].index("@greeter").not_nil! + 2
+    ivar_hover = Crystalline::Lightweight::Hover.hover(source, ivar_line_number, ivar_column_number, query)
+    ivar_hover.should_not be_nil
+    hover_value(ivar_hover.not_nil!).should contain("@greeter : Greeter")
+
+    self_method_line_number = lines.index! { |item| item.strip == "self.hello" }
+    self_method_column_number = lines[self_method_line_number].rindex("hello").not_nil! + 2
+    self_method_hover = Crystalline::Lightweight::Hover.hover(source, self_method_line_number, self_method_column_number, query)
+    self_method_hover.should_not be_nil
+    hover_value(self_method_hover.not_nil!).should contain("Wrapper#hello() : String")
+
+    ivar_method_line_number = lines.index! { |item| item.strip == "@greeter.shout" }
+    ivar_method_column_number = lines[ivar_method_line_number].rindex("shout").not_nil! + 2
+    ivar_method_hover = Crystalline::Lightweight::Hover.hover(source, ivar_method_line_number, ivar_method_column_number, query)
+    ivar_method_hover.should_not be_nil
+    hover_value(ivar_method_hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers helper and container receiver methods" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(candidate : Greeter | Nil)
+        items = [Greeter.new]
+        items.first.shout
+        candidate.not_nil!.shout
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    first_line_number = lines.index! { |item| item.strip == "items.first.shout" }
+    first_column_number = lines[first_line_number].rindex("shout").not_nil! + 2
+    first_hover = Crystalline::Lightweight::Hover.hover(source, first_line_number, first_column_number, query)
+    first_hover.should_not be_nil
+    hover_value(first_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    not_nil_line_number = lines.index! { |item| item.strip == "candidate.not_nil!.shout" }
+    not_nil_column_number = lines[not_nil_line_number].rindex("shout").not_nil! + 2
+    not_nil_hover = Crystalline::Lightweight::Hover.hover(source, not_nil_line_number, not_nil_column_number, query)
+    not_nil_hover.should_not be_nil
+    hover_value(not_nil_hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers methods in standalone syntax-only files" do
+    source = <<-CRYSTAL
+      class Clazz
+        def method1(num : Int32)
+          2
+        end
+      end
+
+      puts Clazz.new.method1(num: 42)
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("Clazz.new.method1") }
+    column_number = lines[line_number].rindex("method1").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("Clazz#method1(num : Int32)")
+  end
+
+  it "hovers block arguments inferred from helpers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        items = [Greeter.new]
+        items.each_with_index do |item, index|
+          item
+          index
+        end
+
+        Greeter.new.tap do |value|
+          value
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    item_line_number = lines.index! { |item| item.strip == "item" }
+    item_column_number = lines[item_line_number].index("item").not_nil! + 1
+    item_hover = Crystalline::Lightweight::Hover.hover(source, item_line_number, item_column_number, query)
+    item_hover.should_not be_nil
+    hover_value(item_hover.not_nil!).should contain("item : Greeter")
+
+    index_line_number = lines.index! { |item| item.strip == "index" }
+    index_column_number = lines[index_line_number].index("index").not_nil! + 1
+    index_hover = Crystalline::Lightweight::Hover.hover(source, index_line_number, index_column_number, query)
+    index_hover.should_not be_nil
+    hover_value(index_hover.not_nil!).should contain("index : Int32")
+
+    value_line_number = lines.index! { |item| item.strip == "value" }
+    value_column_number = lines[value_line_number].index("value").not_nil! + 1
+    value_hover = Crystalline::Lightweight::Hover.hover(source, value_line_number, value_column_number, query)
+    value_hover.should_not be_nil
+    hover_value(value_hover.not_nil!).should contain("value : Greeter")
+  end
+
+  it "hovers tuple and named tuple derived receivers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        pair = {Greeter.new, 1}
+        pair.first.shout
+
+        tuple_pair = {1, "x"}
+        tuple_pair.map
+
+        named = {greeter: Greeter.new}
+        named.greeter.shout
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    tuple_line_number = lines.index! { |item| item.strip == "pair.first.shout" }
+    tuple_column_number = lines[tuple_line_number].rindex("shout").not_nil! + 2
+    tuple_hover = Crystalline::Lightweight::Hover.hover(source, tuple_line_number, tuple_column_number, query)
+    tuple_hover.should_not be_nil
+    hover_value(tuple_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    tuple_map_line_number = lines.index! { |item| item.strip == "tuple_pair.map" }
+    tuple_map_column_number = lines[tuple_map_line_number].rindex("map").not_nil! + 2
+    tuple_map_hover = Crystalline::Lightweight::Hover.hover(source, tuple_map_line_number, tuple_map_column_number, query)
+    tuple_map_hover.should_not be_nil
+    hover_value(tuple_map_hover.not_nil!).should contain("Tuple(Int32, String)#map()")
+
+    named_line_number = lines.index! { |item| item.strip == "named.greeter.shout" }
+    named_column_number = lines[named_line_number].rindex("shout").not_nil! + 2
+    named_hover = Crystalline::Lightweight::Hover.hover(source, named_line_number, named_column_number, query)
+    named_hover.should_not be_nil
+    hover_value(named_hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers helper chains that preserve collection receiver shapes" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(items : Array(Greeter), candidate : Greeter | Nil)
+        items.select.first?.not_nil!.shout
+        items.find.not_nil!.shout
+        candidate.try &.shout
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    select_line_number = lines.index! { |item| item.strip == "items.select.first?.not_nil!.shout" }
+    select_column_number = lines[select_line_number].rindex("shout").not_nil! + 2
+    select_hover = Crystalline::Lightweight::Hover.hover(source, select_line_number, select_column_number, query)
+    select_hover.should_not be_nil
+    hover_value(select_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    find_line_number = lines.index! { |item| item.strip == "items.find.not_nil!.shout" }
+    find_column_number = lines[find_line_number].rindex("shout").not_nil! + 2
+    find_hover = Crystalline::Lightweight::Hover.hover(source, find_line_number, find_column_number, query)
+    find_hover.should_not be_nil
+    hover_value(find_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    try_line_number = lines.index! { |item| item.strip == "candidate.try &.shout" }
+    try_column_number = lines[try_line_number].rindex("shout").not_nil! + 2
+    try_hover = Crystalline::Lightweight::Hover.hover(source, try_line_number, try_column_number, query)
+    try_hover.should_not be_nil
+    hover_value(try_hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers richer hash and reducer helper flows" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        def word : String | Nil
+          "hi"
+        end
+      end
+
+      def demo
+        lookup = {"primary" => Greeter.new}
+        lookup.each do |key, value|
+          key
+          value
+        end
+
+        numbers = [1, 2]
+        numbers.reduce do |memo, item|
+          memo
+          item
+        end
+
+        collected = lookup.values.each_with_object([] of String) do |collected_item, collected_memo|
+          collected_item
+          collected_memo
+        end
+        collected.first.upcase
+
+        mapped = lookup.values.map { |item| item.word.not_nil! }
+        mapped.first.upcase
+
+        flat_mapped = lookup.values.flat_map { |item| [item.word.not_nil!] }
+        flat_mapped.first.upcase
+
+        compacted = lookup.values.compact_map { |item| item.word }
+        compacted.first.upcase
+
+        indexed = lookup.values.index_by { |item| item.word.not_nil! }
+        indexed["primary"].shout
+
+        grouped = lookup.values.group_by { |item| item.word.not_nil! }
+        grouped["primary"].first.shout
+
+        found_value = lookup.values.find_value { |item| item.word }
+        found_value.not_nil!.upcase
+
+        resolved = lookup.values.first?.try { |item| item.word.not_nil! }
+        resolved.not_nil!.upcase
+
+        lookup.dig.shout
+
+        items = [Greeter.new]
+        items.find!.shout
+        items.compact_map
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    key_line_number = lines.index! { |item| item.strip == "key" }
+    key_column_number = lines[key_line_number].index("key").not_nil! + 1
+    key_hover = Crystalline::Lightweight::Hover.hover(source, key_line_number, key_column_number, query)
+    key_hover.should_not be_nil
+    hover_value(key_hover.not_nil!).should contain("key : String")
+
+    value_line_number = lines.index! { |item| item.strip == "value" }
+    value_column_number = lines[value_line_number].index("value").not_nil! + 1
+    value_hover = Crystalline::Lightweight::Hover.hover(source, value_line_number, value_column_number, query)
+    value_hover.should_not be_nil
+    hover_value(value_hover.not_nil!).should contain("value : Greeter")
+
+    memo_line_number = lines.index! { |item| item.strip == "memo" }
+    memo_column_number = lines[memo_line_number].index("memo").not_nil! + 1
+    memo_hover = Crystalline::Lightweight::Hover.hover(source, memo_line_number, memo_column_number, query)
+    memo_hover.should_not be_nil
+    hover_value(memo_hover.not_nil!).should contain("memo : Int32")
+
+    item_line_number = lines.index! { |item| item.strip == "item" }
+    item_column_number = lines[item_line_number].index("item").not_nil! + 1
+    item_hover = Crystalline::Lightweight::Hover.hover(source, item_line_number, item_column_number, query)
+    item_hover.should_not be_nil
+    hover_value(item_hover.not_nil!).should contain("item : Int32")
+
+    each_with_object_item_line_number = lines.index! { |item| item.strip == "collected_item" }
+    each_with_object_item_column_number = lines[each_with_object_item_line_number].index("collected_item").not_nil! + 1
+    each_with_object_item_hover = Crystalline::Lightweight::Hover.hover(source, each_with_object_item_line_number, each_with_object_item_column_number, query)
+    each_with_object_item_hover.should_not be_nil
+    hover_value(each_with_object_item_hover.not_nil!).should contain("collected_item : Greeter")
+
+    each_with_object_memo_line_number = lines.index! { |item| item.strip == "collected_memo" }
+    each_with_object_memo_column_number = lines[each_with_object_memo_line_number].index("collected_memo").not_nil! + 1
+    each_with_object_memo_hover = Crystalline::Lightweight::Hover.hover(source, each_with_object_memo_line_number, each_with_object_memo_column_number, query)
+    each_with_object_memo_hover.should_not be_nil
+    hover_value(each_with_object_memo_hover.not_nil!).should contain("collected_memo : Array(String)")
+
+    collected_line_number = lines.index! { |item| item.strip == "collected.first.upcase" }
+    collected_column_number = lines[collected_line_number].rindex("upcase").not_nil! + 2
+    collected_hover = Crystalline::Lightweight::Hover.hover(source, collected_line_number, collected_column_number, query)
+    collected_hover.should_not be_nil
+    hover_value(collected_hover.not_nil!).should contain("String#upcase(")
+
+    mapped_line_number = lines.index! { |item| item.strip == "mapped.first.upcase" }
+    mapped_column_number = lines[mapped_line_number].rindex("upcase").not_nil! + 2
+    mapped_hover = Crystalline::Lightweight::Hover.hover(source, mapped_line_number, mapped_column_number, query)
+    mapped_hover.should_not be_nil
+    hover_value(mapped_hover.not_nil!).should contain("String#upcase(")
+
+    flat_mapped_line_number = lines.index! { |item| item.strip == "flat_mapped.first.upcase" }
+    flat_mapped_column_number = lines[flat_mapped_line_number].rindex("upcase").not_nil! + 2
+    flat_mapped_hover = Crystalline::Lightweight::Hover.hover(source, flat_mapped_line_number, flat_mapped_column_number, query)
+    flat_mapped_hover.should_not be_nil
+    hover_value(flat_mapped_hover.not_nil!).should contain("String#upcase(")
+
+    compacted_line_number = lines.index! { |item| item.strip == "compacted.first.upcase" }
+    compacted_column_number = lines[compacted_line_number].rindex("upcase").not_nil! + 2
+    compacted_hover = Crystalline::Lightweight::Hover.hover(source, compacted_line_number, compacted_column_number, query)
+    compacted_hover.should_not be_nil
+    hover_value(compacted_hover.not_nil!).should contain("String#upcase(")
+
+    indexed_line_number = lines.index! { |item| item.strip == "indexed[\"primary\"].shout" }
+    indexed_column_number = lines[indexed_line_number].rindex("shout").not_nil! + 2
+    indexed_hover = Crystalline::Lightweight::Hover.hover(source, indexed_line_number, indexed_column_number, query)
+    indexed_hover.should_not be_nil
+    hover_value(indexed_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    grouped_line_number = lines.index! { |item| item.strip == "grouped[\"primary\"].first.shout" }
+    grouped_column_number = lines[grouped_line_number].rindex("shout").not_nil! + 2
+    grouped_hover = Crystalline::Lightweight::Hover.hover(source, grouped_line_number, grouped_column_number, query)
+    grouped_hover.should_not be_nil
+    hover_value(grouped_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    found_value_line_number = lines.index! { |item| item.strip == "found_value.not_nil!.upcase" }
+    found_value_column_number = lines[found_value_line_number].rindex("upcase").not_nil! + 2
+    found_value_hover = Crystalline::Lightweight::Hover.hover(source, found_value_line_number, found_value_column_number, query)
+    found_value_hover.should_not be_nil
+    hover_value(found_value_hover.not_nil!).should contain("String#upcase(")
+
+    resolved_line_number = lines.index! { |item| item.strip == "resolved.not_nil!.upcase" }
+    resolved_column_number = lines[resolved_line_number].rindex("upcase").not_nil! + 2
+    resolved_hover = Crystalline::Lightweight::Hover.hover(source, resolved_line_number, resolved_column_number, query)
+    resolved_hover.should_not be_nil
+    hover_value(resolved_hover.not_nil!).should contain("String#upcase(")
+
+    dig_line_number = lines.index! { |item| item.strip == "lookup.dig.shout" }
+    dig_column_number = lines[dig_line_number].rindex("shout").not_nil! + 2
+    dig_hover = Crystalline::Lightweight::Hover.hover(source, dig_line_number, dig_column_number, query)
+    dig_hover.should_not be_nil
+    hover_value(dig_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    find_bang_line_number = lines.index! { |item| item.strip == "items.find!.shout" }
+    find_bang_column_number = lines[find_bang_line_number].rindex("shout").not_nil! + 2
+    find_bang_hover = Crystalline::Lightweight::Hover.hover(source, find_bang_line_number, find_bang_column_number, query)
+    find_bang_hover.should_not be_nil
+    hover_value(find_bang_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    inherited_line_number = lines.index! { |item| item.strip == "items.compact_map" }
+    inherited_column_number = lines[inherited_line_number].rindex("compact_map").not_nil! + 2
+    inherited_hover = Crystalline::Lightweight::Hover.hover(source, inherited_line_number, inherited_column_number, query)
+    inherited_hover.should_not be_nil
+    hover_value(inherited_hover.not_nil!).should contain("compact_map")
+  end
+
+  it "hovers methods on receivers from calls with arguments" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build(name : String) : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo(factory : Factory)
+        Greeter.new("hi").shout
+        factory.build("hi").shout
+      end
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+
+    new_line_number = lines.index! { |item| item.strip == "Greeter.new(\"hi\").shout" }
+    new_column_number = lines[new_line_number].rindex("shout").not_nil! + 2
+    new_hover = Crystalline::Lightweight::Hover.hover(source, new_line_number, new_column_number, query)
+    new_hover.should_not be_nil
+    hover_value(new_hover.not_nil!).should contain("Greeter#shout() : String")
+
+    build_line_number = lines.index! { |item| item.strip == "factory.build(\"hi\").shout" }
+    build_column_number = lines[build_line_number].rindex("shout").not_nil! + 2
+    build_hover = Crystalline::Lightweight::Hover.hover(source, build_line_number, build_column_number, query)
+    build_hover.should_not be_nil
+    hover_value(build_hover.not_nil!).should contain("Greeter#shout() : String")
+  end
+
+  it "hovers namespace-relative type names" do
+    source = <<-CRYSTAL
+      module Outer
+        class Inner
+        end
+
+        def demo
+          Inner.new
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "Inner.new" }
+    column_number = lines[line_number].index("Inner").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("Outer::Inner")
+  end
+
+  it "does not resolve tokens inside comments" do
+    source = <<-CRYSTAL
+      def demo
+        # requests that are pending
+        x = 1
+      end
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("requests") }
+    column_number = lines[line_number].index("requests").not_nil! + 2
+
+    Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query).should be_nil
+  end
+
+  it "does not resolve tokens inside string literals" do
+    source = <<-CRYSTAL
+      require "./workspace"
+
+      def demo
+        x = 1
+      end
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("workspace") }
+    column_number = lines[line_number].index("workspace").not_nil! + 2
+
+    Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query).should be_nil
+  end
+
+  it "hovers a bare getter self-call" do
+    source = <<-CRYSTAL
+      class Clazz
+        getter! workspace : Clazz
+
+        def demo
+          workspace
+        end
+      end
+    CRYSTAL
+
+    query = build_syntax_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.strip == "workspace" }
+    column_number = lines[line_number].index("workspace").not_nil! + 2
+
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("workspace")
+  end
+
+  it "hovers a method whose receiver sits inside an unclosed paren group" do
+    source = <<-CRYSTAL
+      class Project
+        def entry_point? : String
+          "x"
+        end
+      end
+
+      def demo(project : Project)
+        return unless (target = project.entry_point?)
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("entry_point?") }
+    column_number = lines[line_number].index("entry_point?").not_nil! + 1
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("entry_point?")
+  end
+
+  it "hovers compiler-intrinsic predicates like nil? even when the receiver is untyped" do
+    source = <<-CRYSTAL
+      def demo(path : String)
+        if path.nil?
+          ""
+        end
+      end
+    CRYSTAL
+
+    query = build_lightweight_hover_query(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("path.nil?") }
+    column_number = lines[line_number].index("nil?").not_nil! + 1
+    hover = Crystalline::Lightweight::Hover.hover(source, line_number, column_number, query)
+    hover.should_not be_nil
+    hover_value(hover.not_nil!).should contain("nil? : Bool")
+  end
+end

--- a/spec/lightweight/index_spec.cr
+++ b/spec/lightweight/index_spec.cr
@@ -1,0 +1,414 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/query"
+
+private def build_lightweight_index(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-index-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Index.from_program(result.program)
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe Crystalline::Lightweight::Index do
+  it "provides query helpers over the lightweight index" do
+    index = build_lightweight_index <<-CRYSTAL
+      module Foo
+        class Bar
+          def baz(x : Int32) : String
+            x.to_s
+          end
+
+          def self.make(name : String) : Foo::Bar
+            new
+          end
+        end
+      end
+
+      def top_level(value : Bool) : Int32
+        value ? 1 : 0
+      end
+    CRYSTAL
+
+    query = Crystalline::Lightweight::Query.new(index)
+
+    query.find_type("Foo::Bar").should_not be_nil
+    query.subtypes_for("Foo").should contain("Foo::Bar")
+
+    instance_methods = query.methods_for("Foo::Bar")
+    instance_methods.map(&.name).should contain("baz")
+    instance_methods.any?(&.macro).should be_false
+
+    class_methods = query.methods_for("Foo::Bar", class_method: true)
+    class_methods.map(&.name).should contain("make")
+
+    query.top_level_methods.map(&.name).should contain("top_level")
+  end
+
+  it "indexes top-level methods and nested types from top-level semantic results" do
+    index = build_lightweight_index <<-CRYSTAL
+      module Foo
+        class Bar
+          def baz(x : Int32) : String
+            x.to_s
+          end
+
+          def self.make(name : String) : Foo::Bar
+            new
+          end
+        end
+      end
+
+      def top_level(value : Bool) : Int32
+        value ? 1 : 0
+      end
+    CRYSTAL
+
+    foo = index.types["Foo"]?
+    foo.should_not be_nil
+    foo.not_nil!.kind.should eq(Crystalline::Lightweight::TypeKind::Module)
+    foo.not_nil!.subtypes.should contain("Foo::Bar")
+
+    bar = index.types["Foo::Bar"]?
+    bar.should_not be_nil
+    bar = bar.not_nil!
+    bar.kind.should eq(Crystalline::Lightweight::TypeKind::Class)
+
+    baz = bar.methods.find { |method| method.name == "baz" && !method.class_method && !method.macro }
+    baz.should_not be_nil
+    baz = baz.not_nil!
+    baz.return_type.should eq("String")
+    baz.args.map(&.restriction).should eq(["Int32"])
+
+    make = bar.methods.find { |method| method.name == "make" && method.class_method }
+    make.should_not be_nil
+    make = make.not_nil!
+    make.return_type.should eq("Foo::Bar")
+    make.args.map(&.restriction).should eq(["String"])
+
+    top_level = index.top_level_methods.find(&.name.==("top_level"))
+    top_level.should_not be_nil
+    top_level.not_nil!.return_type.should eq("Int32")
+    top_level.not_nil!.args.map(&.restriction).should eq(["Bool"])
+  end
+
+  it "indexes nested types from single-member source bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class Foo
+        class Inner; end
+      end
+      class WithMethods
+        def bar : Int32
+          1
+        end
+      end
+    CRYSTAL
+
+    foo = index.types["Foo"]?
+    foo.should_not be_nil
+    foo.not_nil!.subtypes.should contain("Foo::Inner")
+    index.types["Foo::Inner"]?.should_not be_nil
+
+    with_methods = index.types["WithMethods"]?
+    with_methods.should_not be_nil
+    with_methods.not_nil!.methods.map(&.name).should contain("bar")
+  end
+
+  it "indexes accessor macros from source bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class User
+        getter name : String
+        property age : Int32
+        getter? active : Bool
+        class_property @@count : Int32
+        setter raw
+      end
+    CRYSTAL
+
+    user = index.types["User"]?.should_not be_nil
+
+    getter = user.methods.find { |m| m.name == "name" && !m.class_method }
+    getter.should_not be_nil
+    getter.not_nil!.return_type.should eq("String")
+    getter.not_nil!.args.should be_empty
+
+    user.methods.map(&.name).should contain("age")
+    user.methods.map(&.name).should contain("age=")
+    user.methods.map(&.name).should contain("active?")
+
+    class_getter = user.methods.find { |m| m.name == "count" && m.class_method }
+    class_getter.should_not be_nil
+    class_getter.not_nil!.return_type.should eq("Int32")
+
+    setter = user.methods.find(&.name.==("raw="))
+    setter.should_not be_nil
+    setter.not_nil!.args.map(&.name).should eq(["value"])
+  end
+
+  it "indexes classes defined in macro bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module LSP
+        macro finished
+          class HoverRequest < RequestMessage(Hover?)
+            property params : HoverParams
+          end
+        end
+      end
+    CRYSTAL
+
+    hover = index.types["LSP::HoverRequest"]?.should_not be_nil
+    hover.methods.map(&.name).should contain("params")
+    hover.parent_types.should contain("RequestMessage(Hover | ::Nil)")
+  end
+
+  it "types accessor initializers from their of-clause" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class Store
+        getter entries = {} of String => Int32
+        getter items = [] of String
+        getter count = 42
+      end
+    CRYSTAL
+
+    store = index.types["Store"]?.should_not be_nil
+
+    entries = store.methods.find(&.name.==("entries"))
+    entries.should_not be_nil
+    entries.not_nil!.return_type.should eq("Hash(String, Int32)")
+    store.ivars["@entries"]?.should eq(["Hash(String, Int32)"])
+
+    items = store.methods.find(&.name.==("items"))
+    items.should_not be_nil
+    items.not_nil!.return_type.should eq("Array(String)")
+
+    count = store.methods.find(&.name.==("count"))
+    count.should_not be_nil
+    count.not_nil!.return_type.should be_nil
+  end
+
+  it "indexes private and protected defs from source bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class User
+        private def secret : String
+          "s"
+        end
+
+        protected def helper(name : String) : Int32
+          name.size
+        end
+      end
+    CRYSTAL
+
+    user = index.types["User"].should_not be_nil
+
+    secret = user.methods.find(&.name.==("secret"))
+    secret.should_not be_nil
+    secret.not_nil!.return_type.should eq("String")
+
+    helper = user.methods.find(&.name.==("helper"))
+    helper.should_not be_nil
+    helper.not_nil!.args.map(&.name).should eq(["name"])
+  end
+
+  it "indexes records as types with field getters from source bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module Compiler
+        record Result, program : Program, node : ASTNode
+      end
+    CRYSTAL
+
+    result = index.types["Compiler::Result"]?.should_not be_nil
+    result.kind.should eq(Crystalline::Lightweight::TypeKind::Struct)
+
+    node = result.methods.find(&.name.==("node"))
+    node.should_not be_nil
+    node.not_nil!.return_type.should eq("ASTNode")
+    node.not_nil!.args.should be_empty
+
+    program = result.methods.find(&.name.==("program"))
+    program.should_not be_nil
+    program.not_nil!.return_type.should eq("Program")
+  end
+
+  it "indexes aliases inside module and class bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module Dispatcher
+        alias Handler = Proc(String, URI, String)
+
+        class Registry
+          alias Item = Hash(String, Int32)
+        end
+      end
+    CRYSTAL
+
+    handler = index.types["Dispatcher::Handler"]?.should_not be_nil
+    handler.kind.should eq(Crystalline::Lightweight::TypeKind::Alias)
+    handler.parent_types.should contain("Proc(String, URI, String)")
+
+    item = index.types["Dispatcher::Registry::Item"]?.should_not be_nil
+    item.parent_types.should contain("Hash(String, Int32)")
+  end
+
+  it "merges split definitions into a union of methods, parents and subtypes" do
+    index_a = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module Crystal
+        class ASTNode
+          def at : Location?
+            nil
+          end
+
+          def no_returns? : Bool
+            false
+          end
+        end
+      end
+    CRYSTAL
+
+    index_b = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module Crystal
+        class ASTNode
+          def accept(visitor)
+          end
+
+          def accept_children(visitor)
+          end
+        end
+      end
+    CRYSTAL
+
+    merged = Crystalline::Lightweight::Index.merge([index_a, index_b])
+    ast_node = merged.types["Crystal::ASTNode"]?.should_not be_nil
+
+    ast_node.methods.map(&.name).should contain("at")
+    ast_node.methods.map(&.name).should contain("accept")
+    ast_node.methods.map(&.name).should contain("accept_children")
+  end
+
+  it "records superclasses and includes as parents from source bodies" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      module Mixin
+      end
+
+      class Base
+      end
+
+      class Sub < Base
+        include Mixin
+      end
+    CRYSTAL
+
+    sub = index.types["Sub"]?.should_not be_nil
+    sub.parent_types.should contain("Base")
+    sub.parent_types.should contain("Mixin")
+  end
+
+  it "records the implicit Reference superclass for superclass-less classes" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class Plain
+      end
+
+      record Pair, left : Int32, right : Int32
+    CRYSTAL
+
+    plain = index.types["Plain"]?.should_not be_nil
+    plain.parent_types.should contain("Reference")
+
+    pair = index.types["Pair"]?.should_not be_nil
+    pair.parent_types.should_not contain("Reference")
+  end
+
+  it "synthesizes a class-method new from initialize" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class WithArgs
+        def initialize(name : String, count : Int32)
+        end
+      end
+
+      class Bare
+      end
+    CRYSTAL
+
+    with_args = index.types["WithArgs"]?.should_not be_nil
+    new_method = with_args.methods.find { |m| m.class_method && m.name == "new" }.should_not be_nil
+    new_method.not_nil!.args.map(&.name).should eq(["name", "count"])
+    new_method.not_nil!.args.map(&.restriction).should eq(["String", "Int32"])
+    new_method.not_nil!.return_type.should eq("WithArgs")
+
+    bare_new = index.types["Bare"].not_nil!.methods.find { |m| m.class_method && m.name == "new" }
+    bare_new.should_not be_nil
+    bare_new.not_nil!.args.should be_empty
+  end
+
+  it "records getter-backed ivars with their restrictions" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class User
+        getter root_uri : URI?
+        property age : Int32
+      end
+    CRYSTAL
+
+    user = index.types["User"]?.should_not be_nil
+    # `URI?` parses as a union whose to_s expands to `URI | ::Nil`.
+    user.ivars["@root_uri"].should eq(["URI | ::Nil"])
+    user.ivars["@age"].should eq(["Int32"])
+  end
+
+  it "infers the return type of untyped defs from the body's last expression" do
+    index = Crystalline::Lightweight::Index.from_source(<<-CRYSTAL).should_not be_nil
+      class Store
+        @cache : Hash(String, {Crystal::Compiler::Result?, Time::Instant?}) = {} of String => {Crystal::Compiler::Result?, Time::Instant?}
+
+        def get(entry : String)
+          @cache[entry]?.try &.[0]
+        end
+
+        def name
+          "hello"
+        end
+
+        def count
+          42
+        end
+
+        def empty
+          @cache.empty?
+        end
+
+        def make
+          Foo.new
+        end
+      end
+    CRYSTAL
+
+    store = index.types["Store"]?.should_not be_nil
+
+    get = store.methods.find(&.name.==("get")).should_not be_nil
+    get.not_nil!.return_type.should eq("Crystal::Compiler::Result | ::Nil")
+
+    name = store.methods.find(&.name.==("name")).should_not be_nil
+    name.not_nil!.return_type.should eq("String")
+
+    count = store.methods.find(&.name.==("count")).should_not be_nil
+    count.not_nil!.return_type.should eq("Int32")
+
+    empty = store.methods.find(&.name.==("empty")).should_not be_nil
+    empty.not_nil!.return_type.should eq("Bool")
+
+    make = store.methods.find(&.name.==("make")).should_not be_nil
+    make.not_nil!.return_type.should eq("Foo")
+  end
+end

--- a/spec/lightweight/inference_spec.cr
+++ b/spec/lightweight/inference_spec.cr
@@ -1,0 +1,751 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/query"
+require "../../src/crystalline/lightweight/inference"
+
+private def build_lightweight_index(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-inference-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Index.from_program(result.program)
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+private def prelude_index : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::PreludeIndex.ensure_loaded
+  until (index = Crystalline::Lightweight::PreludeIndex.get)
+    sleep 50.milliseconds
+  end
+  index
+end
+
+describe Crystalline::Lightweight::Inference do
+  it "infers argument restrictions and simple literal assignments before the cursor" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Foo
+      end
+
+      def top_level(value : Bool) : Int32
+        value ? 1 : 0
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo(x : Int32)
+        message = "hello"
+        enabled = true
+        amount = 1
+        thing = Foo.new
+        total = top_level(enabled)
+        amount
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      7,
+      14,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("x").should eq(["Int32"])
+    inference.types_for("message").should eq(["String"])
+    inference.types_for("enabled").should eq(["Bool"])
+    inference.types_for("amount").should eq(["Int32"])
+    inference.types_for("thing").should eq(["Foo"])
+    inference.types_for("total").should eq(["Int32"])
+  end
+
+  it "infers self and instance variables from the enclosing type" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Wrapper
+        def hello : String
+          "hi"
+        end
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      class Wrapper
+        def initialize
+          @greeter = Greeter.new
+        end
+
+        def demo
+          current = self
+          @greeter.shout
+          current.hello
+        end
+
+        def hello : String
+          "hi"
+        end
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      8,
+      12,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.self_types.should eq({["Wrapper"], false})
+    inference.types_for("current").should eq(["Wrapper"])
+    inference.types_for_instance_var("@greeter").should eq(["Greeter"])
+  end
+
+  it "merges conditional branch assignments into union-like local types" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Foo
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo(flag : Bool)
+        value = 1
+
+        if flag
+          item = Foo.new
+          value = "hello"
+        else
+          item = 1
+        end
+
+        item
+        value
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      11,
+      8,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("item").sort.should eq(["Foo", "Int32"])
+    inference.types_for("value").sort.should eq(["Int32", "String"])
+  end
+
+  it "expands union restrictions and explicit return types into individual names" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Foo
+      end
+
+      class Bar
+      end
+
+      def maybe_item : Foo | Bar | Nil
+        Foo.new
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo(value : Foo | Bar | Nil)
+        result = maybe_item
+        result
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      3,
+      8,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("value").sort.should eq(["Bar", "Foo", "Nil"])
+    inference.types_for("result").sort.should eq(["Bar", "Foo", "Nil"])
+  end
+
+  it "narrows types inside is_a? and truthy conditional branches" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    isa_source = <<-CRYSTAL
+      def demo(candidate : Greeter | Nil | Int32)
+        if candidate.is_a?(Greeter)
+          narrowed = candidate
+          narrowed
+        end
+      end
+    CRYSTAL
+
+    narrowed_inference = Crystalline::Lightweight::Inference.for(
+      isa_source,
+      4,
+      10,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    narrowed_inference.should_not be_nil
+    narrowed_inference = narrowed_inference.not_nil!
+    narrowed_inference.types_for("candidate").should eq(["Greeter"])
+    narrowed_inference.types_for("narrowed").should eq(["Greeter"])
+
+    truthy_source = <<-CRYSTAL
+      def demo(candidate : Greeter | Nil)
+        if candidate
+          truthy_candidate = candidate
+          truthy_candidate
+        end
+      end
+    CRYSTAL
+
+    truthy_inference = Crystalline::Lightweight::Inference.for(
+      truthy_source,
+      4,
+      12,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    truthy_inference.should_not be_nil
+    truthy_inference = truthy_inference.not_nil!
+    truthy_inference.types_for("candidate").should eq(["Greeter"])
+    truthy_inference.types_for("truthy_candidate").should eq(["Greeter"])
+  end
+
+  it "narrows case subjects in when branches" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Wrapper
+        def hello : String
+          "hi"
+        end
+      end
+    CRYSTAL
+
+    case_source = <<-CRYSTAL
+      def demo(candidate : Greeter | Wrapper)
+        case candidate
+        when Greeter
+          narrowed = candidate
+          narrowed
+        end
+      end
+    CRYSTAL
+
+    case_inference = Crystalline::Lightweight::Inference.for(
+      case_source,
+      5,
+      1,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    case_inference.should_not be_nil
+    case_inference = case_inference.not_nil!
+    case_inference.types_for("candidate").should eq(["Greeter"])
+    case_inference.types_for("narrowed").should eq(["Greeter"])
+
+    # A subtype when narrows an abstract subject to the when-type.
+    union_source = <<-CRYSTAL
+      def demo(candidate : Greeter)
+        case candidate
+        when Greeter
+          narrowed = candidate
+          narrowed
+        end
+      end
+    CRYSTAL
+
+    union_inference = Crystalline::Lightweight::Inference.for(
+      union_source,
+      4,
+      11,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+    union_inference.should_not be_nil
+    union_inference = union_inference.not_nil!
+    union_inference.types_for("candidate").should eq(["Greeter"])
+  end
+
+  it "resolves inherited methods from bare-named parents" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    query = Crystalline::Lightweight::Query.new(index, secondary: prelude_index)
+    names = query.methods_for("Crystal::Def").map(&.name)
+    # `location`/`doc` live on Crystal::ASTNode, which the prelude
+    # records as a bare-named parent of Crystal::Def.
+    names.should contain("location")
+    names.should contain("doc")
+  end
+
+  it "infers fallback types from logical or expressions" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo(candidate : Greeter | Nil)
+        resolved = candidate || Greeter.new
+        resolved
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      3,
+      12,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("resolved").should eq(["Greeter"])
+  end
+
+  it "preserves tuple literal element shapes for generic specialization" do
+    index = build_lightweight_index <<-CRYSTAL
+      def noop
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo
+        pair = {1, "x"}
+        pair
+      end
+    CRYSTAL
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      3,
+      6,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("pair").should eq(["Tuple(Int32, String)"])
+  end
+
+  it "infers block args and container return types for richer collection helpers" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        def word : String | Nil
+          "hi"
+        end
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo
+        lookup = {"primary" => Greeter.new}
+        lookup.each do |key, value|
+          key
+          value
+        end
+
+        numbers = [1, 2]
+        numbers.reduce do |memo, item|
+          memo
+          item
+        end
+
+        collected = lookup.values.each_with_object([] of String) do |item, memo|
+          item.word.not_nil!
+          memo.first?
+        end
+
+        mapped = lookup.values.map { |item| item.word.not_nil! }
+        flat_mapped = lookup.values.flat_map { |item| [item.word.not_nil!] }
+        compacted = lookup.values.compact_map { |item| item.word }
+        indexed = lookup.values.index_by { |item| item.word.not_nil! }
+        grouped = lookup.values.group_by { |item| item.word.not_nil! }
+        found_value = lookup.values.find_value { |item| item.word }
+        resolved = lookup.values.first?.try { |item| item.word.not_nil! }
+
+        found = lookup.dig
+        current = numbers.find!
+        found
+        current
+      end
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+
+    key_line_number = lines.index! { |line| line.strip == "key" } + 1
+    key_column_number = lines[key_line_number - 1].index("key").not_nil! + 2
+    hash_inference = Crystalline::Lightweight::Inference.for(
+      source,
+      key_line_number,
+      key_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    hash_inference.should_not be_nil
+    hash_inference = hash_inference.not_nil!
+    hash_inference.types_for("key").should eq(["String"])
+    hash_inference.types_for("value").should eq(["Greeter"])
+
+    memo_line_number = lines.index! { |line| line.strip == "memo" } + 1
+    memo_column_number = lines[memo_line_number - 1].index("memo").not_nil! + 2
+    reduce_inference = Crystalline::Lightweight::Inference.for(
+      source,
+      memo_line_number,
+      memo_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    reduce_inference.should_not be_nil
+    reduce_inference = reduce_inference.not_nil!
+    reduce_inference.types_for("memo").should eq(["Int32"])
+    reduce_inference.types_for("item").should eq(["Int32"])
+
+    each_with_object_line_number = lines.index! { |line| line.includes?("memo.first?") } + 1
+    each_with_object_column_number = lines[each_with_object_line_number - 1].index("memo").not_nil! + 2
+    each_with_object_inference = Crystalline::Lightweight::Inference.for(
+      source,
+      each_with_object_line_number,
+      each_with_object_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    each_with_object_inference.should_not be_nil
+    each_with_object_inference = each_with_object_inference.not_nil!
+    each_with_object_inference.types_for("item").should eq(["Greeter"])
+    each_with_object_inference.types_for("memo").should eq(["Array(String)"])
+
+    found_line_number = lines.index! { |line| line.strip == "found" } + 1
+    found_column_number = lines[found_line_number - 1].index("found").not_nil! + 2
+    return_inference = Crystalline::Lightweight::Inference.for(
+      source,
+      found_line_number,
+      found_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    return_inference.should_not be_nil
+    return_inference = return_inference.not_nil!
+    return_inference.types_for("collected").should eq(["Array(String)"])
+    return_inference.types_for("mapped").should eq(["Array(String)"])
+    return_inference.types_for("flat_mapped").should eq(["Array(String)"])
+    return_inference.types_for("compacted").should eq(["Array(String)"])
+    return_inference.types_for("indexed").should eq(["Hash(String, Greeter)"])
+    return_inference.types_for("grouped").should eq(["Hash(String, Array(Greeter))"])
+    return_inference.types_for("found_value").sort.should eq(["Nil", "String"])
+    return_inference.types_for("resolved").sort.should eq(["Nil", "String"])
+    return_inference.types_for("found").should eq(["Greeter", "Nil"])
+    return_inference.types_for("current").should eq(["Int32"])
+  end
+
+  it "infers the reduce accumulator from the memo argument" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Foo
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      def demo(items : Array(String))
+        items.reduce([] of Int32) do |acc, item|
+          acc
+        end
+      end
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+    acc_line_number = lines.index! { |line| line.strip == "acc" } + 1
+    acc_column_number = lines[acc_line_number - 1].index("acc").not_nil! + 2
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      acc_line_number,
+      acc_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("acc").should eq(["Array(Int32)"])
+    inference.types_for("item").should eq(["String"])
+  end
+
+  it "infers top-level locals before the cursor" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Foo
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      foo = Foo.new
+      message = "hello"
+      count = 42
+      foo
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+    cursor_line_number = lines.index! { |line| line.strip == "foo" } + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("foo").not_nil! + 2
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("foo").should eq(["Foo"])
+    inference.types_for("message").should eq(["String"])
+    inference.types_for("count").should eq(["Int32"])
+  end
+
+  it "infers inside private defs and resolves bare self-calls" do
+    index = build_lightweight_index <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        private def message : String
+          shout
+        end
+      end
+    CRYSTAL
+
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        private def message : String
+          m = shout
+          m
+        end
+      end
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+    cursor_line_number = lines.index! { |line| line.strip == "m" } + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("m").not_nil! + 2
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.current_def.not_nil!.name.should eq("message")
+    inference.self_types[0].should eq(["Greeter"])
+    # The bare self-call `shout` resolves through the enclosing type.
+    inference.types_for("m").should eq(["String"])
+  end
+
+  it "infers assignments inside while loops and their conditions" do
+    source = <<-CRYSTAL
+      def demo
+        while (line = "x")
+          message = line
+          message
+        end
+        message
+      end
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+    cursor_line_number = lines.rindex { |line| line.strip == "message" }.not_nil! + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("message").not_nil! + 2
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(Crystalline::Lightweight::Index.new),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("line").should eq(["String"])
+    inference.types_for("message").should eq(["String"])
+  end
+
+  it "infers assignments inside case and select when bodies" do
+    source = <<-CRYSTAL
+      def demo
+        case 1
+        when 1
+          message = "one"
+        when 2
+          message = "two"
+        end
+
+        select
+        when x = foo()
+          selected = "x"
+        else
+          selected = "y"
+        end
+        message
+      end
+    CRYSTAL
+
+    lines = source.lines(chomp: false)
+    cursor_line_number = lines.rindex { |line| line.strip == "message" }.not_nil! + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("message").not_nil! + 2
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(Crystalline::Lightweight::Index.new),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("message").should eq(["String"])
+    inference.types_for("selected").should eq(["String"])
+  end
+
+  it "infers untyped args from call sites and same-name locals" do
+    source = <<-CRYSTAL
+      def compile(server : LSP::Server, file_uri)
+        project = Project.best_fit_for_file
+      end
+
+      def recalculate_dependencies(server, project)
+        server.
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    lines = fixed.lines(chomp: false)
+    cursor_line_number = lines.index! { |line| line.includes?("server.") } + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("server").not_nil! + 2
+    index = build_lightweight_index(<<-CRYSTAL)
+      class Project
+        def self.best_fit_for_file : Project?
+          nil
+        end
+      end
+    CRYSTAL
+    inference = Crystalline::Lightweight::Inference.for(
+      fixed,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("server").should eq(["LSP::Server"])
+    inference.types_for("project").should contain("Project")
+  end
+
+  it "infers locals assigned inside a return unless guard" do
+    source = <<-CRYSTAL
+      def compile(server)
+        project = Project.new
+        recalculate_dependencies(project)
+      end
+
+      def recalculate_dependencies(project)
+        return unless (target = project.entry_point?)
+        target.
+      end
+    CRYSTAL
+
+    fixed = Crystalline::BrokenSourceFixer.fix(source)
+    lines = fixed.lines(chomp: false)
+    cursor_line_number = lines.index! { |line| line.includes?("target.") } + 1
+    cursor_column_number = lines[cursor_line_number - 1].index("target").not_nil! + 2
+    index = build_lightweight_index(<<-CRYSTAL)
+      class Project
+        def entry_point? : String
+          "x"
+        end
+      end
+    CRYSTAL
+    inference = Crystalline::Lightweight::Inference.for(
+      fixed,
+      cursor_line_number,
+      cursor_column_number,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    inference = inference.not_nil!
+    inference.types_for("target").should eq(["String"])
+  end
+
+  it "walks ||= begin ... end blocks so the ivar keeps the block's type" do
+    source = <<-CRYSTAL
+      class Cache
+        def get(key : String) : String
+          @values ||= begin
+            {} of String => String
+          end
+          @values[key]
+        end
+      end
+    CRYSTAL
+
+    index = build_lightweight_index(source)
+    lines = source.lines(chomp: false)
+    line_number = lines.index! { |item| item.includes?("@values[key]") }
+    cursor = lines[line_number].index("@values").not_nil! + "@values".size
+
+    inference = Crystalline::Lightweight::Inference.for(
+      source,
+      line_number + 1,
+      cursor + 1,
+      Crystalline::Lightweight::Query.new(index, secondary: prelude_index),
+    )
+
+    inference.should_not be_nil
+    # The index records no ivars; the ||= block's hash literal types it.
+    inference.not_nil!.types_for_instance_var("@values").should eq(["Hash(String, String)"])
+  end
+end

--- a/spec/lightweight/prelude_index_spec.cr
+++ b/spec/lightweight/prelude_index_spec.cr
@@ -1,0 +1,49 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/prelude_index"
+
+describe Crystalline::Lightweight::PreludeIndex do
+  it "round-trips the prelude index through the cache format" do
+    original = Crystalline::Lightweight::PreludeIndex.generate
+    original.should_not be_nil
+    original = original.not_nil!
+    original.types.size.should be > 500
+    original.types["String"]?.should_not be_nil
+
+    path = File.join(Dir.tempdir, "crystalline-prelude-test-#{Random::Secure.hex(8)}.bin")
+    begin
+      Crystalline::Lightweight::PreludeIndex.save_to_cache_for_test(original, path)
+      loaded = Crystalline::Lightweight::PreludeIndex.load_from_cache_for_test(path)
+      loaded.should_not be_nil
+      loaded = loaded.not_nil!
+
+      loaded.types.size.should eq(original.types.size)
+      loaded.top_level_methods.size.should eq(original.top_level_methods.size)
+
+      string_type = loaded.types["String"].should_not be_nil
+      string_type.methods.map(&.name).should contain("upcase")
+      string_type.methods.map(&.name).should contain("split")
+      string_type.parent_types.should contain("Reference")
+
+      # Restrictions and return types survive the round trip.
+      to_i = string_type.methods.find(&.name.==("to_i"))
+      to_i.should_not be_nil
+      to_i.not_nil!.args.first.name.should eq("base")
+      to_i.not_nil!.args.first.restriction.should eq("Int")
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
+  it "indexes aliases with the aliased type as their parent" do
+    index = Crystalline::Lightweight::PreludeIndex.generate
+    index.should_not be_nil
+    index = index.not_nil!
+
+    mutex = index.types["Mutex"]?
+    mutex.should_not be_nil
+    mutex.not_nil!.kind.should eq(Crystalline::Lightweight::TypeKind::Alias)
+    mutex.not_nil!.parent_types.should contain("Sync::Mutex")
+  end
+end

--- a/spec/lightweight/query_spec.cr
+++ b/spec/lightweight/query_spec.cr
@@ -1,0 +1,156 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/query"
+
+private def index_from_source(source : String) : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::Index.from_source(source).should_not be_nil
+end
+
+private def build_lightweight_index(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-query-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless result
+    Crystalline::Lightweight::Index.from_program(result.program)
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe Crystalline::Lightweight::Query do
+  it "overlays a dirty-buffer index on top of the base index" do
+    base = index_from_source(<<-CRYSTAL)
+      class Greeter
+        def hello : Int32
+          1
+        end
+
+        def old_method : Int32
+          1
+        end
+      end
+
+      def top_level_old : Int32
+        1
+      end
+
+      def top_level_shared : String
+        "base"
+      end
+    CRYSTAL
+
+    # The leading comment shifts every location by one line, so the
+    # redefined methods live at different locations than the base ones.
+    overlay = index_from_source(<<-CRYSTAL)
+      # overlay
+
+      class Greeter
+        def hello : String
+          "hi"
+        end
+
+        def new_method : Bool
+          true
+        end
+      end
+
+      def top_level_new : Float64
+        1.0
+      end
+
+      def top_level_shared : String
+        "overlay"
+      end
+    CRYSTAL
+
+    query = Crystalline::Lightweight::Query.new(base, overlay: overlay)
+
+    # A same-signature redefinition at a different location wins.
+    hello = query.methods_for("Greeter").find(&.name.==("hello")).should_not be_nil
+    hello.not_nil!.return_type.should eq("String")
+
+    # Base methods that are not redefined are preserved, and overlay-only
+    # methods are added.
+    query.methods_for("Greeter").map(&.name).should contain("old_method")
+    query.methods_for("Greeter").map(&.name).should contain("new_method")
+
+    # A type defined only in the overlay resolves.
+    query.find_type("Greeter").should_not be_nil
+
+    # Top-level methods: the overlay adds new ones, same-signature base wins.
+    query.top_level_methods.map(&.name).should contain("top_level_new")
+    query.top_level_methods.map(&.name).should contain("top_level_old")
+    shared = query.top_level_methods.find(&.name.==("top_level_shared")).should_not be_nil
+    shared.not_nil!.return_type.should eq("String")
+  end
+
+  it "keeps the base method when the overlay redefinition shares its location" do
+    source = <<-CRYSTAL
+      class Greeter
+        def hello : Int32
+          1
+        end
+      end
+    CRYSTAL
+
+    base = index_from_source(source)
+    overlay = index_from_source(source.gsub(": Int32", ": String"))
+
+    query = Crystalline::Lightweight::Query.new(base, overlay: overlay)
+    hello = query.methods_for("Greeter").find(&.name.==("hello")).should_not be_nil
+    hello.not_nil!.return_type.should eq("Int32")
+  end
+
+  it "resolves types and methods from the secondary index" do
+    base = index_from_source("class Base\nend\n")
+    secondary = index_from_source("class Side\n  def side_method : Int32\n    1\n  end\nend\n")
+
+    query = Crystalline::Lightweight::Query.new(base, secondary: secondary)
+    query.find_type("Side").should_not be_nil
+    query.methods_for("Side").map(&.name).should contain("side_method")
+    query.resolve_type_name("Side").should eq("Side")
+  end
+
+  it "resolves methods through overlay-redefined parent types" do
+    # Parent/child relationships are only recorded by the compiled program
+    # index, so the base index comes from a top-level semantic pass.
+    base = build_lightweight_index(<<-CRYSTAL)
+      class Parent
+        def base_method : Int32
+          1
+        end
+      end
+
+      class Child < Parent
+      end
+    CRYSTAL
+
+    # The leading comment shifts every location by one line, so the
+    # redefined parent methods live at different locations than the base.
+    overlay = index_from_source(<<-CRYSTAL)
+      # overlay
+
+      class Parent
+        def overlay_method : String
+          "o"
+        end
+      end
+    CRYSTAL
+
+    query = Crystalline::Lightweight::Query.new(base, overlay: overlay)
+    names = query.methods_for("Child").map(&.name)
+    names.should contain("base_method")
+    names.should contain("overlay_method")
+  end
+end

--- a/spec/lightweight/seed_cache_spec.cr
+++ b/spec/lightweight/seed_cache_spec.cr
@@ -1,0 +1,69 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/lightweight/query"
+require "../../src/crystalline/lightweight/inference"
+require "../../src/crystalline/lightweight/hover"
+
+private def repo_root : String
+  File.expand_path("../..", __DIR__)
+end
+
+private def prelude_index : Crystalline::Lightweight::Index
+  Crystalline::Lightweight::PreludeIndex.ensure_loaded
+  until (index = Crystalline::Lightweight::PreludeIndex.get)
+    sleep 50.milliseconds
+  end
+  index
+end
+
+# The pre-compile query shape from Workspace#lightweight_query_for: the
+# project's parse-only source index as base, the stdlib prelude underneath,
+# and the per-file overlay on top.
+private def lightweight_query_for_repo_file(rel : String, source : String) : Crystalline::Lightweight::Query
+  path = File.join(repo_root, rel)
+  project = Crystalline::Project.new(URI.parse("file://#{repo_root}"))
+  overlay = Crystalline::Lightweight::Index.from_source(source, path).not_nil!
+  Crystalline::Lightweight::Query.new(project.source_index.not_nil!, secondary: prelude_index, overlay: overlay)
+end
+
+Crystalline::EnvironmentConfig.run
+
+describe Crystalline::Lightweight do
+  # The untyped-arg seed scan is cursor-independent and memoized per def on
+  # the query (commit 3fd5c44): repeated requests on the same buffer must
+  # return IDENTICAL types, for both a directly-typed arg and the
+  # caller-walk (`token`) family.
+  describe "untyped-arg seed cache" do
+    it "returns identical types for cold and cached requests" do
+      source = File.read(File.join(repo_root, "src/crystalline/lightweight/inference.cr"))
+      query = lightweight_query_for_repo_file("src/crystalline/lightweight/inference.cr", source)
+      li = source.lines.index { |l| l.includes?("node.expressions.each") } || raise "seed site line not found"
+
+      types = [] of Array(String)
+      3.times do
+        inference = Crystalline::Lightweight::Inference.for(source, li + 1, 10, query)
+        types << inference.not_nil!.types_for("node").sort
+      end
+
+      types[0].should eq(["Crystal::Expressions"])
+      types[1].should eq(types[0])
+      types[2].should eq(types[0])
+    end
+
+    it "keeps the caller-walk token family resolving through the cache" do
+      source = File.read(File.join(repo_root, "src/crystalline/completion_context.cr"))
+      query = lightweight_query_for_repo_file("src/crystalline/completion_context.cr", source)
+      li = source.lines.index { |l| l.includes?("case token.type") } || raise "token site line not found"
+      col = source.lines[li].index("type").not_nil!
+
+      hov, why = Crystalline::Lightweight::Hover.hover_and_reason(source, li, col, query)
+      hov.should_not be_nil, why
+      hov2, _ = Crystalline::Lightweight::Hover.hover_and_reason(source, li, col, query)
+      hov2.should_not be_nil
+
+      inference = Crystalline::Lightweight::Inference.for(source, li + 1, col + 1, query)
+      inference.not_nil!.types_for("token").should contain("Crystal::Token")
+    end
+  end
+end

--- a/spec/lightweight/summary_spec.cr
+++ b/spec/lightweight/summary_spec.cr
@@ -1,0 +1,196 @@
+require "spec"
+require "../../src/crystalline/requires"
+require "../../src/crystalline/main"
+require "../../src/crystalline/completion_context"
+require "../../src/crystalline/lightweight/completion"
+require "../../src/crystalline/lightweight/summary"
+
+private def build_query_with_summary(source : String)
+  path = File.join(Dir.tempdir, "crystalline-lightweight-summary-#{Random::Secure.hex(8)}.cr")
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+
+    top_level_result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      top_level: true,
+      ignore_diagnostics: true,
+    )
+    raise "expected top-level semantic result" unless top_level_result
+
+    semantic_result = Crystalline::Analysis.compile(
+      server,
+      URI.parse("file://#{path}"),
+      lib_path: File.join(Dir.current, "lib"),
+      ignore_diagnostics: true,
+      wants_doc: true,
+    )
+    raise "expected semantic result" unless semantic_result
+
+    index = Crystalline::Lightweight::Index.from_program(top_level_result.program)
+    summary = Crystalline::Lightweight::Summary.from_result(semantic_result)
+    Crystalline::Lightweight::Query.new(index, summary)
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe Crystalline::Lightweight::Summary do
+  it "derives method contracts from available method summaries" do
+    query = build_query_with_summary <<-CRYSTAL
+      class Greeter
+      end
+
+      class Wrapper
+        def tap
+          self
+        end
+
+        def current
+          Greeter.new
+        end
+
+        def current?
+          Greeter.new || nil
+        end
+      end
+
+      wrapper = Wrapper.new
+      wrapper.tap
+      wrapper.current
+      wrapper.current?
+    CRYSTAL
+
+    tap_contracts = query.method_contracts_for("Wrapper", "tap")
+    tap_contracts.map(&.kind).should contain(Crystalline::Lightweight::MethodContractKind::YieldSelf)
+    tap_contracts.map(&.kind).should contain(Crystalline::Lightweight::MethodContractKind::PreserveReceiver)
+
+    current_contracts = query.method_contracts_for("Wrapper", "current")
+    current_contracts.map(&.kind).should contain(Crystalline::Lightweight::MethodContractKind::ReturnValue)
+
+    current_nilable_contracts = query.method_contracts_for("Wrapper", "current?")
+    current_nilable_contracts.map(&.kind).should contain(Crystalline::Lightweight::MethodContractKind::ReturnValueOrNil)
+  end
+
+  it "captures inferred return types for typed defs" do
+    query = build_query_with_summary <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build
+          Greeter.new
+        end
+      end
+
+      Factory.new.build
+    CRYSTAL
+
+    build_method = query.methods_for("Factory").find(&.name.==("build"))
+    build_method.should_not be_nil
+    build_method.not_nil!.return_type.should eq("Greeter")
+  end
+
+  it "uses semantic summaries to resolve ivar types and inferred receiver chains" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Wrapper
+        def seed
+          @greeter = Greeter.new
+        end
+
+        def build
+          @greeter
+        end
+      end
+
+      wrapper = Wrapper.new
+      wrapper.seed
+      wrapper.build
+    CRYSTAL
+
+    query = build_query_with_summary(source)
+    query.instance_var_types_for("Wrapper", "@greeter").sort.should eq(["Greeter", "Nil"])
+
+    completion_source = source + <<-CRYSTAL
+
+      def demo(wrapper : Wrapper)
+        wrapper.build.sh
+      end
+    CRYSTAL
+
+    lines = completion_source.lines(chomp: false)
+    line_number = lines.index! { |line| line.includes?("wrapper.build.sh") }
+    context = Crystalline::CompletionContext.detect(lines[line_number], lines[line_number].size - 1, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(completion_source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("shout")
+  end
+
+  it "specializes inherited splat generic owners for tuple receivers" do
+    query = build_query_with_summary <<-CRYSTAL
+      def demo
+        tuple_pair = {1, "x"}
+        tuple_pair.each_with_object([] of String) do |item, memo|
+          memo << item.to_s
+        end
+      end
+    CRYSTAL
+
+    each_with_object_method = query.methods_for("Tuple(Int32, String)").find(&.name.==("each_with_object"))
+    each_with_object_method.should_not be_nil
+    each_with_object_method.not_nil!.owner.should eq("Enumerable(Int32 | String)")
+  end
+
+  it "uses semantic summaries for tuple destructuring and try block inference" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class CursorVisitor
+        def process
+          { [Greeter.new], nil }
+        end
+      end
+
+      CursorVisitor.new.process
+    CRYSTAL
+
+    query = build_query_with_summary(source)
+
+    completion_source = source + <<-CRYSTAL
+
+      def demo
+        nodes, context = CursorVisitor.new.process
+        nodes.last?.try { |node| node.sh }
+      end
+    CRYSTAL
+
+    lines = completion_source.lines(chomp: false)
+    line_number = lines.index! { |line| line.includes?("node.sh") }
+    cursor = lines[line_number].index("node.sh").not_nil! + "node.sh".size
+    context = Crystalline::CompletionContext.detect(lines[line_number], cursor, nil)
+    context.should_not be_nil
+
+    items = Crystalline::Lightweight::Completion.complete(completion_source, line_number, context.not_nil!, query)
+    items.should_not be_nil
+    items.not_nil!.map(&.insert_text).compact.should contain("shout")
+  end
+end

--- a/spec/position_utils_spec.cr
+++ b/spec/position_utils_spec.cr
@@ -1,0 +1,36 @@
+require "spec"
+require "../src/crystalline/position_utils"
+
+# "aé😀bc": a = 1 code unit, é = 1, 😀 (astral) = 2, b = 1, c = 1.
+LINE = "aé😀bc"
+
+describe Crystalline::PositionUtils do
+  describe ".utf16_to_char_index" do
+    it "is the identity on ascii lines" do
+      Crystalline::PositionUtils.utf16_to_char_index("abc", 2).should eq(2)
+    end
+
+    it "maps bmp characters one-to-one" do
+      Crystalline::PositionUtils.utf16_to_char_index(LINE, 2).should eq(2)
+    end
+
+    it "accounts for astral characters" do
+      Crystalline::PositionUtils.utf16_to_char_index(LINE, 4).should eq(3)
+    end
+
+    it "clamps past the end of the line" do
+      Crystalline::PositionUtils.utf16_to_char_index(LINE, 99).should eq(5)
+    end
+  end
+
+  describe ".char_to_utf16_index" do
+    it "is the identity on ascii lines" do
+      Crystalline::PositionUtils.char_to_utf16_index("abc", 2).should eq(2)
+    end
+
+    it "accounts for astral characters" do
+      Crystalline::PositionUtils.char_to_utf16_index(LINE, 3).should eq(4)
+      Crystalline::PositionUtils.char_to_utf16_index(LINE, 5).should eq(6)
+    end
+  end
+end

--- a/spec/project_spec.cr
+++ b/spec/project_spec.cr
@@ -1,0 +1,29 @@
+require "spec"
+require "file_utils"
+require "../src/crystalline/project"
+
+describe Crystalline::Project do
+  it "does not match unrelated files once dependencies are known" do
+    root = File.join(Dir.tempdir, "crystalline-project-spec-#{Random::Secure.hex(8)}")
+    begin
+      Dir.mkdir_p(root)
+      project = Crystalline::Project.new(URI.parse("file://#{root}"))
+      dependency_path = File.join(root, "src", "main.cr")
+      unrelated_path = File.join(root, "scratch.cr")
+      Dir.mkdir_p(File.dirname(dependency_path))
+      File.write(dependency_path, "")
+      File.write(unrelated_path, "")
+
+      project.dependencies << dependency_path
+
+      Crystalline::Project.best_fit_for_file([project], URI.parse("file://#{dependency_path}")).should eq(project)
+      Crystalline::Project.best_fit_for_file([project], URI.parse("file://#{unrelated_path}")).should be_nil
+
+      # Lightweight queries may opt into a pure path-based fit.
+      Crystalline::Project.best_fit_for_file([project], URI.parse("file://#{unrelated_path}"), require_dependency: false).should eq(project)
+      Crystalline::Project.best_fit_for_file([project], URI.parse("file://#{dependency_path}"), require_dependency: false).should eq(project)
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+end

--- a/spec/source_mask_spec.cr
+++ b/spec/source_mask_spec.cr
@@ -1,0 +1,40 @@
+require "spec"
+require "../src/crystalline/source_mask"
+
+describe Crystalline::SourceMask do
+  it "masks comments" do
+    mask = Crystalline::SourceMask.new("x = 1 # the end\n")
+    mask.comment_or_string?(0, 6).should be_true
+    mask.comment_or_string?(0, 4).should be_false
+  end
+
+  it "masks string and char literals but not surrounding code" do
+    source = %(x = "foo" + 'c' + "bar"\n)
+    mask = Crystalline::SourceMask.new(source)
+    mask.comment_or_string?(0, 5).should be_true  # inside "foo"
+    mask.comment_or_string?(0, 13).should be_true # inside 'c'
+    mask.comment_or_string?(0, 20).should be_true # inside "bar"
+    mask.comment_or_string?(0, 2).should be_false # code
+  end
+
+  it "masks heredoc bodies until the terminator" do
+    source = <<-SRC
+      def demo
+        text = <<-CRYSTAL
+      hello world
+        CRYSTAL
+        text
+      end
+    SRC
+    mask = Crystalline::SourceMask.new(source)
+    mask.comment_or_string?(2, 0).should be_true # heredoc body
+    mask.comment_or_string?(2, 6).should be_true
+    mask.comment_or_string?(3, 0).should be_false # terminator line
+    mask.comment_or_string?(4, 4).should be_false # code after
+  end
+
+  it "does not mistake shift-left expressions for heredocs" do
+    mask = Crystalline::SourceMask.new("x << y\nz = 1\n")
+    mask.comment_or_string?(1, 0).should be_false
+  end
+end

--- a/spec/text_document_spec.cr
+++ b/spec/text_document_spec.cr
@@ -80,4 +80,23 @@ describe Crystalline::TextDocument do
     document.contents.should eq("zap\n")
     document.version.should eq(5)
   end
+
+  it "tracks dirty state across edits and saves" do
+    document = doc("foo\n")
+
+    document.dirty?.should be_false
+
+    document.update_contents([
+      {"bar", LSP::Range.new(
+        start: LSP::Position.new(line: 0, character: 0),
+        end: LSP::Position.new(line: 0, character: 3),
+      )},
+    ], version: 1)
+
+    document.dirty?.should be_true
+
+    document.mark_saved
+
+    document.dirty?.should be_false
+  end
 end

--- a/spec/workspace_interactive_spec.cr
+++ b/spec/workspace_interactive_spec.cr
@@ -1,0 +1,755 @@
+require "spec"
+require "file_utils"
+require "../src/crystalline/requires"
+require "../src/crystalline/main"
+
+private def with_workspace_document(source : String, &)
+  root = File.join(Dir.tempdir, "crystalline-workspace-interactive-#{Random::Secure.hex(8)}")
+  Dir.mkdir_p(root)
+  path = File.join(root, "src", "main.cr")
+  Dir.mkdir_p(File.dirname(path))
+  File.write(File.join(root, "shard.yml"), <<-YAML)
+    name: workspace_interactive
+    targets:
+      workspace_interactive:
+        main: src/main.cr
+  YAML
+  File.write(path, source)
+
+  begin
+    Crystalline::EnvironmentConfig.run
+    server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+    workspace = Crystalline::Workspace.new(server, "file://#{root}")
+    uri = URI.parse("file://#{path}")
+    workspace.opened_documents[uri.to_s] = Crystalline::TextDocument.new(uri, workspace.projects.first?, source)
+    yield server, workspace, uri
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+class Crystalline::Workspace
+  def send_lightweight_query_for_test(document : Crystalline::TextDocument)
+    lightweight_query_for(document)
+  end
+
+  def semantic_cache_has_key?(key : String) : Bool
+    @semantic_cache.has_key?(key)
+  end
+
+  def seed_semantic_result(key : String, result : Crystal::Compiler::Result)
+    @semantic_cache[key] = result
+  end
+
+  def seed_compiled_source_mtime(path : String, time : Time)
+    @compiled_source_mtimes[path] = time
+  end
+
+  def seed_result_cache(key : String, result : Crystal::Compiler::Result?)
+    @result_cache.set(key, result)
+  end
+
+  def result_cache_invalidated?(key : String) : Bool
+    @result_cache.invalidated?(key)
+  end
+end
+
+module Crystalline::Analysis
+  def self.stdlib_llvm_error_for_test?(e : Crystal::CodeError)
+    stdlib_llvm_error?(e)
+  end
+end
+
+private def mark_workspace_document_dirty(document : Crystalline::TextDocument, contents : String, version : Int32 = 1)
+  document.update_contents([{contents, nil}], version: version)
+end
+
+describe Crystalline::Workspace do
+  it "does not compile unsupported completion requests without a semantic cache" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build(name : String) : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo(factory : Factory)
+        factory.build("hi").unknown.sh
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("factory.build(\"hi\").unknown.sh") }
+      position = LSP::Position.new(line: line_number, character: lines[line_number].size - 1)
+
+      workspace.completion(server, uri, position, nil).should be_nil
+    end
+  end
+
+  it "does not compile unsupported hover requests without a semantic cache" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      class Factory
+        def build(name : String) : Greeter
+          Greeter.new
+        end
+      end
+
+      def demo(factory : Factory)
+        factory.build("hi").unknown.shout
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("factory.build(\"hi\").unknown.shout") }
+      character = lines[line_number].rindex("shout").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      workspace.hover(server, uri, position).should be_nil
+    end
+  end
+
+  it "uses lightweight definitions without a semantic cache" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(greeter : Greeter)
+        greeter.shout
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("greeter.shout") }
+      character = lines[line_number].rindex("shout").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      definitions = workspace.definitions(server, uri, position)
+      definitions.should_not be_nil
+      definitions.not_nil!.size.should be > 0
+    end
+  end
+
+  it "completes methods of project types before the first compile" do
+    source = <<-CRYSTAL
+      def demo
+        helper = LocalHelper.new
+        helper.
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      # A second project file that is only ever parsed, never compiled.
+      root = workspace.projects.first?.not_nil!.root_uri.decoded_path
+      File.write(Path[root, "src", "helper.cr"], <<-CRYSTAL)
+        class LocalHelper
+          def shout : String
+            "!"
+          end
+        end
+      CRYSTAL
+
+      position = LSP::Position.new(line: 2, character: 15)
+      items = workspace.completion(server, uri, position, nil)
+      items.should_not be_nil
+      items.not_nil!.items.map(&.insert_text).compact.should contain("shout")
+    end
+  end
+
+  it "does not use stale semantic cache for dirty buffers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo(greeter : Greeter)
+        greeter.shout
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      workspace.seed_semantic_result(project.entry_point?.not_nil!.to_s, result.not_nil!)
+
+      workspace.opened_documents[uri.to_s].not_nil!.update_contents([
+        {"sh", LSP::Range.new(
+          start: LSP::Position.new(line: 6, character: 16),
+          end: LSP::Position.new(line: 6, character: 21),
+        )},
+      ], version: 1)
+
+      position = LSP::Position.new(line: 6, character: 18)
+      workspace.hover(server, uri, position).should be_nil
+      workspace.definitions(server, uri, position).should be_nil
+      # Completion resolves the dirty buffer through the lightweight engine
+      # (the "h" fragment matches nothing in the buffer's `gsh` parameter),
+      # instead of falling back to the stale semantic cache.
+      completion = workspace.completion(server, uri, position, nil).should_not be_nil
+      completion.as(LSP::CompletionList).items.should be_empty
+    end
+  end
+
+  it "uses summary-backed lightweight hover on dirty generic receiver chains" do
+    source = <<-CRYSTAL
+      def demo
+        reply_channel = Channel(String).new
+        reply_channel.receive.upcase
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("reply_channel.receive.upcase") }
+      character = lines[line_number].rindex("upcase").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("String#upcase")
+    end
+  end
+
+  it "uses current-source lightweight overlays for dirty file method hovers" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter.shout
+      end
+    CRYSTAL
+
+    dirty_source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+
+        def whisper : String
+          "."
+        end
+      end
+
+      def demo
+        greeter = Greeter.new
+        greeter.whisper
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, dirty_source)
+
+      lines = dirty_source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("greeter.whisper") }
+      character = lines[line_number].rindex("whisper").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("Greeter#whisper() : String")
+    end
+  end
+
+  it "uses dirty-buffer hover for relative namespace tuple and try chains" do
+    source = <<-CRYSTAL
+      module Outer
+        class Visitor
+          def process : Tuple(Array(String), Hash(String, Tuple(String | Nil, Int32 | Nil)))
+            {["hello"], {"key" => {nil, 1}}}
+          end
+        end
+
+        def self.demo
+          nodes, context = Visitor.new.process
+          nodes.last?.try do |node|
+            node.upcase
+          end
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("node.upcase") }
+      character = lines[line_number].rindex("upcase").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("String#upcase")
+    end
+  end
+
+  it "uses dirty-buffer hover through is_a? and conditional-assignment helper chains" do
+    source = <<-CRYSTAL
+      module Outer
+        class Location
+          def expanded_location : String
+            "x"
+          end
+        end
+
+        class Item
+          def location : Outer::Location | Nil
+            Outer::Location.new
+          end
+        end
+
+        class Node
+          def target_defs : Array(Outer::Item) | Nil
+            [Outer::Item.new]
+          end
+        end
+
+        def self.demo(node : Outer::Node | String)
+          if node.is_a?(Outer::Node)
+            if (defs = node.target_defs)
+              defs.compact_map do |d|
+                d.location.try do |loc|
+                  loc.expanded_location.upcase
+                end
+              end
+            end
+          end
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("loc.expanded_location.upcase") }
+      character = lines[line_number].rindex("upcase").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("String#upcase")
+    end
+  end
+
+  it "uses dirty-buffer hover inside exception-handler bodies" do
+    source = <<-CRYSTAL
+      def demo
+        reply_channel = Channel(String).new
+
+        begin
+          reply_channel.receive.upcase
+        rescue error : Exception
+          error.message
+        ensure
+          1
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("reply_channel.receive.upcase") }
+      character = lines[line_number].rindex("receive").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("Channel(String)#receive()")
+    end
+  end
+
+  it "uses dirty-buffer hover inside assigned begin-style value bodies" do
+    source = <<-CRYSTAL
+      def demo(items : Array(String))
+        value = begin
+          items.each do |item|
+            item.upcase
+          end
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      project.semantic_summary = Crystalline::Lightweight::Summary.from_result(result.not_nil!)
+
+      mark_workspace_document_dirty(workspace.opened_documents[uri.to_s].not_nil!, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("item.upcase") }
+      character = lines[line_number].rindex("upcase").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+      hover.not_nil!.contents.as(LSP::MarkupContent).value.should contain("String#upcase")
+    end
+  end
+
+  it "gives non-dependency files lightweight project context" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      workspace.recalculate_dependencies(server, project)
+
+      # A second file inside the project root that the entry point does not
+      # require: it must still resolve project types in lightweight queries.
+      scratch_path = File.join(File.dirname(uri.decoded_path), "scratch.cr")
+      scratch_uri = URI.parse("file://#{scratch_path}")
+      scratch_document = Crystalline::TextDocument.new(scratch_uri, nil, "greeter = Greeter.new\ngreeter.shout\n")
+      workspace.opened_documents[scratch_uri.to_s] = scratch_document
+
+      query = workspace.send_lightweight_query_for_test(scratch_document).should_not be_nil
+      query.not_nil!.find_type("Greeter").should_not be_nil
+    end
+  end
+
+  it "returns an empty list for resolved-but-empty lightweight completions" do
+    source = <<-CRYSTAL
+      class Greeter
+        def demo
+          @zzz
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      document = workspace.opened_documents[uri.to_s].not_nil!
+      mark_workspace_document_dirty(document, source)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("@zzz") }
+      character = lines[line_number].size - 1
+      position = LSP::Position.new(line: line_number, character: character)
+
+      # The engine resolves the request but finds no matching ivars: the
+      # client must get a real (empty) list, not a fallthrough to nil.
+      result = workspace.completion(server, uri, position, "@")
+      result.should_not be_nil
+      result = result.as(LSP::CompletionList)
+      result.items.should be_empty
+      result.is_incomplete.should be_false
+    end
+  end
+
+  it "exposes lightweight miss reasons for dirty-buffer interactive requests" do
+    # The prelude (stdlib surface) loads asynchronously once in the
+    # process: load it deterministically so this spec behaves the same
+    # whether it runs first or after the lightweight suite.
+    Crystalline::Lightweight::PreludeIndex.ensure_loaded
+    until Crystalline::Lightweight::PreludeIndex.get
+      sleep 50.milliseconds
+    end
+
+    source = <<-CRYSTAL
+      def demo(items : Array(String))
+        items.unknown_method
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |_server, workspace, uri|
+      workspace.opened_documents[uri.to_s].not_nil!.update_contents([{source, nil}], version: 1)
+      fixed_source = workspace.opened_documents[uri.to_s].not_nil!.contents
+      lines = fixed_source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("items.unknown_method") }
+      character = lines[line_number].rindex("unknown_method").not_nil! + 2
+      completion_context = Crystalline::CompletionContext.detect(lines[line_number], character, ".").not_nil!
+      query = workspace.send_lightweight_query_for_test(workspace.opened_documents[uri.to_s].not_nil!).not_nil!
+
+      Crystalline::Lightweight::Hover.diagnose(fixed_source, line_number, character, query).should contain("no lightweight method hover")
+      Crystalline::Lightweight::Definitions.diagnose(fixed_source, uri, line_number, character, query).should contain("no lightweight method definitions")
+      # With the prelude layered under the project source, `items` (an
+      # `Array(String)`) resolves to the full stdlib method list: the
+      # completion itself is not a miss, only the unknown method is.
+      Crystalline::Lightweight::Completion.diagnose(fixed_source, line_number, completion_context, query).should contain("resolved")
+    end
+  end
+
+  it "rebuilds lightweight queries when the document changes" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      workspace.recalculate_dependencies(server, workspace.projects.first?.not_nil!)
+
+      document = workspace.opened_documents[uri.to_s].not_nil!
+      first_query = workspace.send_lightweight_query_for_test(document).not_nil!
+
+      # A second request with the same contents is served from the cache.
+      workspace.send_lightweight_query_for_test(document).should be(first_query)
+
+      document.update_contents([{source.sub("def shout", "def shouter"), nil}], version: 1)
+
+      # After the change the query is rebuilt from the new buffer.
+      workspace.send_lightweight_query_for_test(document).should_not be(first_query)
+    end
+  end
+
+  it "filters error-tolerant artifacts from the stdlib llvm wrapper" do
+    llvm_error = Crystal::TypeException.new(
+      "bogus conversion",
+      Crystal::Location.new("/home/linuxbrew/.linuxbrew/Cellar/crystal/1.21.0/share/crystal/src/llvm/di_builder.cr", 99, 13),
+    )
+    user_error = Crystal::TypeException.new(
+      "real error",
+      Crystal::Location.new("/home/user/project/src/main.cr", 1, 1),
+    )
+
+    Crystalline::Analysis.stdlib_llvm_error_for_test?(llvm_error).should be_true
+    Crystalline::Analysis.stdlib_llvm_error_for_test?(user_error).should be_false
+  end
+
+  it "invalidates the result cache on save even when dependency lookup no longer matches" do
+    source = <<-CRYSTAL
+      class Greeter
+        def shout : String
+          "!"
+        end
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      entry_point = project.entry_point?.not_nil!
+      result = Crystalline::Analysis.compile(
+        server,
+        entry_point,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+
+      workspace.seed_result_cache(entry_point.to_s, result)
+      workspace.seed_semantic_result(entry_point.to_s, result.not_nil!)
+      workspace.result_cache_invalidated?(entry_point.to_s).should be_false
+      workspace.semantic_cache_has_key?(entry_point.to_s).should be_true
+
+      project.dependencies = Set{entry_point.decoded_path}
+
+      workspace.save_document(
+        server,
+        LSP::DidSaveTextDocumentParams.new(
+          text_document: LSP::TextDocumentIdentifier.new(uri: uri.to_s),
+        ),
+      )
+
+      workspace.result_cache_invalidated?(entry_point.to_s).should be_true
+      # The semantic cache is deliberately kept across edits (it is guarded
+      # by the compiled-source freshness check instead).
+      workspace.semantic_cache_has_key?(entry_point.to_s).should be_true
+    end
+  end
+
+  it "keeps serving the last successful compile for clean buffers after an edit" do
+    source = <<-CRYSTAL
+      def demo(message : LSP::NotificationMessage)
+        message.params
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      workspace.seed_semantic_result(project.entry_point?.not_nil!.to_s, result.not_nil!)
+
+      # Edit the buffer, then save it: the buffer is clean again and the
+      # last successful compile must still serve the fallback.
+      workspace.update_document(
+        server,
+        LSP::DidChangeTextDocumentParams.new(
+          text_document: LSP::VersionedTextDocumentIdentifier.new(uri: uri.to_s, version: 2),
+          content_changes: [
+            LSP::DidChangeTextDocumentParams::TextDocumentContentChangeEvent.new(
+              range: LSP::Range.new(
+                start: LSP::Position.new(line: 1, character: 4),
+                end: LSP::Position.new(line: 1, character: 4),
+              ),
+              text: " ",
+            ),
+          ],
+        ),
+      )
+      workspace.save_document(
+        server,
+        LSP::DidSaveTextDocumentParams.new(
+          text_document: LSP::TextDocumentIdentifier.new(uri: uri.to_s),
+        ),
+      )
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("message.params") }
+      character = lines[line_number].rindex("params").not_nil! + 2
+      hover = workspace.hover(server, uri, LSP::Position.new(line: line_number, character: character))
+      hover.should_not be_nil
+    end
+  end
+
+  it "does not serve the semantic cache for files changed on disk after the compile" do
+    source = <<-CRYSTAL
+      def demo(message : LSP::NotificationMessage)
+        message.params
+      end
+    CRYSTAL
+
+    with_workspace_document(source) do |server, workspace, uri|
+      project = workspace.projects.first?.not_nil!
+      result = Crystalline::Analysis.compile(
+        server,
+        uri,
+        lib_path: project.default_lib_path,
+        ignore_diagnostics: true,
+        wants_doc: true,
+        compiler_flags: project.flags,
+      )
+      result.should_not be_nil
+      workspace.seed_semantic_result(project.entry_point?.not_nil!.to_s, result.not_nil!)
+      workspace.seed_compiled_source_mtime(uri.decoded_path, File.info(uri.decoded_path).modification_time)
+
+      lines = source.lines(chomp: false)
+      line_number = lines.index! { |line| line.includes?("message.params") }
+      character = lines[line_number].rindex("params").not_nil! + 2
+      position = LSP::Position.new(line: line_number, character: character)
+
+      hover = workspace.hover(server, uri, position)
+      hover.should_not be_nil
+
+      # The file changes on disk without a compile: the stale cache must
+      # refuse to serve it.
+      File.touch(uri.decoded_path)
+      workspace.hover(server, uri, position).should be_nil
+    end
+  end
+end

--- a/src/crystalline/analysis/analysis.cr
+++ b/src/crystalline/analysis/analysis.cr
@@ -3,29 +3,59 @@ require "./cursor_visitor"
 require "./submodule_visitor"
 
 module Crystalline::Analysis
-  {% if flag?(:preview_mt) %}
+  {% if Fiber.has_constant?(:ExecutionContext) %}
+    # New execution-contexts runtime (Crystal >= 1.21): run compilation fibers on a
+    # dedicated single-worker parallel context, so compiles never block the LSP
+    # event loop (the main context is single-threaded by default).
+    @@compile_context : Fiber::ExecutionContext::Parallel = Fiber::ExecutionContext::Parallel.new("crystalline-compile", 1)
+
+    private def self.spawn_dedicated(*, name : String? = nil, &block)
+      @@compile_context.spawn(name: name, &block)
+    end
+  {% elsif flag?(:preview_mt) %}
+    # Legacy multithreading runtime: pin compilation fibers to a dedicated thread.
     @@dedicated_thread : Thread = Thread.new(name: "crystalline-dedicated-thread") do
       scheduler = Thread.current.scheduler
       scheduler.run_loop
     end
+
+    private def self.spawn_dedicated(*, name : String? = nil, &block)
+      fiber = Fiber.new(name, &block)
+      fiber.set_current_thread(@@dedicated_thread)
+      fiber.enqueue
+      fiber
+    end
+  {% else %}
+    # Single-threaded runtime: spawn on the current context.
+    private def self.spawn_dedicated(*, name : String? = nil, &block)
+      Fiber.new(name, &block).enqueue
+    end
   {% end %}
 
-  private def self.spawn_dedicated(*, name : String? = nil, &block)
-    fiber = Fiber.new(name, &block)
-    {% if flag?(:preview_mt) %} fiber.set_current_thread(@@dedicated_thread) {% end %}
-    fiber.enqueue
-    fiber
+  # Runs *block* on the dedicated compile context and waits for its result.
+  # Keeps CPU-heavy work (compiles, index/summary builds) off the LSP event
+  # loop whenever the runtime provides a parallel context.
+  def self.run_dedicated(&block : -> T) : T forall T
+    reply_channel = Channel(T | Exception).new
+    spawn_dedicated do
+      reply_channel.send(block.call)
+    rescue e : Exception
+      reply_channel.send(e)
+    end
+    result = reply_channel.receive
+    raise result if result.is_a?(Exception)
+    result
   end
 
   # Compile a target *file_uri*.
-  def self.compile(server : LSP::Server, file_uri : URI, *, lib_path : String? = nil, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false, compiler_flags : Array(String) = [] of String)
+  def self.compile(server : LSP::Server, file_uri : URI, *, lib_path : String? = nil, file_overrides : Hash(String, String)? = nil, ignore_diagnostics = false, wants_doc = false, fail_fast = false, top_level = false, compiler_flags : Array(String) = [] of String) : Crystal::Compiler::Result?
     if file_uri.scheme == "file"
       file = File.new file_uri.decoded_path
       sources = [
         Crystal::Compiler::Source.new(file_uri.decoded_path, file.gets_to_end),
       ]
       file.close
-      self.compile(server, sources, lib_path: lib_path, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level, compiler_flags: compiler_flags)
+      self.compile(server, sources, lib_path: lib_path, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, fail_fast: fail_fast, top_level: top_level, compiler_flags: compiler_flags)
     end
   end
 
@@ -85,7 +115,13 @@ module Crystalline::Analysis
       end
 
       result.program.error_stack.try &.each do |e|
-        diagnostics.append_from_exception(e) if e.is_a?(Crystal::TypeException) || e.is_a?(Crystal::SyntaxException)
+        next unless e.is_a?(Crystal::TypeException) || e.is_a?(Crystal::SyntaxException)
+        # The error-tolerant semantic can emit bogus errors inside the stdlib's
+        # llvm wrapper (e.g. Bool-to-Int32 conversions that a regular compile
+        # never reports, see di_builder.cr). Real user-facing errors surface at
+        # the user's call site instead, so these are safe to skip.
+        next if stdlib_llvm_error?(e)
+        diagnostics.append_from_exception(e)
       end
     end
 
@@ -101,6 +137,17 @@ module Crystalline::Analysis
   ensure
     # Propagate diagnostics to the client.
     diagnostics.try &.publish(server) unless ignore_diagnostics
+  end
+
+  # True when the error is located inside the stdlib's llvm wrapper, where the
+  # error-tolerant semantic can report errors a regular compile never does.
+  private def self.stdlib_llvm_error?(e : Crystal::CodeError) : Bool
+    return false unless e.is_a?(Crystal::TypeException)
+
+    filename = e.filename
+    return false unless filename
+
+    filename.to_s.includes?("/src/llvm/") || filename.to_s.includes?("\\src\\llvm\\")
   end
 
   # Return the node at the given *location*.

--- a/src/crystalline/broken_source_fixer.cr
+++ b/src/crystalline/broken_source_fixer.cr
@@ -9,18 +9,128 @@ class Crystalline::BrokenSourceFixer
   # Try to fix a broken source code by adding missing "end" and "}"
   # according to indentation.
   def self.fix(source : String) : String
+    # A trailing dot (mid-typing `foo.`) is a syntax error the parser cannot
+    # recover from: append a placeholder identifier so the rest of the source
+    # still parses (and completion on the receiver keeps working).
+    lines = source.lines.map do |line|
+      # A trailing dot inside a comment is sentence punctuation, not a
+      # method-call receiver: never append the placeholder there.
+      if !line.lstrip.starts_with?("#") && (dot_index = trailing_dot_index(line))
+        # The truncation deleted the line's tail, which may have held the
+        # closing delimiters of calls opened before the dot: re-close them
+        # right after the placeholder so the rest of the file still parses.
+        closers = missing_closers(line[0...dot_index])
+        # A cut inside the true-branch of a ternary (`cond ? foo.`) deleted
+        # the else branch: supply `: nil` or the parser stops at the next
+        # `end` expecting the ternary's `:`.
+        ternary = ternary_else_suffix(line[0...dot_index])
+        "#{line[0...dot_index + 1]}placeholder#{closers}#{ternary}#{line[dot_index + 1..]}#{line.ends_with?('\n') ? '\n' : ""}"
+      elsif !line.lstrip.starts_with?("#") && (sigil_match = line.match(/@+$/))
+        # A lone sigil (`@` or `@@`) mid-edit is the same kind of error:
+        # give it a placeholder name so the rest of the source parses.
+        "#{line[0...sigil_match.begin(0)]}#{sigil_match[0]}placeholder#{line.ends_with?('\n') ? '\n' : ""}"
+      elsif !line.lstrip.starts_with?("#") && (colon_match = line.match(/::$/))
+        # A trailing `::` (e.g. `when Severity::` mid-edit) needs a CONST
+        # name after it before the source parses.
+        "#{line[0...colon_match.begin(0)]}::Placeholder#{line.ends_with?('\n') ? '\n' : ""}"
+      else
+        line
+      end
+    end
+
+    fixed = lines.join("\n")
+    return fixed if parses?(fixed)
+
+    # A trailing-dot cut can land inside a call opened on an EARLIER line
+    # (`Location.new(\n  file_uri.`): the delimiters opened before the cut
+    # are re-closed right after the placeholder, and the call's orphaned
+    # remainder (its remaining argument lines and closing delimiter) is
+    # dropped so the rest of the file still parses.
+    if fix_multiline_call_tails!(lines)
+      fixed = lines.join("\n")
+      return fixed if parses?(fixed)
+    end
+
+    # A trailing-dot cut can delete a `do`-block header (`tokens.each do
+    # |x|` -> `tokens.`): the block body and its `end` dangle below with
+    # no opener. When the lines below form a self-contained block body
+    # (a bare `end` at the cut's indent within a bounded window, nothing
+    # shallower in between), re-open the block with `do` so the body's
+    # own `end` closes it. Parse-guarded on a copy: a candidate that
+    # does not parse leaves the lines untouched for the balance pass.
+    if fix_block_tails!(lines)
+      fixed = lines.join("\n")
+      return fixed if parses?(fixed)
+    end
+
+    # The indentation-balancing pass is a last resort: it can make a broken
+    # file worse (e.g. appending closers to unrelated lines). Only apply it
+    # when the line fixes were not enough, and fall back to the line-fixed
+    # version if the balanced output still does not parse.
+    balanced = lines.dup
+    balance!(balanced)
+    fixed = balanced.join("\n")
+    return fixed if parses?(fixed)
+
+    # Mid-edit truncations can leave unterminated calls (`foo.bar(` with
+    # the closing paren deleted): append the missing closing delimiters
+    # at the end of the file so the rest parses.
+    delimiter_fixed = balance_delimiters(fixed)
+    return delimiter_fixed if parses?(delimiter_fixed)
+
+    lines.join("\n")
+  end
+
+  private def self.parses?(source : String) : Bool
+    Crystal::Parser.parse(source)
+    true
+  rescue
+    false
+  end
+
+  private def self.balance!(lines : Array(String))
     # Keep a stack of opening keywords.
     # We push to the stack when we find an opening keyword and
     # we pop from the stack when we find a closing keyword,
     # or when we find a wrong indentation.
     stack = [] of LineInfo
-
-    lines = source.lines
-    lines.each_with_index do |line, line_index|
-      next if line.blank?
+    line_index = 0
+    while line_index < lines.size
+      line = lines[line_index]
+      if line.blank? || line.lstrip.starts_with?('#') || line.lstrip.starts_with?("{%")
+        # Blank lines, comment-only lines (can contain any text, e.g.
+        # "the end") and macro lines (`{% if ... %}` / `{% end %}` carry
+        # their own structure) are never interpreted as keywords.
+        line_index += 1
+        next
+      end
 
       keyword = line_keyword(line)
       indent = line_indent(line)
+      # A blank line before the current line signals a visual dedent: the
+      # user left the block (without typing `end`).
+      was_blank_gap = line_index > 0 && lines[line_index - 1].blank?
+
+      # A line can both close a block and open a new one
+      # (`}.try do |x|`, `end.each do |x|`): line_keyword reports only the
+      # trailing opener, so the leading closer would be lost and the block
+      # it closes would leak until a wrong-indent `; end` append corrupts
+      # the line below. Close the leading closer first.
+      if (keyword == "do" || keyword == "{") && (stripped = line.lstrip)
+        if stripped.starts_with?('}')
+          if last_info = stack.last?
+            if last_info.keyword == "{"
+              stack.pop
+            elsif brace_index = stack.rindex { |info| info.keyword == "{" }
+              stack.pop(stack.size - brace_index)
+            end
+          end
+        elsif stripped.starts_with?("end") && (stripped.size == 3 || !stripped[3].ascii_alphanumeric?)
+          if last_info = stack.last?
+            stack.pop if last_info.keyword != "{"
+          end
+        end
+      end
 
       while true
         last_info = stack.last?
@@ -29,7 +139,7 @@ class Crystalline::BrokenSourceFixer
         closing_keyword = closing_keyword(last_info)
 
         # Nothing to fix unless there's a wrong indent
-        break unless wrong_indent?(indent, keyword, closing_keyword, last_info, line)
+        break unless wrong_indent?(indent, keyword, closing_keyword, last_info, line, was_blank_gap)
 
         # We have a wrong indentation so we fix/close the opening keyword
         # by adding an "end" (or "}") to it.
@@ -47,12 +157,48 @@ class Crystalline::BrokenSourceFixer
         stack.pop
       end
 
-      # If we found an "end" at exactly the indentation of the last
-      # opening keyword, remove it from the stack.
-      if last_info && indent == last_info.indent && keyword == closing_keyword(last_info)
-        # all good: an end is closing an opening keyword
-        stack.pop
-        next
+      # If we found a closing keyword matching the last opening keyword,
+      # pop it. A mid-edit can leave an `end` with no opener (e.g. after
+      # deleting a `do |x|` block header): treat it as closing the nearest
+      # matching opener anyway so the rest of the file still parses.
+      if last_info = stack.last?
+        if keyword == "}" && last_info.keyword != "{"
+          # A `}` closes the nearest `{` opener even when inner openers
+          # sit above it (they are implicitly closed by the block's end):
+          # pop everything down to and including the `{`.
+          if brace_index = stack.rindex { |info| info.keyword == "{" }
+            stack.pop(stack.size - brace_index)
+            line_index += 1
+            next
+          end
+        end
+
+        if keyword == closing_keyword(last_info)
+          if indent > last_info.indent + 1
+            # A much deeper `end` is a legit closer aligned with its
+            # branches (`value = if cond\n  a\nelse\n  b\nend` ends deeper
+            # than the `if`): close the opener normally.
+            stack.pop
+          elsif indent > last_info.indent && keyword == "end"
+            # An `end` one level deeper than its opener is an orphan left
+            # behind by a deleted block header: drop the line (without
+            # closing the opener) so the file still parses. A `}` one level
+            # deeper is the normal closing style and is never dropped. The
+            # deletion shifts every later line: keep the stack's stored
+            # indices in sync, and re-examine the line that shifted into
+            # this slot (it may be the enclosing block's real `end`, which
+            # an each_with_index loop would silently skip).
+            lines.delete_at(line_index)
+            stack.map! do |info|
+              info.line_index > line_index ? LineInfo.new(info.line_index - 1, info.indent, info.keyword) : info
+            end
+            next
+          else
+            stack.pop
+          end
+          line_index += 1
+          next
+        end
       end
 
       # Push to the stack if we found an opening keyword.
@@ -63,13 +209,544 @@ class Crystalline::BrokenSourceFixer
           keyword: keyword
         )
       end
+      line_index += 1
     end
 
     while (line_info = stack.pop?)
       lines[-1] = "#{lines[-1]}; #{closing_keyword(line_info)}"
     end
+  end
 
-    lines.join("\n")
+  # The closing delimiters missing from *source*: `(`/`[`/`{` opened
+  # without their match (strings, chars and comments are skipped; the
+  # callers guard with a parse check, so a miscount simply falls back).
+  private def self.missing_closers(source : String) : String
+    openers = [] of Char
+    quote = nil.as(Char?)
+    prev = nil.as(Char?)
+    chars = source.chars
+    index = 0
+    while index < chars.size
+      char = chars[index]
+      if quote
+        if char == '\\'
+          index += 2
+          next
+        elsif char == quote
+          quote = nil
+        end
+      elsif char.in?('"', '\'')
+        quote = char
+      elsif char == '/' && regex_position?(prev)
+        # A regex literal: skip to its unescaped closing slash (a slash
+        # inside a `[...]` character class does not close it), so parens
+        # inside regexes (e.g. `\.try\s*(?:\(\s*)?`) are not counted.
+        index += 1
+        in_class = false
+        while index < chars.size
+          c = chars[index]
+          if c == '\\'
+            index += 2
+            next
+          elsif c == '['
+            in_class = true
+          elsif c == ']'
+            in_class = false
+          elsif c == '/' && !in_class
+            break
+          end
+          index += 1
+        end
+      elsif char == '#'
+        index += 1
+        while index < chars.size && chars[index] != '\n'
+          index += 1
+        end
+        next
+      elsif char.in?('(', '[', '{')
+        openers << char
+      elsif char.in?(')', ']', '}')
+        if openers.last? == delimiter_counterpart(char)
+          openers.pop
+        end
+      end
+      prev = char unless char.whitespace? || quote
+      index += 1
+    end
+    openers.reverse.map { |opener| delimiter_counterpart(opener) }.join
+  end
+
+  # Whether the cut prefix ends inside the true-branch of an unclosed
+  # ternary (`cond ? receiver`): ` ? ` (a `?` preceded by whitespace or
+  # an opener and followed by whitespace — not a `foo?` method name, a
+  # `String?` nilable type or a `?a` char literal) with no `:` else
+  # branch after it on the line. Returns the ` : nil` suffix to supply,
+  # or an empty string when the ternary is complete or absent.
+  private def self.ternary_else_suffix(prefix : String) : String
+    last_ternary = -1
+    quote = nil.as(Char?)
+    prev = nil.as(Char?)
+    chars = prefix.chars
+    index = 0
+    while index < chars.size
+      char = chars[index]
+      if quote
+        quote = nil if char == quote
+      elsif char.in?('"', '\'')
+        quote = char
+      elsif char == '?'
+        nxt = index + 1 < chars.size ? chars[index + 1] : nil
+        # A ternary `?` is spaced on both sides; `foo?`, `String?`,
+        # `?a` and the nilable forms `x[0]?` / `foo()?` are not.
+        if prev && nxt && nxt.whitespace? && !prev.ascii_alphanumeric? && prev != '_' && prev != '?' && !prev.in?(')', ']', '}')
+          last_ternary = index
+        end
+      end
+      prev = char
+      index += 1
+    end
+    return "" if last_ternary < 0
+
+    has_colon = false
+    quote = nil.as(Char?)
+    index = last_ternary + 1
+    while index < chars.size
+      char = chars[index]
+      if quote
+        quote = nil if char == quote
+      elsif char.in?('"', '\'')
+        quote = char
+      elsif char == ':'
+        has_colon = true
+        break
+      end
+      index += 1
+    end
+    has_colon ? "" : " : nil"
+  end
+
+  # Whether a `/` at this position starts a regex literal rather than a
+  # division: after a value (identifier, literal, closer, string) it is
+  # division; at the start or after an operator/paren/comma it is a regex.
+  private def self.regex_position?(prev : Char?) : Bool
+    prev.nil? || (!prev.ascii_alphanumeric? && prev != '_' && !prev.in?(')', ']', '}', '"', '\''))
+  end
+
+  private def self.delimiter_counterpart(char : Char) : Char
+    case char
+    when '(' then ')'
+    when '[' then ']'
+    when '{' then '}'
+    when ')' then '('
+    when ']' then '['
+    else          '{'
+    end
+  end
+
+  private def self.balance_delimiters(source : String) : String
+    closers = missing_closers(source)
+    closers.empty? ? source : source + closers
+  end
+
+  # Re-closes delimiters opened BEFORE a trailing-dot cut and drops the
+  # orphaned tail of the call the cut landed in. The line pass already
+  # closed delimiters opened on the cut line itself; only delimiters open
+  # since an earlier line indicate a multi-line call whose remainder
+  # (remaining argument lines plus the closing delimiter) dangles below.
+  # Returns true if any line was removed.
+  private def self.fix_multiline_call_tails!(lines : Array(String)) : Bool
+    changed = false
+    deletions = [] of {Int32, Int32}
+    line_index = 0
+    while line_index < lines.size
+      line = lines[line_index]
+      if (dot = line.rindex(".placeholder"))
+        entering = openers_before(lines, line_index)
+        if entering.empty?
+          # The cut may have deleted the call's OWN opener (`Foo.new(` ->
+          # `Foo.`): the call's argument lines dangle below with no
+          # delimiter to anchor them. Drop the tail when it looks like a
+          # pure call remainder.
+          if drop_dangling_args!(lines, line_index, deletions)
+            changed = true
+          end
+        else
+          # The cut is directly inside the TOP delimiter opened before it
+          # (e.g. `Location.new(` above `file_uri.`); the openers further
+          # down the stack belong to enclosing blocks whose closers come
+          # later and must be left alone.
+          top = entering[0]
+          if top == '}'
+            # The cut sits inside a brace block whose own closer may be
+            # far below, while the deleted call's closer dangles right
+            # under the cut. Drop the dangling tail; close the brace
+            # inline only when the tail ends in the brace's own `}` (a
+            # tuple), not a `)`/`]` that belongs to the deleted call.
+            closer = drop_dangling_args!(lines, line_index, deletions)
+            if closer
+              changed = true
+              if closer == '}'
+                lines[line_index] = line.sub(".placeholder", ".placeholder}")
+              end
+            else
+              # No clean tail: fall back to closing the brace inline and
+              # dropping its own orphaned remainder (parse-guarded).
+              lines[line_index] = line.sub(".placeholder", ".placeholder}")
+              stack = ['{']
+              j = line_index + 1
+              while j < lines.size && !stack.empty? && j - line_index <= 100
+                stack = consume_delimiters(stack, lines[j])
+                j += 1
+              end
+              if stack.empty? && j > line_index + 1
+                deletions << {line_index + 1, j - 1}
+                changed = true
+              end
+            end
+          else
+            # A call/array cut: close the nested calls inline (the outer
+            # calls' closers would otherwise be eaten by the tail drop,
+            # orphaning their openers) and drop the orphaned remainder —
+            # the remaining argument lines up to and including the line
+            # closing the last nested opener. The closers are appended
+            # after the line pass's own closers so the innermost
+            # (same-line) call closes first. A `}` in *entering* is an
+            # ENCLOSING brace block whose own body and closers live
+            # below the cut: it is left alone (its `end`/`}` lines stay).
+            # A mismatched closer or a scan that never balances leaves
+            # the file as-is (the parse guards fall back).
+            prefix = entering[0...(entering.index('}') || entering.size)]
+            lines[line_index] = "#{line}#{prefix}"
+            # prefix is innermost-first; the scan pops the stack top, so
+            # the counterparts must be pushed outermost-first.
+            stack = prefix.chars.reverse.map { |closer| delimiter_counterpart(closer) }
+            j = line_index + 1
+            while j < lines.size && !stack.empty? && j - line_index <= 100
+              stack = consume_delimiters(stack, lines[j])
+              j += 1
+            end
+            if stack.empty? && j > line_index + 1
+              # An inner call's orphaned closer (`),`) can pop the scan
+              # early, leaving the outer call's real closer dangling:
+              # when the emptied line is comma-suffixed (mid-call), the
+              # outer call's remaining argument lines still dangle below.
+              # Extend the deletion over them when they form a pure arg
+              # tail (delimiter balance goes negative at its closer).
+              if j < lines.size && lines[j - 1].strip.ends_with?(',')
+                b = 0
+                k = j
+                while k < lines.size && k - j <= 30
+                  b += net_delimiters(lines[k])
+                  if b < 0
+                    j = k + 1
+                    break
+                  end
+                  k += 1
+                end
+              end
+              deletions << {line_index + 1, j - 1}
+              changed = true
+            end
+          end
+        end
+      end
+      line_index += 1
+    end
+    deletions.reverse_each do |from, to|
+      to.downto(from) { |i| lines.delete_at(i) }
+    end
+    changed
+  end
+
+  # Re-opens a `do`-block whose header a trailing-dot cut deleted: when
+  # the lines below a `.placeholder` line form a self-contained block
+  # body (the next non-blank line is deeper-indented and a bare `end`
+  # sits at the cut's own indent within a bounded window, with nothing
+  # shallower in between), appending ` do` to the cut line lets the
+  # body's own `end` close it. Each candidate is parse-checked on a
+  # copy before it is committed. Returns true if any line changed.
+  private def self.fix_block_tails!(lines : Array(String)) : Bool
+    changed = false
+    lines.each_with_index do |line, i|
+      next unless line.includes?(".placeholder")
+      base = line_indent(line)
+      next unless base
+
+      j = i + 1
+      while j < lines.size && (lines[j].blank? || lines[j].lstrip.starts_with?('#'))
+        j += 1
+      end
+      next if j >= lines.size
+      next unless (first_indent = line_indent(lines[j])) && first_indent > base
+
+      found = nil
+      k = j
+      while k < lines.size && k - i <= 30
+        l = lines[k]
+        if l.blank? || l.lstrip.starts_with?('#')
+          k += 1
+          next
+        end
+        ind = line_indent(l)
+        stripped = l.lstrip
+        if ind == base && stripped.starts_with?("end") && (stripped.size == 3 || !stripped[3].ascii_alphanumeric?)
+          found = k
+          break
+        end
+        # Any line at or above the cut's indent before the `end` means
+        # the lines below are not a block body.
+        break unless ind && ind > base
+        k += 1
+      end
+      next unless found
+
+      candidate = lines.dup
+      candidate[i] = "#{line} do"
+      next unless parses?(candidate.join("\n"))
+      lines[i] = candidate[i]
+      changed = true
+    end
+    changed
+  end
+
+  # The closers needed to close the delimiters opened before *line_index*
+  # (top of the stack first). Unlike missing_closers on a joined prefix,
+  # the quote/comment state resets at every line boundary: a lone quote in
+  # a comment or a char literal must not swallow the rest of the file.
+  private def self.openers_before(lines : Array(String), line_index : Int32) : String
+    stack = [] of Char
+    line_index.times do |i|
+      line = lines[i]
+      next if line.lstrip.starts_with?('#')
+      quote = nil.as(Char?)
+      prev = nil.as(Char?)
+      chars = line.chars
+      index = 0
+      while index < chars.size
+        char = chars[index]
+        if quote
+          if char == '\\'
+            index += 2
+            next
+          elsif char == quote
+            quote = nil
+          end
+        elsif char.in?('"', '\'')
+          quote = char
+        elsif char == '/' && regex_position?(prev)
+          index += 1
+          in_class = false
+          while index < chars.size
+            c = chars[index]
+            if c == '\\'
+              index += 2
+              next
+            elsif c == '['
+              in_class = true
+            elsif c == ']'
+              in_class = false
+            elsif c == '/' && !in_class
+              break
+            end
+            index += 1
+          end
+        elsif char == '#'
+          index += 1
+          while index < chars.size && chars[index] != '\n'
+            index += 1
+          end
+          next
+        elsif char.in?('(', '[', '{')
+          stack << char
+        elsif char.in?(')', ']', '}')
+          if stack.last? == delimiter_counterpart(char)
+            stack.pop
+          end
+        end
+        prev = char unless char.whitespace? || quote
+        index += 1
+      end
+    end
+    stack.reverse.map { |opener| delimiter_counterpart(opener) }.join
+  end
+
+  # Drops the dangling argument lines of a call whose opener was ON the
+  # cut line (`Foo.new(` deleted with the line's tail). The tail must look
+  # like a pure call remainder: the first non-blank line is arg-like
+  # (comma-suffixed, a named argument, or a bare closer), the closer line
+  # that drops the delimiter balance below zero arrives within a bounded
+  # window, and no keyword line is crossed. Returns the closer char of the
+  # dropped tail, or nil when no clean tail was found.
+  private def self.drop_dangling_args!(lines : Array(String), line_index : Int32, deletions : Array({Int32, Int32})) : Char?
+    j = line_index + 1
+    while j < lines.size && (lines[j].blank? || lines[j].lstrip.starts_with?('#'))
+      j += 1
+    end
+    return nil if j >= lines.size
+    first = lines[j].strip
+    return nil unless arg_like_line?(first) || bare_closer_line?(first)
+
+    cut_indent = line_indent(lines[line_index])
+    balance = 0
+    while j < lines.size
+      line = lines[j]
+      # A keyword line at or above the cut's indent means the "tail" is
+      # really the next statement. Keyword-looking content DEEPER than
+      # the cut (a `try { |doc|` block or an `.end.to_s` call inside the
+      # dangling call's own arguments) is part of the tail itself.
+      if balance >= 0 && (kw = line_keyword(line)) && cut_indent && (ind = line_indent(line)) && ind <= cut_indent
+        return nil
+      end
+      balance += net_delimiters(line)
+      if balance < 0
+        deletions << {line_index + 1, j}
+        return line.rindex(/[)\]}]/).try { |i| line[i] }
+      end
+      j += 1
+      return nil if j - line_index > 30
+    end
+    nil
+  end
+
+  # Whether *stripped* looks like an argument line of a multi-line call:
+  # comma-suffixed, a named argument, or a nested closer/continuation.
+  private def self.arg_like_line?(stripped : String) : Bool
+    stripped.ends_with?(',') || stripped.ends_with?(':') ||
+      stripped.ends_with?(')') || stripped.ends_with?(']') ||
+      stripped.matches?(/^\w[\w?!]*\s*:/)
+  end
+
+  # Whether *stripped* is a bare closer line (`)`, `},`, `]`...).
+  private def self.bare_closer_line?(stripped : String) : Bool
+    stripped.matches?(/^[)\]}][\s,;]*$/)
+  end
+
+  # The net delimiter balance of *line* (strings, chars and comments
+  # skipped): +1 per opener, -1 per closer.
+  private def self.net_delimiters(line : String) : Int32
+    net = 0
+    quote = nil.as(Char?)
+    prev = nil.as(Char?)
+    chars = line.chars
+    index = 0
+    while index < chars.size
+      char = chars[index]
+      if quote
+        if char == '\\'
+          index += 2
+          next
+        elsif char == quote
+          quote = nil
+        end
+      elsif char.in?('"', '\'')
+        quote = char
+      elsif char == '/' && regex_position?(prev)
+        index += 1
+        in_class = false
+        while index < chars.size
+          c = chars[index]
+          if c == '\\'
+            index += 2
+            next
+          elsif c == '['
+            in_class = true
+          elsif c == ']'
+            in_class = false
+          elsif c == '/' && !in_class
+            break
+          end
+          index += 1
+        end
+      elsif char == '#'
+        index += 1
+        while index < chars.size && chars[index] != '\n'
+          index += 1
+        end
+        next
+      elsif char.in?('(', '[', '{')
+        net += 1
+      elsif char.in?(')', ']', '}')
+        net -= 1
+      end
+      prev = char unless char.whitespace? || quote
+      index += 1
+    end
+    net
+  end
+
+  # Walks *line* (skipping strings, chars and comments), pushing open
+  # delimiters onto *stack* and popping matching closers. A closer that
+  # does not match the top is ignored; the caller treats a stack that
+  # never empties as "no clean tail" and falls back.
+  private def self.consume_delimiters(stack : Array(Char), line : String) : Array(Char)
+    quote = nil.as(Char?)
+    prev = nil.as(Char?)
+    chars = line.chars
+    index = 0
+    while index < chars.size
+      char = chars[index]
+      if quote
+        if char == '\\'
+          index += 2
+          next
+        elsif char == quote
+          quote = nil
+        end
+      elsif char.in?('"', '\'')
+        quote = char
+      elsif char == '/' && regex_position?(prev)
+        index += 1
+        in_class = false
+        while index < chars.size
+          c = chars[index]
+          if c == '\\'
+            index += 2
+            next
+          elsif c == '['
+            in_class = true
+          elsif c == ']'
+            in_class = false
+          elsif c == '/' && !in_class
+            break
+          end
+          index += 1
+        end
+      elsif char == '#'
+        index += 1
+        while index < chars.size && chars[index] != '\n'
+          index += 1
+        end
+        next
+      elsif char.in?('(', '[', '{')
+        stack << char
+      elsif char.in?(')', ']', '}')
+        if stack.last? == delimiter_counterpart(char)
+          stack.pop
+        end
+      end
+      prev = char unless char.whitespace? || quote
+      index += 1
+    end
+    stack
+  end
+
+  private def self.trailing_dot_index(line : String) : Int32?
+    stripped = line.rstrip
+    return unless stripped.size >= 2
+
+    # A `.` right before a closing delimiter (mid-edit inside an
+    # interpolation like `"#{foo.}"`) or at the end of the line.
+    dot_index = stripped.rindex(/\.(?=\s*[}\)\]]|$)/)
+    return unless dot_index
+    return if dot_index == 0
+
+    previous = stripped[dot_index - 1]
+    # Exclude ranges (`a..`), splats (`*..`) and floats (`1.`), which are
+    # either valid or not something a placeholder can fix.
+    return if previous == '.'
+    return if previous.ascii_number?
+
+    dot_index
   end
 
   private def self.line_indent(line : String) : Int32?
@@ -97,9 +774,16 @@ class Crystalline::BrokenSourceFixer
         (private\s+)?(abstract\s+)?struct |
         (private\s+)?module |
         (private\s+)?enum |
-        (private\s+)?annotation
-      )\s/x)
+        (private\s+)?annotation |
+        (private\s+)?macro(?!\s*:) |
+        case |
+        select
+      )(\s|$)/x)
       $1
+    elsif m = line.match(/^\s*(?:[\w.?!@\[\]]+\s*=\s*)(if|unless|while|until|case|select)\s/)
+      # An assignment-form opener (`value = if cond`): the `if` does not
+      # start the line, but it still opens a block closed by `end`.
+      m[1]
     elsif line.matches?(/\s*begin\s*$/)
       "begin"
     elsif line.ends_with?(/\s*do(\s+\|[^|]+\|)?\s*$/)
@@ -108,10 +792,14 @@ class Crystalline::BrokenSourceFixer
       "{"
     elsif line.ends_with?(/\s*[\w\d]\s*{(\s*\|[^|]+\|)?\s*$/)
       "{"
-    elsif line.matches?(/\s*end\s*$/)
-      "end"
-    elsif line.matches?(/\s*}\s*$/)
-      "}"
+    elsif line.matches?(/\s*\{\s*(\|[^|]*\|)?\s*$/)
+      # A bare `{` (or `{ |x|`) on its own line — a multi-line tuple or
+      # block opened without a call before it. Without this, the `}` that
+      # closes it would rindex-pop an EARLIER `{` (and everything above it,
+      # including still-open do-blocks).
+      "{"
+    elsif m = line.match(/(?:^|\W)(end|})([\s.,)\]}]|$)/)
+      m[1]
     elsif line.matches?(/\s*else\s*$/)
       "else"
     elsif line.starts_with?(/\s*elsif\s+/)
@@ -143,6 +831,7 @@ class Crystalline::BrokenSourceFixer
     closing_keyword : String?,
     last_info : LineInfo,
     line : String,
+    was_blank_gap : Bool,
   )
     # If the indent is less than the opening one it's definitely wrong.
     if indent < last_info.indent
@@ -151,6 +840,16 @@ class Crystalline::BrokenSourceFixer
 
     # If the indent is greater, it's all good (it's probably content inside that definition)
     if indent > last_info.indent
+      return false
+    end
+
+    # Equal indentation is only wrong for a visual dedent; an arbitrary
+    # statement at the same indentation is content (e.g. `next unless ...`
+    # inside a block), and closing the open keyword for it would corrupt
+    # the structure. Recognized keywords (closing keyword, else/elsif/
+    # rescue/ensure, continuation lines) are never treated as dedents.
+    stripped_line = line.strip
+    if stripped_line.ends_with?(')') || stripped_line.ends_with?(']')
       return false
     end
 
@@ -190,6 +889,10 @@ class Crystalline::BrokenSourceFixer
       return false
     end
 
-    true
+    if was_blank_gap
+      return true
+    end
+
+    false
   end
 end

--- a/src/crystalline/completion_context.cr
+++ b/src/crystalline/completion_context.cr
@@ -1,4 +1,5 @@
 require "compiler/crystal/syntax"
+require "./position_utils"
 
 class Crystalline::CompletionContext
   record TokenSpan,
@@ -24,15 +25,40 @@ class Crystalline::CompletionContext
   end
 
   def detect : self?
+    # The LSP cursor column is UTF-16-based; everything computed from it
+    # (fragments, token spans, analysis column) is character-based.
+    @cursor = PositionUtils.utf16_to_char_index(@line, @cursor)
+
     fragment_start, fragment_end = identifier_fragment_bounds
     @replace_start = fragment_start
     @replace_end = fragment_end
 
-    tokens = tokens_for_line
-    return if inside_comment?(tokens) || inside_delimited_literal?(tokens)
+    tokens = begin
+      tokens_for_line
+    rescue Crystal::SyntaxException
+      # Mid-edit lines can contain lexer garbage (a lone `@`, an unterminated
+      # string...): fall back to an empty token list so completion detection
+      # can still run on the fragment.
+      [] of TokenSpan
+    end
+    # The lexer lexes a `#{` inside a string as the start of a comment, and
+    # the cursor is "inside a string" per the delimiter scan — but an
+    # interpolation is code: completion should still work there
+    # (`"#{position.`).
+    in_interpolation = (interp = @line.rindex("\#{", @cursor)) && !@line[interp + 2, @cursor - interp - 2].includes?('}')
+    return if !in_interpolation && (inside_comment?(tokens) || inside_delimited_literal?(tokens))
 
-    if @trigger_character.nil?
-      @trigger_character = inferred_trigger(tokens, fragment_start)
+    trigger = @trigger_character
+    if trigger.nil? || trigger.matches?(/\A[A-Za-z]\z/) || trigger == "_"
+      # Clients register the identifier characters as completion triggers
+      # (per-keystroke completions), so typing `foo.a` arrives with
+      # trigger "a" — but the receiver is still `foo`, and the analysis
+      # must end at the trigger dot (or `::`/sigil) or the method list is
+      # replaced by plain context items. Infer the structural trigger from
+      # the line when the reported one is an identifier character.
+      if inferred = inferred_trigger(tokens, fragment_start)
+        @trigger_character = inferred
+      end
     end
 
     case @trigger_character
@@ -40,6 +66,15 @@ class Crystalline::CompletionContext
       if operator = preceding_period(tokens, fragment_start)
         @analysis_column = operator.start_char
         @replace_start = operator.end_char
+      elsif fragment_start > 0 && @line[fragment_start - 1] == '.'
+        # The tokenizer could not identify the period (mid-edit lexer
+        # failures on regex/string-heavy lines): the character before
+        # the fragment is still the trigger, so the analysis prefix
+        # must end there — otherwise the fragment is dragged into the
+        # receiver chain (`foo.scan(/x/).placeholde`) and resolution
+        # fails on it.
+        @analysis_column = fragment_start - 1
+        @replace_start = fragment_start
       end
     when ":"
       if operator = preceding_colon_colon(tokens, fragment_start)
@@ -47,15 +82,23 @@ class Crystalline::CompletionContext
         @replace_start = operator.end_char
       end
     when "@"
+      # The replace range covers the sigil (`@documents_`), so the edit
+      # text carries the full name and VSCode's filter word matches the
+      # filterText as a clean prefix. The range ends at the cursor: the
+      # fixer may have appended a placeholder name to the sigil, which the
+      # user has not typed.
       if sigil = current_sigiled_token(tokens)
         @analysis_column = sigil.start_char
-        @replace_start = sigil.start_char + sigil_prefix_size(sigil.type)
+        @replace_start = sigil.start_char
+        @replace_end = @cursor
       elsif @cursor > 1 && @line[@cursor - 2, 2]? == "@@"
         @analysis_column = @cursor - 2
-        @replace_start = @cursor
+        @replace_start = @cursor - 2
+        @replace_end = @cursor
       elsif @cursor > 0 && @line[@cursor - 1] == '@'
         @analysis_column = @cursor - 1
-        @replace_start = @cursor
+        @replace_start = @cursor - 1
+        @replace_end = @cursor
       end
     else
       @analysis_column = @cursor
@@ -72,26 +115,9 @@ class Crystalline::CompletionContext
 
   def completion_range(line_number : Int32) : LSP::Range
     LSP::Range.new(
-      start: LSP::Position.new(line: line_number, character: @replace_start),
-      end: LSP::Position.new(line: line_number, character: @replace_end),
+      start: LSP::Position.new(line: line_number, character: PositionUtils.char_to_utf16_index(@line, @replace_start)),
+      end: LSP::Position.new(line: line_number, character: PositionUtils.char_to_utf16_index(@line, @replace_end)),
     )
-  end
-
-  def rewritten_line : String
-    suffix = @line[@replace_end..]?
-    right_offset = 0
-    truncate_line = false
-
-    suffix.try &.each_char_with_index do |char, index|
-      unless ident_char?(char) || char == ':'
-        truncate_line = true if char == '(' || char == '{' || char == '['
-        right_offset = index
-        break
-      end
-    end
-
-    suffix = suffix.try &.[right_offset...]?
-    analysis_prefix + (!truncate_line ? (suffix || "\n") : "\n")
   end
 
   private def identifier_fragment_bounds
@@ -188,6 +214,14 @@ class Crystalline::CompletionContext
 
     return "." if preceding_period(tokens, fragment_start)
     return ":" if preceding_colon_colon(tokens, fragment_start)
+
+    # Fallback for mid-edit lines the lexer cannot tokenize as code (a `#{`
+    # inside a string lexes as a comment): the character before the fragment
+    # still tells us the trigger.
+    if fragment_start > 0
+      return "." if @line[fragment_start - 1] == '.'
+      return ":" if fragment_start >= 2 && @line[fragment_start - 2, 2] == "::"
+    end
   end
 
   private def current_sigiled_token(tokens : Array(TokenSpan))
@@ -196,10 +230,6 @@ class Crystalline::CompletionContext
         @cursor >= token.start_char &&
         @cursor <= token.end_char
     end
-  end
-
-  private def sigil_prefix_size(type : Crystal::Token::Kind)
-    type.class_var? ? 2 : 1
   end
 
   private def preceding_period(tokens : Array(TokenSpan), fragment_start : Int32)

--- a/src/crystalline/controller.cr
+++ b/src/crystalline/controller.cr
@@ -7,7 +7,6 @@ class Crystalline::Controller
   @pending_requests : Set(LSP::RequestMessage::RequestId) = Set(LSP::RequestMessage::RequestId).new
   # Used to process certain requests synchronously.
   @documents_lock = Mutex.new
-  @compiler_lock = Mutex.new
 
   def initialize(@server : LSP::Server)
     @server.start(self)
@@ -18,11 +17,24 @@ class Crystalline::Controller
   end
 
   def when_ready : Nil
-    # Compile the workspace at once.
-    spawn same_thread: true do
+    spawn do
+      # Ensure the disk-cached stdlib index is available for single-file
+      # queries issued before the project index exists: instant on cache
+      # hits, generated in the background on the first run.
+      Crystalline::Lightweight::PreludeIndex.ensure_loaded
+
+      # Then run the top-level semantic pass per project: it populates the
+      # lightweight project index (including the stdlib) within seconds, so
+      # interactive features work before the full compile finishes.
+      workspace.projects.each do |p|
+        workspace.recalculate_dependencies(@server, p)
+      end
+
+      # Then compile each project entry point at once.
       workspace.projects.each do |p|
         if (entry_point = p.entry_point?)
-          workspace.compile(@server, entry_point)
+          LSP::Log.info { "[compile] startup: #{entry_point.decoded_path}" }
+          workspace.compile(@server, entry_point, wants_doc: true)
         end
       end
     end
@@ -60,23 +72,17 @@ class Crystalline::Controller
         }
       }
     when LSP::HoverRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.hover(@server, file_uri, message.params.position)
-      end
+      return nil unless @pending_requests.includes? message.id
+      file_uri = URI.parse message.params.text_document.uri
+      workspace.hover(@server, file_uri, message.params.position)
     when LSP::DefinitionRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.definitions(@server, file_uri, message.params.position)
-      end
+      return nil unless @pending_requests.includes? message.id
+      file_uri = URI.parse message.params.text_document.uri
+      workspace.definitions(@server, file_uri, message.params.position)
     when LSP::CompletionRequest
-      @compiler_lock.synchronize do
-        return nil unless @pending_requests.includes? message.id
-        file_uri = URI.parse message.params.text_document.uri
-        workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
-      end
+      return nil unless @pending_requests.includes? message.id
+      file_uri = URI.parse message.params.text_document.uri
+      workspace.completion(@server, file_uri, message.params.position, message.params.context.try &.trigger_character)
     when LSP::DocumentSymbolsRequest
       @documents_lock.synchronize do
         file_uri = URI.parse message.params.text_document.uri
@@ -123,13 +129,14 @@ class Crystalline::Controller
       }
       file_uri = message.params.text_document.uri
       spawn do
-        @compiler_lock.synchronize {
-          workspace.compile(
-            @server,
-            URI.parse(file_uri),
-            discard_nil_cached_result: true,
-          )
-        }
+        parsed_uri = URI.parse(file_uri)
+        LSP::Log.info { "[compile] save: #{parsed_uri.decoded_path}" }
+        workspace.compile(
+          @server,
+          parsed_uri,
+          discard_nil_cached_result: true,
+          wants_doc: true,
+        )
       end
     when LSP::CancelNotification
       @pending_requests.delete message.params.id

--- a/src/crystalline/lightweight/completion.cr
+++ b/src/crystalline/lightweight/completion.cr
@@ -1,0 +1,375 @@
+require "lsp/server"
+require "../completion_context"
+require "../source_mask"
+require "./inference"
+require "./query"
+require "./resolver"
+
+module Crystalline::Lightweight
+  class Completion
+    def self.complete(source : String, line_number : Int32, context : Crystalline::CompletionContext, query : Query) : Array(LSP::CompletionItem)?
+      complete_and_reason(source, line_number, context, query)[0]
+    end
+
+    def self.diagnose(source : String, line_number : Int32, context : Crystalline::CompletionContext, query : Query) : String
+      complete_and_reason(source, line_number, context, query)[1]
+    end
+
+    # Computes the completion items and their miss reason in a single pass,
+    # so that workspace logging does not double the cost of a miss.
+    def self.complete_and_reason(source : String, line_number : Int32, context : Crystalline::CompletionContext, query : Query) : {Array(LSP::CompletionItem)?, String}
+      new(source, line_number, context, query).complete_or_reason
+    end
+
+    def initialize(@source : String, @line_number : Int32, @context : Crystalline::CompletionContext, @query : Query)
+    end
+
+    def complete_or_reason : {Array(LSP::CompletionItem)?, String}
+      if SourceMask.new(@source).comment_or_string?(@line_number, @context.analysis_column)
+        return {nil, "cursor inside comment or string"}
+      end
+
+      case @context.trigger_character
+      when "."
+        items = complete_methods
+        if items
+          {items, items.empty? ? "no matching lightweight methods for receiver '#{receiver_expression}'" : "resolved"}
+        else
+          {nil, "could not resolve method receiver '#{receiver_expression}'"}
+        end
+      else
+        items = complete_context_items
+        if items
+          {items, items.empty? ? "no matching context completions" : "resolved"}
+        else
+          {nil, "could not build context completions"}
+        end
+      end
+    end
+
+    private def complete_methods : Array(LSP::CompletionItem)?
+      receiver = receiver_expression
+      return if receiver.empty?
+
+      type_names, class_method = resolve_receiver(receiver)
+      return if type_names.empty?
+
+      items = [] of LSP::CompletionItem
+      seen = Set(String).new
+      # One BFS per receiver type, then per-method hash lookups: ranking
+      # per method with its own BFS made completion O(methods × scan).
+      ranks = method_ranks(type_names)
+
+      type_names.each do |type_name|
+        methods = @query.methods_for(type_name, class_method: class_method)
+        if Crystalline::Lightweight::Query.subtype_fallback_type?(type_name)
+          # Hierarchy roots list the full surface of their subtypes so
+          # `node.`-style completions on compiler AST bases offer the
+          # accessors the base itself does not declare.
+          methods = methods + @query.subtype_methods_for(type_name, class_method: class_method, include_macros: false)
+        end
+        methods.each do |method|
+          # Keep overloads distinct. The key must include the args'
+          # names, not just restrictions: `foo()` and `foo(x)` (an
+          # untyped arg) both join to the same empty signature string,
+          # which would silently drop one overload.
+          args_signature = method.args.map { |arg| "#{arg.name}:#{arg.restriction}" }.join(",")
+          key = "#{method.owner}:#{method.class_method}:#{method.name}(#{args_signature})"
+          next if seen.includes?(key)
+          seen << key
+          items << method_completion_item(method, hierarchy_rank: ranks[method.owner]?)
+        end
+      end
+
+      items
+    end
+
+    private def complete_context_items : Array(LSP::CompletionItem)?
+      fragment = current_fragment
+      items = [] of LSP::CompletionItem
+      seen = Set(String).new
+
+      if @context.trigger_character == "@"
+        # The replace range now includes the sigil, so the fragment does
+        # too: strip it before matching against the bare ivar names.
+        fragment = fragment.lchop('@').lchop('@')
+        inference = Inference.for(@source, @line_number + 1, @context.analysis_column + 1, @query)
+        if inference
+          inference.instance_var_types.each_key do |name|
+            next unless name.lchop('@').starts_with?(fragment)
+            next if seen.includes?(name)
+            seen << name
+            items << variable_completion_item(name, kind: LSP::CompletionItemKind::Field, detail: "#{name} : #{inference.types_for_instance_var(name).uniq.join(" | ")}", insert_text: name)
+          end
+
+          inference.class_var_types.each_key do |name|
+            next unless name.lchop("@@").starts_with?(fragment)
+            next if seen.includes?(name)
+            seen << name
+            items << variable_completion_item(name, kind: LSP::CompletionItemKind::Field, detail: "#{name} : #{inference.types_for_class_var(name).uniq.join(" | ")}", insert_text: name)
+          end
+
+          return items
+        end
+
+        # A lone `@` does not parse (the buffer may be mid-edit): fall back
+        # to scanning ivar/class-var names in the source.
+        return ivar_names_from_source(fragment)
+      end
+
+      if @context.trigger_character == ":" || fragment[0]?.try(&.ascii_uppercase?)
+        if @context.trigger_character == ":"
+          # The fixer may have appended a placeholder name after the `::`;
+          # the user has not typed it, so match as if the fragment were empty.
+          fragment = "" if fragment == "Placeholder"
+          receiver = Resolver.receiver_from_prefix(@context.analysis_prefix).rchop("::")
+          resolved = @query.find_type(receiver) || @query.resolve_type_name(receiver, namespace: nil)
+          if resolved
+            resolved_name = resolved.is_a?(String) ? resolved : resolved.name
+            @query.subtypes_for(resolved_name).each do |type_name|
+              short_name = type_name.split("::").last
+              next unless short_name.starts_with?(fragment)
+              next if seen.includes?(type_name)
+              seen << type_name
+              if type = @query.find_type(type_name)
+                items << scoped_type_completion_item(type)
+              else
+                # Enum members and other constants are subtypes without
+                # their own TypeInfo: offer a plain constant item.
+                items << LSP::CompletionItem.new(
+                  label: short_name,
+                  kind: LSP::CompletionItemKind::EnumMember,
+                  detail: resolved_name,
+                  insert_text: short_name,
+                )
+              end
+            end
+            return items
+          end
+        end
+
+        @query.all_types.each do |type|
+          next unless type.name.split("::").last.starts_with?(fragment) || type.name.starts_with?(fragment)
+          next if seen.includes?(type.name)
+          seen << type.name
+          items << type_completion_item(type)
+        end
+        return items
+      end
+
+      inference = Inference.for(@source, @line_number + 1, @context.analysis_column + 1, @query)
+
+      if fragment.empty? || "self".starts_with?(fragment)
+        items << variable_completion_item("self", kind: LSP::CompletionItemKind::Variable, detail: self_completion_detail(inference), insert_text: "self")
+        seen << "self"
+      end
+
+      if inference
+        inference.local_types.each do |name, type_names|
+          next unless name.starts_with?(fragment)
+          next if seen.includes?(name)
+          seen << name
+          items << variable_completion_item(name, detail: "#{name} : #{type_names.uniq.join(" | ")}")
+        end
+
+        # A bare identifier in a def body is a self-call: offer the current
+        # type's own methods (class methods when in class context) so
+        # `process` completes to `process_result`/`process_type`.
+        if current_type = inference.current_type_name
+          ranks = method_ranks([current_type])
+          @query.methods_for(current_type, class_method: inference.class_method_context?).each do |method|
+            next unless method.name.starts_with?(fragment)
+            args_signature = method.args.map { |arg| "#{arg.name}:#{arg.restriction}" }.join(",")
+            key = "#{method.owner}:#{method.class_method}:#{method.name}(#{args_signature})"
+            next if seen.includes?(key)
+            seen << key
+            items << method_completion_item(method, hierarchy_rank: ranks[method.owner]?)
+          end
+        end
+      end
+
+      @query.top_level_methods.each do |method|
+        next unless method.name.starts_with?(fragment)
+        next if seen.includes?(method.name)
+        seen << method.name
+        items << method_completion_item(method)
+      end
+
+      items
+    end
+
+    private def resolve_receiver(receiver : String) : {Array(String), Bool}
+      Resolver.receiver_types(@source, @line_number, @context.analysis_column, receiver, @query)
+    end
+
+    private def receiver_expression : String
+      # The receiver may span lines: walk back over the whole source when
+      # the single-line receiver suggests a block closer or a continuation
+      # (see Resolver.receiver_from_line_prefix).
+      Resolver.receiver_from_line_prefix(@source, @line_number, @context.analysis_prefix)
+    end
+
+    private def method_completion_item(method : MethodInfo, *, hierarchy_rank : Int32? = nil) : LSP::CompletionItem
+      LSP::CompletionItem.new(
+        label: format_method(method),
+        insert_text: method.name,
+        filter_text: method.name,
+        detail: format_method(method, include_owner: true),
+        kind: method.class_method ? LSP::CompletionItemKind::Function : LSP::CompletionItemKind::Method,
+        # Closest-type-first: the hierarchy rank (0 = the receiver's own
+        # methods) dominates, alphabetical order within the same rank.
+        sort_text: hierarchy_rank ? "#{hierarchy_rank.to_s.rjust(3, '0')}:#{method.name}" : method.name,
+        text_edit: LSP::TextEdit.new(
+          range: @context.completion_range(@line_number),
+          new_text: method.name,
+        ),
+        documentation: method.doc.try { |doc|
+          LSP::MarkupContent.new(
+            kind: LSP::MarkupKind::MarkDown,
+            value: doc,
+          )
+        },
+      )
+    end
+
+    # Owner ranks across the receiver types (min distance): own methods
+    # rank 0, direct parents 1, and so on; owners that are not ancestors
+    # (e.g. subtype-fallback surfaces) stay unranked so they keep the
+    # plain-name sort_text and sort after the ranked hierarchy.
+    private def method_ranks(type_names : Array(String)) : Hash(String, Int32)
+      ranks = {} of String => Int32
+      type_names.each do |type_name|
+        @query.type_hierarchy_depths(type_name).each do |owner, depth|
+          if (existing = ranks[owner]?).nil? || depth < existing
+            ranks[owner] = depth
+          end
+        end
+      end
+      ranks
+    end
+
+    private def variable_completion_item(name : String, *, kind = LSP::CompletionItemKind::Variable, detail : String? = nil, insert_text : String = name) : LSP::CompletionItem
+      LSP::CompletionItem.new(
+        label: detail || name,
+        insert_text: insert_text,
+        filter_text: name,
+        detail: detail,
+        kind: kind,
+        sort_text: name,
+        text_edit: LSP::TextEdit.new(
+          range: @context.completion_range(@line_number),
+          new_text: insert_text,
+        ),
+      )
+    end
+
+    private def scoped_type_completion_item(type : TypeInfo) : LSP::CompletionItem
+      short_name = type.name.split("::").last
+      LSP::CompletionItem.new(
+        label: type.name,
+        insert_text: short_name,
+        filter_text: short_name,
+        detail: type.kind.to_s,
+        kind: type_completion_kind(type.kind),
+        sort_text: short_name,
+        text_edit: LSP::TextEdit.new(
+          range: @context.completion_range(@line_number),
+          new_text: short_name,
+        ),
+        documentation: type.doc.try { |doc|
+          LSP::MarkupContent.new(
+            kind: LSP::MarkupKind::MarkDown,
+            value: doc,
+          )
+        },
+      )
+    end
+
+    private def type_completion_item(type : TypeInfo) : LSP::CompletionItem
+      LSP::CompletionItem.new(
+        label: type.name,
+        insert_text: type.name,
+        filter_text: type.name,
+        detail: type.kind.to_s,
+        kind: type_completion_kind(type.kind),
+        sort_text: type.name,
+        text_edit: LSP::TextEdit.new(
+          range: @context.completion_range(@line_number),
+          new_text: type.name,
+        ),
+        documentation: type.doc.try { |doc|
+          LSP::MarkupContent.new(
+            kind: LSP::MarkupKind::MarkDown,
+            value: doc,
+          )
+        },
+      )
+    end
+
+    private def self_completion_detail(inference : Inference?) : String?
+      return unless inference
+
+      type_names, class_method = inference.self_types
+      return if type_names.empty?
+
+      class_method ? "self : #{type_names.uniq.join(" | ")}.class" : "self : #{type_names.uniq.join(" | ")}"
+    end
+
+    # Best-effort ivar/class-var completion when the buffer does not parse.
+    private def ivar_names_from_source(fragment : String) : Array(LSP::CompletionItem)
+      items = [] of LSP::CompletionItem
+      seen = Set(String).new
+      @source.scan(/@@?[a-zA-Z_]\w*/).each do |match|
+        name = match[0]
+        next unless name.lchop('@').starts_with?(fragment) || name.lchop("@@").starts_with?(fragment)
+        next if seen.includes?(name)
+        seen << name
+        items << variable_completion_item(name, kind: LSP::CompletionItemKind::Field, detail: name, insert_text: name)
+      end
+      items
+    end
+
+    private def current_fragment : String
+      line = @source.lines(chomp: false)[@line_number]? || ""
+      line[@context.replace_start...@context.replace_end]? || ""
+    end
+
+    private def format_method(method : MethodInfo, *, include_owner = false) : String
+      args = method.args.map do |arg|
+        if restriction = arg.restriction
+          "#{arg.name} : #{restriction}"
+        else
+          arg.name
+        end
+      end.join(", ")
+
+      signature = String.build do |str|
+        if include_owner
+          str << method.owner
+          str << (method.class_method ? "." : "#")
+        end
+
+        str << method.name
+        str << "(#{args})"
+        str << " : #{method.return_type}" if method.return_type
+      end
+
+      signature
+    end
+
+    private def type_completion_kind(kind : TypeKind)
+      case kind
+      when .class?
+        LSP::CompletionItemKind::Class
+      when .module?
+        LSP::CompletionItemKind::Module
+      when .struct?
+        LSP::CompletionItemKind::Struct
+      when .enum?
+        LSP::CompletionItemKind::Enum
+      else
+        LSP::CompletionItemKind::Class
+      end
+    end
+  end
+end

--- a/src/crystalline/lightweight/contracts.cr
+++ b/src/crystalline/lightweight/contracts.cr
@@ -1,0 +1,302 @@
+require "./index"
+require "./type_utils"
+
+module Crystalline::Lightweight
+  enum MethodContractKind
+    YieldSelf
+    YieldElement
+    YieldElementWithIndex
+    YieldKey
+    YieldValue
+    YieldKeyValue
+    YieldAccumulatorAndElement
+    PreserveReceiver
+    ReturnElement
+    ReturnElementOrNil
+    ReturnValue
+    ReturnValueOrNil
+  end
+
+  enum MethodContractResultShape
+    ArrayOfBlockResult
+    ArrayOfCompactBlockResult
+    ArrayOfFlattenedBlockResult
+    HashOfBlockResultToReceiverElement
+    HashOfBlockResultToReceiverElementArray
+    BlockResultOrNil
+  end
+
+  record MethodContract,
+    kind : MethodContractKind,
+    types : Array(String) = [] of String,
+    block_args : Array(Array(String)) = [] of Array(String),
+    result_shape : MethodContractResultShape? = nil,
+    class_method : Bool = false
+
+  module Contracts
+    extend self
+
+    # Derives a method's contracts from its own declaration — the block
+    # restriction and the return type — instead of a per-method-name
+    # table. `map(& : T -> U) : Array(U)` yields the element and returns
+    # an array of the block result; `index_by(& : T -> U) : Hash(U, T)`
+    # yields the element and returns a hash of block result to element.
+    # The declaration is the spec, so stdlib changes cannot drift.
+    def derive(owner_name : String, method : MethodInfo) : Array(MethodContract)
+      contracts = [] of MethodContract
+      # `T?` to_s-es as `T | ::Nil`: strip the absolute-path marker so
+      # the structural comparisons see plain names.
+      normalized_return_types = method.return_type.try { |return_type| TypeUtils.expand_type_names(return_type).map(&.lchop("::")) }
+
+      if normalized_return_types
+        if normalized_return_types == [owner_name] || normalized_return_types == ["self"]
+          contracts << MethodContract.new(kind: MethodContractKind::PreserveReceiver, types: [owner_name], class_method: method.class_method)
+        elsif normalized_return_types.sort == [owner_name, "Nil"].sort
+          contracts << MethodContract.new(kind: MethodContractKind::ReturnValueOrNil, types: [owner_name], class_method: method.class_method)
+        elsif normalized_return_types.includes?("Nil")
+          contracts << MethodContract.new(kind: MethodContractKind::ReturnValueOrNil, types: normalized_return_types.reject(&.==("Nil")), class_method: method.class_method)
+        else
+          contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, types: normalized_return_types, class_method: method.class_method)
+        end
+      end
+
+      if block_restriction = method.block_restriction
+        if split = split_proc_restriction(block_restriction)
+          proc_inputs, proc_output = split
+          element_types = TypeUtils.enumerable_element_types(owner_name) || [] of String
+          element_var = element_types.first? || generic_element_var(owner_name)
+
+          if yield_contract = yield_contract_for(proc_inputs, owner_name, element_types, method)
+            contracts << yield_contract
+          end
+
+          if shape = block_result_shape_for(proc_output, method.return_type, element_types, owner_name)
+            contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, result_shape: shape, class_method: method.class_method)
+          end
+        end
+      end
+
+      # A bare-& method that yields the receiver (`OptionParser.parse do
+      # |parser|`, `File.open(path) do |file|`): the declaration cannot
+      # express the yield target, so the known receiver-yielders are
+      # name-keyed. `String.build` declares the same shape but yields its
+      # builder, not the receiver — deliberately absent.
+      if method.block_restriction.nil? && method.return_type == "self"
+        case "#{owner_name}.#{method.name}"
+        when "OptionParser.parse", "File.open", "IO.open"
+          contracts << MethodContract.new(kind: MethodContractKind::YieldSelf, types: [owner_name], class_method: method.class_method)
+        end
+      end
+
+      # Residual computed shapes: the stdlib declares these with an
+      # untyped block and no return type — `flat_map(& : T -> _)`,
+      # `compact_map(& : T -> _)`, `group_by(& : T -> U)` — the result
+      # only exists in the method body, which the structural derivation
+      # deliberately does not evaluate.
+      case method.name
+      when "flat_map"
+        contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, result_shape: MethodContractResultShape::ArrayOfFlattenedBlockResult, class_method: method.class_method)
+      when "compact_map"
+        contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, result_shape: MethodContractResultShape::ArrayOfCompactBlockResult, class_method: method.class_method)
+      when "group_by"
+        contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, result_shape: MethodContractResultShape::HashOfBlockResultToReceiverElementArray, class_method: method.class_method)
+      when "find_value"
+        contracts << MethodContract.new(kind: MethodContractKind::ReturnValueOrNil, result_shape: MethodContractResultShape::BlockResultOrNil, class_method: method.class_method)
+      end
+
+      # Language intrinsics with no block restriction in the declaration:
+      # `tap(&)` yields the receiver and returns `self`; `try(&)` yields
+      # the non-nil receiver and returns the block result or nil. The
+      # block-arg seeding for both happens at the call site (receiver
+      # types), only the return contracts live here.
+      if method.name == "tap" && normalized_return_types == [owner_name]
+        contracts << MethodContract.new(kind: MethodContractKind::YieldSelf, types: [owner_name], class_method: method.class_method)
+      end
+      if method.name == "try" && !method.class_method
+        contracts << MethodContract.new(kind: MethodContractKind::ReturnValueOrNil, result_shape: MethodContractResultShape::BlockResultOrNil, class_method: method.class_method)
+      end
+
+      # Element-return contracts: the declared return matches the owner's
+      # element/key/value types (`first : T` on `Array(T)`).
+      if element_types = TypeUtils.enumerable_element_types(owner_name)
+        if normalized_return_types
+          if normalized_return_types.sort == element_types.sort
+            contracts << MethodContract.new(kind: MethodContractKind::ReturnElement, types: element_types, class_method: method.class_method)
+          elsif normalized_return_types.sort == (element_types + ["Nil"]).uniq.sort
+            contracts << MethodContract.new(kind: MethodContractKind::ReturnElementOrNil, types: element_types, class_method: method.class_method)
+          end
+        end
+      end
+
+      if key_types = TypeUtils.hash_key_types(owner_name)
+        if value_types = TypeUtils.hash_value_types(owner_name)
+          if normalized_return_types
+            if normalized_return_types.sort == value_types.sort
+              contracts << MethodContract.new(kind: MethodContractKind::ReturnValue, types: value_types, class_method: method.class_method)
+            elsif normalized_return_types.sort == (value_types + ["Nil"]).uniq.sort
+              contracts << MethodContract.new(kind: MethodContractKind::ReturnValueOrNil, types: value_types, class_method: method.class_method)
+            end
+          end
+        end
+      end
+
+      # `reduce`'s accumulator type depends on the memo argument at the
+      # call site: the declaration (`& : (U, T) -> U`) cannot express it,
+      # so it stays name-keyed.
+      if method.name == "reduce"
+        if element_types = TypeUtils.enumerable_element_types(owner_name)
+          contracts << MethodContract.new(kind: MethodContractKind::YieldAccumulatorAndElement, block_args: [element_types, element_types], class_method: method.class_method)
+        end
+      end
+
+      contracts
+    end
+
+    # `(T -> U)` / `(T, Int32 ->)` / `(T -> U | ::Nil)` → {inputs, output}.
+    private def split_proc_restriction(restriction : String) : {Array(String), String}
+      normalized = restriction.strip
+      if normalized.starts_with?('(') && normalized.ends_with?(')')
+        normalized = normalized[1...-1]
+      end
+
+      # The last ` ->` separates the inputs from the output (a nested
+      # Proc type could contain an earlier arrow).
+      arrow = normalized.rindex(" ->")
+      if arrow
+        inputs = TypeUtils.split_top_level(normalized[0...arrow], ',').map(&.strip)
+        output = normalized[arrow + 3..].strip
+        {inputs, output}
+      else
+        {[] of String, normalized}
+      end
+    end
+
+    # Matches the block's input vars against the owner's element/key/value
+    # types: `& : T -> ` on `Array(T)` yields the element, `& : K, V -> `
+    # on `Hash(K, V)` yields key and value. The semantic form of a
+    # multi-arg block is a single tuple input (`::Tuple(K, V) ->`).
+    private def yield_contract_for(proc_inputs : Array(String), owner_name : String, element_types : Array(String), method : MethodInfo) : MethodContract?
+      return nil if proc_inputs == ["self"]
+
+      inputs = if proc_inputs.size == 1
+                 if tuple_parts = TypeUtils.tuple_element_types(proc_inputs.first)
+                   # The block destructures a single tuple element into multiple
+                   # params (`map { |k, v| ... }` on `Array(Tuple(K, V))`):
+                   # compare against the element tuple's parts, not the whole
+                   # tuple.
+                   if element_types.size == 1
+                     if element_parts = TypeUtils.tuple_element_types(element_types.first)
+                       element_types = element_parts.map { |part| part.join(" | ") }
+                     end
+                   end
+                   tuple_parts.map { |part| part.join(" | ") }
+                 else
+                   proc_inputs
+                 end
+               else
+                 proc_inputs
+               end
+
+      if !element_types.empty?
+        # A single input may be a union string (`& : (A | B ->)` on a
+        # compiled instantiation): compare the expanded parts too.
+        expanded_inputs = inputs.flat_map { |input| TypeUtils.expand_type_names(input) }
+        if expanded_inputs == element_types || inputs == element_types
+          return MethodContract.new(kind: MethodContractKind::YieldElement, types: element_types, class_method: method.class_method)
+        end
+        if inputs.size == 2 && inputs[1] == "Int32" && TypeUtils.expand_type_names(inputs[0]) == element_types
+          return MethodContract.new(kind: MethodContractKind::YieldElementWithIndex, types: element_types + ["Int32"], class_method: method.class_method)
+        end
+      elsif element_var = generic_element_var(owner_name)
+        # A generic module owner (`Enumerable(T)`): its single type var is
+        # the element var. The call site substitutes the receiver's types.
+        if inputs == [element_var]
+          return MethodContract.new(kind: MethodContractKind::YieldElement, types: [element_var], class_method: method.class_method)
+        end
+        if inputs == [element_var, "Int32"]
+          return MethodContract.new(kind: MethodContractKind::YieldElementWithIndex, types: [element_var, "Int32"], class_method: method.class_method)
+        end
+      end
+
+      if key_types = TypeUtils.hash_key_types(owner_name)
+        if inputs == key_types
+          return MethodContract.new(kind: MethodContractKind::YieldKey, types: key_types, class_method: method.class_method)
+        end
+        if value_types = TypeUtils.hash_value_types(owner_name)
+          if inputs == value_types
+            return MethodContract.new(kind: MethodContractKind::YieldValue, types: value_types, class_method: method.class_method)
+          end
+          if inputs == key_types + value_types
+            return MethodContract.new(kind: MethodContractKind::YieldKeyValue, types: key_types + value_types, class_method: method.class_method)
+          end
+        end
+      end
+
+      # A helper with a typed block restriction on a non-enumerable owner
+      # (`each_direct_def(node, & : Crystal::Def ->)`): the restriction's
+      # input types ARE the block-arg types. Only concrete names qualify
+      # — a bare single-letter var (`T`) means a generic element handled
+      # by the caller's substitution.
+      if inputs.all? { |input| input.size > 1 || input != input.upcase }
+        return MethodContract.new(kind: MethodContractKind::YieldSelf, types: inputs, class_method: method.class_method)
+      end
+
+      nil
+    end
+
+    # Matches the block's output var against the return type's pattern:
+    # `Array(U)` → array of block result, `U | ::Nil` → block result or
+    # nil, `Hash(U, T)` → hash of block result to element, ...
+    private def block_result_shape_for(proc_output : String, return_type : String?, element_types : Array(String), owner_name : String) : MethodContractResultShape?
+      return nil unless return_type
+      output = proc_output.strip
+      return nil if output.empty?
+
+      # `U?` parses (and to_s-es) as `U | ::Nil`.
+      if output.ends_with?("| ::Nil") || output.ends_with?("| Nil")
+        base = output.rchop("| ::Nil").rchop("| Nil").rstrip
+        return MethodContractResultShape::BlockResultOrNil if return_type == output
+        return MethodContractResultShape::ArrayOfCompactBlockResult if return_type == "Array(#{base})"
+        return nil
+      end
+
+      if output.starts_with?("Array(") && output.ends_with?(')')
+        # `flat_map(& : T -> Array(U)) : Array(U)` splices the block's
+        # array; a map with an array block yields Array(Array(U)).
+        return MethodContractResultShape::ArrayOfFlattenedBlockResult if return_type == output
+        return MethodContractResultShape::ArrayOfBlockResult if return_type == "Array(#{output})"
+        return nil
+      end
+
+      if return_type == "Array(#{output})"
+        return MethodContractResultShape::ArrayOfBlockResult
+      end
+      if return_type == "#{output} | Nil" || return_type == "#{output} | ::Nil"
+        return MethodContractResultShape::BlockResultOrNil
+      end
+      if element_var = element_types.first? || generic_element_var(owner_name)
+        if return_type == "Hash(#{output}, #{element_var})"
+          return MethodContractResultShape::HashOfBlockResultToReceiverElement
+        end
+        if return_type == "Hash(#{output}, Array(#{element_var}))"
+          return MethodContractResultShape::HashOfBlockResultToReceiverElementArray
+        end
+      end
+
+      nil
+    end
+
+    # `Enumerable(T)` → `T`; the single bare type var of a generic owner
+    # is its element var.
+    private def generic_element_var(owner_name : String) : String?
+      open = owner_name.index('(')
+      return nil unless open && owner_name.ends_with?(')')
+
+      args = TypeUtils.split_top_level(owner_name[open + 1...-1], ',')
+      return nil unless args.size == 1
+
+      var = args.first.strip
+      var.size == 1 && var == var.upcase ? var : nil
+    end
+  end
+end

--- a/src/crystalline/lightweight/definitions.cr
+++ b/src/crystalline/lightweight/definitions.cr
@@ -1,0 +1,543 @@
+require "lsp/server"
+require "compiler/crystal/syntax"
+require "../source_mask"
+require "./query"
+require "./resolver"
+
+module Crystalline::Lightweight
+  class Definitions
+    record TypeDefInfo, name : String, location : Crystal::Location?, name_location : Crystal::Location?, name_size : Int32
+    record DefInfo, owner : String?, definition : Crystal::Def, class_method : Bool
+
+    def self.definitions(source : String, file_uri : URI, line_number : Int32, column_number : Int32, query : Query?) : Array(LSP::Location)?
+      definitions_and_reason(source, file_uri, line_number, column_number, query)[0]
+    end
+
+    def self.diagnose(source : String, file_uri : URI, line_number : Int32, column_number : Int32, query : Query?) : String
+      definitions_and_reason(source, file_uri, line_number, column_number, query)[1]
+    end
+
+    # Computes the definitions and their miss reason in a single pass, so
+    # that workspace logging does not double the cost of a miss.
+    def self.definitions_and_reason(source : String, file_uri : URI, line_number : Int32, column_number : Int32, query : Query?) : {Array(LSP::Location)?, String}
+      new(source, file_uri, line_number, column_number, query).definitions_or_reason
+    end
+
+    def initialize(@source : String, @file_uri : URI, @line_number : Int32, @column_number : Int32, @query : Query?)
+    end
+
+    def definitions_or_reason : {Array(LSP::Location)?, String}
+      line = @source.lines(chomp: false)[@line_number]?
+      return {nil, "no line at cursor"} unless line
+
+      # `require "uri"` — jump to the required file.
+      if (require_match = line.match(/\A\s*require\s+["']([^"']+)["']/))
+        string_start = line.index(require_match[1]).not_nil!
+        string_end = string_start + require_match[1].size
+        if @column_number >= string_start && @column_number <= string_end
+          if locations = locations_for_require(require_match[1])
+            return {locations, "resolved require"}
+          end
+          return {nil, "no lightweight require definition for '#{require_match[1]}'"}
+        end
+      end
+
+      span = Resolver.token_span(line, @column_number)
+      return {nil, "no token at cursor"} unless span
+
+      start_index, end_index = span
+      if SourceMask.new(@source).comment_or_string?(@line_number, start_index)
+        return {nil, "token inside comment or string"}
+      end
+
+      token = line[start_index, end_index - start_index]?
+      return {nil, "empty token at cursor"} unless token && !token.empty?
+
+      if start_index > 0 && line[start_index - 1] == '.'
+        receiver = Resolver.receiver_from_line_prefix(@source, @line_number, line[0, start_index - 1])
+        return {nil, "missing query for method definitions"} unless query = @query
+        definitions = locations_for_method(receiver, token, start_index - 1, query)
+        return {definitions, definitions ? "resolved" : "no lightweight method definitions for receiver '#{receiver}' and method '#{token}'"}
+      end
+
+      if Resolver.type_name?(token)
+        definitions = locations_for_type(token)
+        return {definitions, definitions ? "resolved" : "no lightweight type definition for '#{token}'"}
+      end
+
+      if Resolver.instance_var_name?(token) || Resolver.class_var_name?(token)
+        definitions = locations_for_instance_var(token)
+        return {definitions, definitions ? "resolved" : "no lightweight ivar definition for '#{token}'"}
+      end
+
+      if Resolver.local_name?(token)
+        # A local jumps to its declaration (the enclosing def's argument
+        # or the assignment that defines it), which is what hover types
+        # for the same token.
+        if location = visit_local_declarations(parsed_ast, token, @line_number)
+          end_location = Crystal::Location.new(
+            location.filename,
+            location.line_number,
+            location.column_number + token.size - 1,
+          )
+          return {[lsp_location(location, end_location)], "resolved local"}
+        end
+
+        # A bare method name may be a self-call: resolve it against the
+        # enclosing type before falling back to top-level methods.
+        if query = @query
+          if inference = Inference.for(@source, @line_number + 1, @column_number + 1, query)
+            if type_names = inference.self_types[0]?
+              unless type_names.empty?
+                method_infos = type_names.flat_map do |type_name|
+                  query.methods_for(type_name, class_method: inference.class_method_context?).select(&.name.==(token))
+                end
+                if locations = build_method_locations(method_infos)
+                  return {locations, "resolved self-call"}
+                end
+              end
+            end
+          end
+        end
+
+        definitions = locations_for_top_level_method(token)
+        return {definitions, definitions ? "resolved" : "no lightweight top-level method definition for '#{token}'"}
+      end
+
+      {nil, "unsupported definitions token '#{token}'"}
+    end
+
+    private def locations_for_method(receiver : String, method_name : String, analysis_column : Int32, query : Query) : Array(LSP::Location)?
+      type_names, class_method = Resolver.receiver_types(@source, @line_number, analysis_column, receiver, query)
+      return if type_names.empty?
+
+      method_infos = type_names.flat_map do |type_name|
+        # methods_named falls back to the subtypes of compiler hierarchy
+        # roots, so `node.name` on an `ASTNode` receiver jumps to `Var#name`.
+        found = query.methods_named(type_name, method_name, class_method: class_method)
+        if found.empty? && !method_name.ends_with?("=")
+          # Assignment targets hover the setter (`parser.filename` matches
+          # the `filename=` def): jump to it the same way.
+          found = query.methods_named(type_name, "#{method_name}=", class_method: class_method)
+        end
+        found
+      end
+      locations = build_method_locations(method_infos)
+      return locations if locations
+
+      matches = def_infos.select do |info|
+        type_names.includes?(info.owner) && info.class_method == class_method && info.definition.name == method_name
+      end
+      build_locations(matches.map(&.definition))
+    end
+
+    private def locations_for_type(type_name : String) : Array(LSP::Location)?
+      # Resolve the token against the enclosing namespace first, so a bare
+      # `Workspace` inside `Crystalline::Controller` jumps to the type's
+      # indexed definition in another file.
+      if query = @query
+        if inference = Inference.for(@source, @line_number + 1, @column_number + 1, query)
+          if resolved = query.resolve_type_name(type_name, namespace: inference.current_type_name)
+            if type_info = query.find_type(resolved)
+              if start_location = type_info.location
+                infos = [
+                  TypeDefInfo.new(
+                    resolved,
+                    start_location,
+                    type_info.name_location || start_location,
+                    resolved.split("::").last.size,
+                  ),
+                ]
+                return build_type_locations(infos)
+              end
+            end
+          end
+        end
+      end
+
+      matches = type_defs.select do |info|
+        info.name == type_name || info.name.split("::").last == type_name
+      end
+      build_type_locations(matches)
+    end
+
+    # Jumps to the ivar/class-var declaration in this file (`@server : T`,
+    # or the `@server` shorthand argument of initialize). When the variable
+    # is never declared, falls back to the definition of its type, which is
+    # what hover shows.
+    private def locations_for_instance_var(var_name : String) : Array(LSP::Location)?
+      if location = visit_ivar_declarations(parsed_ast, var_name)
+        end_location = Crystal::Location.new(
+          location.filename,
+          location.line_number,
+          location.column_number + var_name.size - 1,
+        )
+        return [lsp_location(location, end_location)]
+      end
+
+      if query = @query
+        if inference = Inference.for(@source, @line_number + 1, @column_number + 1, query)
+          type_names = if Resolver.class_var_name?(var_name)
+                         inference.types_for_class_var(var_name)
+                       else
+                         inference.types_for_instance_var(var_name)
+                       end
+          type_names = type_names.reject(&.==("Nil"))
+          if type_names.size == 1
+            if locations = locations_for_type(type_names.first)
+              return locations
+            end
+          end
+        end
+      end
+
+      nil
+    end
+
+    private def visit_ivar_declarations(node : Crystal::ASTNode, var_name : String) : Crystal::Location?
+      case node
+      when Crystal::Expressions
+        node.expressions.each do |expression|
+          if location = visit_ivar_declarations(expression, var_name)
+            return location
+          end
+        end
+      when Crystal::ClassDef, Crystal::ModuleDef
+        return visit_ivar_declarations(node.body, var_name)
+      when Crystal::Def
+        # The `@server` shorthand in `def initialize(@server : T)` parses as
+        # an arg named "server" plus a leading `@server = server` assignment
+        # in the body; the declaration is the signature argument itself.
+        if var_name.starts_with?('@')
+          body = node.body
+          body_expressions = case body
+                             when Crystal::Expressions then body.expressions
+                             else                           [body]
+                             end
+          body_expressions.each do |expression|
+            next unless expression.is_a?(Crystal::Assign)
+            target = expression.target
+            next unless target.is_a?(Crystal::InstanceVar) && target.name == var_name
+            if arg = node.args.find(&.name.==(var_name.lchop('@')))
+              return arg.location
+            end
+          end
+        end
+        return visit_ivar_declarations(node.body, var_name)
+      when Crystal::TypeDeclaration
+        case var = node.var
+        when Crystal::InstanceVar, Crystal::ClassVar
+          return node.location if var.name == var_name
+        end
+      when Crystal::Assign
+        # An ivar that is never declared (e.g. `@workspace = Workspace.new`)
+        # is defined by its first assignment.
+        case target = node.target
+        when Crystal::InstanceVar, Crystal::ClassVar
+          return target.location if target.name == var_name
+        end
+      end
+      nil
+    end
+
+    private def locations_for_top_level_method(method_name : String) : Array(LSP::Location)?
+      if query = @query
+        method_locations = build_method_locations(query.top_level_methods.select(&.name.==(method_name)))
+        return method_locations if method_locations
+      end
+
+      matches = def_infos.select do |info|
+        info.owner.nil? && info.definition.name == method_name
+      end
+      build_locations(matches.map(&.definition))
+    end
+
+    # Resolves a `require "path"` to the required file, relative to the
+    # requiring file first, then through the crystal path (lib + stdlib).
+    private def locations_for_require(require_name : String) : Array(LSP::Location)?
+      candidates = [] of String
+      file_dir = File.dirname(@file_uri.decoded_path)
+      if require_name.starts_with?("./") || require_name.starts_with?("../")
+        candidates << File.expand_path(require_name, file_dir)
+        candidates << File.join(File.expand_path(File.dirname(require_name), file_dir), "#{File.basename(require_name)}.cr")
+      else
+        (Crystal::CrystalPath.default_paths + [file_dir]).each do |base|
+          candidates << File.join(base, "#{require_name}.cr")
+          candidates << File.join(base, require_name, "#{File.basename(require_name)}.cr")
+          # Shard layout: `require "foo"` resolves to `lib/foo/src/foo.cr`.
+          candidates << File.join(base, require_name, "src", "#{File.basename(require_name)}.cr")
+        end
+      end
+
+      if path = candidates.find { |candidate| File.exists?(candidate) }
+        location = Crystal::Location.new(File.expand_path(path), 1, 1)
+        return [lsp_location(location, location)]
+      end
+      nil
+    end
+
+    # The declaration of a local: the enclosing def's argument, or a
+    # block parameter whose block contains the cursor, else the first
+    # assignment to it in the def's body. Top-level code has no enclosing
+    # def — assignments anywhere qualify.
+    private def visit_local_declarations(node : Crystal::ASTNode, name : String, line : Int32) : Crystal::Location?
+      if definition = enclosing_def(node, line)
+        # Body first: a block parameter shadows the def's argument when
+        # the cursor sits inside the block.
+        if location = visit_local_assignments(definition.body, name, line)
+          return location
+        end
+        return definition.args.find(&.name.==(name)).try(&.location)
+      end
+      visit_local_assignments(node, name, line)
+    end
+
+    private def enclosing_def(node : Crystal::ASTNode, line : Int32) : Crystal::Def?
+      case node
+      when Crystal::Expressions
+        node.expressions.each do |expression|
+          if found = enclosing_def(expression, line)
+            return found
+          end
+        end
+      when Crystal::ClassDef, Crystal::ModuleDef
+        return enclosing_def(node.body, line)
+      when Crystal::Def
+        return node if span_contains_line?(node, line)
+      end
+      nil
+    end
+
+    private def span_contains_line?(node : Crystal::ASTNode, line : Int32) : Bool
+      start_line = node.location.try(&.line_number)
+      return false unless start_line && start_line <= line
+      end_line = node.end_location.try(&.line_number)
+      end_line.nil? || line <= end_line
+    end
+
+    private def visit_local_assignments(node : Crystal::ASTNode?, name : String, line : Int32) : Crystal::Location?
+      node || return
+      case node
+      when Crystal::Expressions
+        node.expressions.each do |expression|
+          if location = visit_local_assignments(expression, name, line)
+            return location
+          end
+        end
+      when Crystal::If
+        if location = visit_local_assignments(node.then, name, line)
+          return location
+        end
+        visit_local_assignments(node.else, name, line)
+      when Crystal::Unless
+        if location = visit_local_assignments(node.then, name, line)
+          return location
+        end
+        visit_local_assignments(node.else, name, line)
+      when Crystal::While, Crystal::Until
+        visit_local_assignments(node.body, name, line)
+      when Crystal::Case
+        node.whens.each do |when_node|
+          if location = visit_local_assignments(when_node.body, name, line)
+            return location
+          end
+        end
+        visit_local_assignments(node.else, name, line)
+      when Crystal::ExceptionHandler
+        if location = visit_local_assignments(node.body, name, line)
+          return location
+        end
+        if node.rescues
+          node.rescues.not_nil!.each do |rescue_node|
+            if location = visit_local_assignments(rescue_node.body, name, line)
+              return location
+            end
+          end
+        end
+        visit_local_assignments(node.else, name, line)
+      when Crystal::Block
+        # A block parameter is a declaration only when the block contains
+        # the cursor — otherwise the name refers to an outer local.
+        if span_contains_line?(node, line)
+          if arg = node.args.find(&.name.==(name))
+            return arg.location
+          end
+        end
+        visit_local_assignments(node.body, name, line)
+      when Crystal::Call
+        if block = node.block
+          if location = visit_local_assignments(block, name, line)
+            return location
+          end
+        end
+        node.args.each do |arg|
+          if location = visit_local_assignments(arg, name, line)
+            return location
+          end
+        end
+        nil
+      when Crystal::Assign
+        if target_location = assignment_target_location(node.target, name)
+          return target_location
+        end
+        visit_local_assignments(node.value, name, line)
+      when Crystal::OpAssign
+        assignment_target_location(node.target, name)
+      when Crystal::MultiAssign
+        node.targets.each do |target|
+          if target_location = assignment_target_location(target, name)
+            return target_location
+          end
+        end
+        nil
+      when Crystal::TypeDeclaration
+        assignment_target_location(node.var, name)
+      else
+        nil
+      end
+    end
+
+    private def assignment_target_location(target : Crystal::ASTNode, name : String) : Crystal::Location?
+      case target
+      when Crystal::Var
+        target.location if target.name == name
+      when Crystal::TupleLiteral
+        # `(a, b) = tuple` destructures into a tuple of Vars.
+        target.elements.each do |element|
+          if location = assignment_target_location(element, name)
+            return location
+          end
+        end
+        nil
+      else
+        nil
+      end
+    end
+
+    private def build_method_locations(methods : Array(MethodInfo)) : Array(LSP::Location)?
+      locations = methods.compact_map do |method|
+        start_location = method.name_location || method.location
+        next unless start_location
+
+        name_size = method.name_size.zero? ? method.name.size : method.name_size
+        end_location = Crystal::Location.new(
+          start_location.filename,
+          start_location.line_number,
+          start_location.column_number + name_size - 1,
+        )
+
+        lsp_location(start_location, end_location)
+      end
+
+      locations.empty? ? nil : locations
+    end
+
+    private def build_locations(definitions : Array(Crystal::Def)) : Array(LSP::Location)?
+      locations = definitions.compact_map do |definition|
+        name_location = definition.name_location || definition.location
+        next unless name_location
+
+        end_location = Crystal::Location.new(
+          name_location.filename,
+          name_location.line_number,
+          name_location.column_number + definition.name.size - 1,
+        )
+
+        lsp_location(name_location, end_location)
+      end
+
+      locations.empty? ? nil : locations
+    end
+
+    private def build_type_locations(type_infos : Array(TypeDefInfo)) : Array(LSP::Location)?
+      locations = type_infos.compact_map do |info|
+        start_location = info.name_location || info.location
+        next unless start_location
+
+        end_location = Crystal::Location.new(
+          start_location.filename,
+          start_location.line_number,
+          start_location.column_number + info.name_size - 1,
+        )
+
+        lsp_location(start_location, end_location)
+      end
+
+      locations.empty? ? nil : locations
+    end
+
+    private def lsp_location(start_location : Crystal::Location, end_location : Crystal::Location) : LSP::Location
+      LSP::Location.new(
+        uri: "file://#{start_location.original_filename}",
+        range: LSP::Range.new(
+          start: LSP::Position.new(line: start_location.line_number - 1, character: start_location.column_number - 1),
+          end: LSP::Position.new(line: end_location.line_number - 1, character: end_location.column_number),
+        ),
+      )
+    end
+
+    private def def_infos : Array(DefInfo)
+      infos = [] of DefInfo
+      visit_defs(parsed_ast, infos)
+      infos
+    end
+
+    private def visit_defs(node : Crystal::ASTNode, infos : Array(DefInfo), namespace : String? = nil)
+      case node
+      when Crystal::Expressions
+        node.expressions.each { |expression| visit_defs(expression, infos, namespace) }
+      when Crystal::ClassDef
+        visit_defs(node.body, infos, qualify_type_name(node.name.to_s, namespace))
+      when Crystal::ModuleDef
+        visit_defs(node.body, infos, qualify_type_name(node.name.to_s, namespace))
+      when Crystal::Def
+        infos << DefInfo.new(owner: namespace, definition: node, class_method: !node.receiver.nil?)
+      end
+    end
+
+    private def type_defs : Array(TypeDefInfo)
+      infos = [] of TypeDefInfo
+      visit_type_defs(parsed_ast, infos)
+      infos
+    end
+
+    private def visit_type_defs(node : Crystal::ASTNode, infos : Array(TypeDefInfo), namespace : String? = nil)
+      case node
+      when Crystal::Expressions
+        node.expressions.each { |expression| visit_type_defs(expression, infos, namespace) }
+      when Crystal::ClassDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        infos << TypeDefInfo.new(type_name, node.location, node.name_location, node.name.to_s.size)
+        visit_type_defs(node.body, infos, type_name)
+      when Crystal::ModuleDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        infos << TypeDefInfo.new(type_name, node.location, node.name_location, node.name.to_s.size)
+        visit_type_defs(node.body, infos, type_name)
+      when Crystal::EnumDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        infos << TypeDefInfo.new(type_name, node.location, node.name_location, node.name.to_s.size)
+      when Crystal::AnnotationDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        infos << TypeDefInfo.new(type_name, node.location, node.name_location, node.name.to_s.size)
+      end
+    end
+
+    # A single definitions request can walk defs, type defs and ivar
+    # declarations: parse the source once and reuse the AST.
+    @parsed_ast : Crystal::ASTNode? = nil
+
+    private def parsed_ast : Crystal::ASTNode
+      @parsed_ast ||= begin
+        parser = Crystal::Parser.new(@source)
+        parser.wants_doc = false
+        parser.filename = @file_uri.decoded_path
+        parser.parse
+      end
+    end
+
+    private def qualify_type_name(name : String, namespace : String?) : String
+      return name if namespace.nil? || name.includes?("::")
+      "#{namespace}::#{name}"
+    end
+  end
+end

--- a/src/crystalline/lightweight/hover.cr
+++ b/src/crystalline/lightweight/hover.cr
@@ -1,0 +1,249 @@
+require "lsp/server"
+require "../source_mask"
+require "./query"
+require "./resolver"
+
+module Crystalline::Lightweight
+  class Hover
+    def self.hover(source : String, line_number : Int32, column_number : Int32, query : Query) : LSP::Hover?
+      hover_and_reason(source, line_number, column_number, query)[0]
+    end
+
+    def self.diagnose(source : String, line_number : Int32, column_number : Int32, query : Query) : String
+      hover_and_reason(source, line_number, column_number, query)[1]
+    end
+
+    # Computes the hover and its miss reason in a single pass, so that
+    # workspace logging does not double the cost of a miss.
+    def self.hover_and_reason(source : String, line_number : Int32, column_number : Int32, query : Query) : {LSP::Hover?, String}
+      new(source, line_number, column_number, query).hover_or_reason
+    end
+
+    def initialize(@source : String, @line_number : Int32, @column_number : Int32, @query : Query)
+    end
+
+    def hover_or_reason : {LSP::Hover?, String}
+      line = @source.lines(chomp: false)[@line_number]?
+      return {nil, "no line at cursor"} unless line
+
+      span = Resolver.token_span(line, @column_number)
+      return {nil, "no token at cursor"} unless span
+
+      start_index, end_index = span
+      if SourceMask.new(@source).comment_or_string?(@line_number, start_index)
+        return {nil, "token inside comment or string"}
+      end
+
+      token = line[start_index, end_index - start_index]?
+      return {nil, "empty token at cursor"} unless token && !token.empty?
+
+      if start_index > 0 && line[start_index - 1] == '.' && !(start_index > 1 && line[start_index - 2] == '.')
+        # The receiver may span lines: walk back over the whole source
+        # when the single-line receiver suggests a block closer or a
+        # continuation (see Resolver.receiver_from_line_prefix).
+        # A token preceded by `..`/`...` is a range bound (`a..b`,
+        # `c...d`), not a method call: fall through to the local/type
+        # hovers instead of building a bogus receiver.
+        line_prefix = line[0, start_index - 1]
+        receiver = Resolver.receiver_from_line_prefix(@source, @line_number, line_prefix)
+        return {nil, "empty method receiver"} if receiver.empty?
+
+        hover = hover_for_method(receiver, token, start_index - 1)
+        return {hover, hover ? "resolved" : "no lightweight method hover for receiver '#{receiver}' and method '#{token}'"}
+      end
+
+      if token == "self"
+        hover = hover_for_self
+        return {hover, hover ? "resolved" : "could not infer self type"}
+      end
+
+      if Resolver.type_name?(token)
+        hover = hover_for_type(token)
+        return {hover, hover ? "resolved" : "unknown lightweight type '#{token}'"}
+      end
+
+      if Resolver.instance_var_name?(token)
+        hover = hover_for_instance_var(token)
+        return {hover, hover ? "resolved" : "could not infer instance var '#{token}'"}
+      end
+
+      if Resolver.class_var_name?(token)
+        hover = hover_for_class_var(token)
+        return {hover, hover ? "resolved" : "could not infer class var '#{token}'"}
+      end
+
+      if Resolver.local_name?(token)
+        # A bare name may be a self-call (e.g. a `getter!` used without an
+        # explicit receiver): resolve it as a method on the enclosing type.
+        hover = hover_for_local(token) || hover_for_method("self", token, start_index) || hover_for_top_level_method(token)
+        return {hover, hover ? "resolved" : "could not infer local or top-level method '#{token}'"}
+      end
+
+      {nil, "unsupported hover token '#{token}'"}
+    end
+
+    # Compiler-intrinsic predicates lexed as token keywords (`nil?`,
+    # `is_a?`, `as?`, `responds_to?`): they exist on every type but are
+    # never real defs in the compiled program, so the index cannot contain
+    # them. Hover with their known signatures instead of a miss.
+    SPECIAL_METHOD_HOVERS = {
+      "nil?"         => "nil? : Bool",
+      "is_a?"        => "is_a?(type : T.class) : Bool",
+      "responds_to?" => "responds_to?(name : String) : Bool",
+      "as"           => "as(type : T.class) : T",
+      "as?"          => "as?(type : T.class) : T | Nil",
+    }
+
+    private def hover_for_method(receiver : String, method_name : String, analysis_column : Int32) : LSP::Hover?
+      type_names, class_method = Resolver.receiver_types(@source, @line_number, analysis_column, receiver, @query)
+      if type_names.empty?
+        # The receiver may be untyped (e.g. a local whose stdlib receiver
+        # type is not in the prelude index): the intrinsic predicates still
+        # exist on every type.
+        if signature = SPECIAL_METHOD_HOVERS[method_name]?
+          return build_hover([signature], nil)
+        end
+        return
+      end
+
+      methods = type_names.flat_map do |type_name|
+        # `parser.wants_doc = true` hovers the base name: also match the
+        # setter form (`wants_doc=`) so assignment targets resolve.
+        # methods_named falls back to the subtypes of compiler hierarchy
+        # roots (`Crystal::ASTNode#name` resolves through `Var`), the
+        # same fallback completion applies.
+        @query.methods_named(type_name, method_name, class_method: class_method) +
+          @query.methods_named(type_name, "#{method_name}=", class_method: class_method)
+      end
+      if methods.empty?
+        if signature = SPECIAL_METHOD_HOVERS[method_name]?
+          return build_hover([signature], nil)
+        end
+        return
+      end
+
+      build_hover(
+        methods.map { |method| format_method(method, include_owner: true) },
+        methods.compact_map(&.doc).first?,
+      )
+    end
+
+    private def hover_for_type(type_name : String) : LSP::Hover?
+      # Resolve against the enclosing namespace so a bare type name (e.g.
+      # `Workspace` inside `Crystalline::Controller`) finds its full name.
+      if inference = Inference.for(@source, @line_number + 1, @column_number + 1, @query)
+        if resolved = @query.resolve_type_name(type_name, namespace: inference.current_type_name)
+          if type = @query.find_type(resolved)
+            return build_hover([type.name], type.doc)
+          end
+        end
+      end
+
+      type = @query.find_type(type_name)
+      return unless type
+
+      build_hover([type.name], type.doc)
+    end
+
+    private def hover_for_self : LSP::Hover?
+      inference = Inference.for(@source, @line_number + 1, @column_number + 1, @query)
+      return unless inference
+
+      type_names, class_method = inference.self_types
+      return if type_names.empty?
+
+      label = class_method ? "self : #{type_names.uniq.join(" | ")}.class" : "self : #{type_names.uniq.join(" | ")}"
+      doc = type_names.size == 1 ? @query.find_type(type_names.first).try(&.doc) : nil
+      build_hover([label], doc)
+    end
+
+    private def hover_for_local(name : String) : LSP::Hover?
+      inference = Inference.for(@source, @line_number + 1, @column_number + 1, @query)
+      return unless inference
+
+      type_names = inference.types_for(name)
+      return if type_names.empty?
+
+      doc = type_names.size == 1 ? @query.find_type(type_names.first).try(&.doc) : nil
+      build_hover(["#{name} : #{type_names.uniq.join(" | ")}"], doc)
+    end
+
+    private def hover_for_instance_var(name : String) : LSP::Hover?
+      inference = Inference.for(@source, @line_number + 1, @column_number + 1, @query)
+      return unless inference
+
+      type_names = inference.types_for_instance_var(name)
+      return if type_names.empty?
+
+      doc = type_names.size == 1 ? @query.find_type(type_names.first).try(&.doc) : nil
+      build_hover(["#{name} : #{type_names.uniq.join(" | ")}"], doc)
+    end
+
+    private def hover_for_class_var(name : String) : LSP::Hover?
+      inference = Inference.for(@source, @line_number + 1, @column_number + 1, @query)
+      return unless inference
+
+      type_names = inference.types_for_class_var(name)
+      return if type_names.empty?
+
+      doc = type_names.size == 1 ? @query.find_type(type_names.first).try(&.doc) : nil
+      build_hover(["#{name} : #{type_names.uniq.join(" | ")}"], doc)
+    end
+
+    private def hover_for_top_level_method(method_name : String) : LSP::Hover?
+      methods = @query.top_level_methods.select { |method| method.name == method_name }
+      return if methods.empty?
+
+      build_hover(
+        methods.map { |method| format_method(method, include_owner: true) },
+        methods.compact_map(&.doc).first?,
+      )
+    end
+
+    private def build_hover(signatures : Array(String), doc : String?) : LSP::Hover
+      contents = [] of String
+      contents << code_markdown(signatures.uniq.join("\n"), language: "crystal")
+
+      if doc
+        contents << "----------"
+        contents << doc
+      end
+
+      LSP::Hover.new(
+        contents: LSP::MarkupContent.new(
+          kind: LSP::MarkupKind::MarkDown,
+          value: contents.join("\n"),
+        ),
+      )
+    end
+
+    private def code_markdown(str : String, *, language = "") : String
+      <<-MARKDOWN
+      ```#{language}
+      #{str}
+      ```
+      MARKDOWN
+    end
+
+    private def format_method(method : MethodInfo, *, include_owner = false) : String
+      args = method.args.map do |arg|
+        if restriction = arg.restriction
+          "#{arg.name} : #{restriction}"
+        else
+          arg.name
+        end
+      end.join(", ")
+
+      String.build do |str|
+        if include_owner
+          str << method.owner
+          str << (method.class_method ? "." : "#")
+        end
+
+        str << method.name
+        str << "(#{args})"
+        str << " : #{method.return_type}" if method.return_type
+      end
+    end
+  end
+end

--- a/src/crystalline/lightweight/index.cr
+++ b/src/crystalline/lightweight/index.cr
@@ -1,0 +1,1186 @@
+require "compiler/crystal/syntax"
+require "./type_utils"
+
+module Crystalline::Lightweight
+  enum TypeKind
+    Class
+    Module
+    Struct
+    Enum
+    Annotation
+    Alias
+    Lib
+    Constant
+    Unknown
+  end
+
+  record ArgInfo, name : String, restriction : String?
+
+  record MethodInfo,
+    name : String,
+    owner : String,
+    args : Array(ArgInfo),
+    return_type : String?,
+    class_method : Bool = false,
+    macro : Bool = false,
+    doc : String? = nil,
+    location : Crystal::Location? = nil,
+    name_location : Crystal::Location? = nil,
+    name_size : Int32 = 0,
+    free_vars : Array(String) = [] of String,
+    block_restriction : String? = nil
+
+  class TypeInfo
+    getter name : String
+    getter kind : TypeKind
+    getter doc : String?
+    getter methods = [] of MethodInfo
+    getter subtypes = [] of String
+    getter parent_types = [] of String
+    getter location : Crystal::Location?
+    getter name_location : Crystal::Location?
+    getter ivars = {} of String => Array(String)
+    getter class_vars = {} of String => Array(String)
+    # `delegate foo, bar, to: @array` — macro-generated passthrough
+    # methods: method name -> delegate target expression (`@array`). The
+    # query resolves them against the target's indexed type.
+    getter delegates = {} of String => String
+    # `forward_missing_to @array` — every unknown method delegates.
+    property forward_missing_to : String?
+
+    def initialize(@name : String, @kind : TypeKind, @doc : String? = nil, @location : Crystal::Location? = nil, @name_location : Crystal::Location? = nil)
+    end
+  end
+
+  class Index
+    getter types = {} of String => TypeInfo
+    getter top_level_methods = [] of MethodInfo
+    # Word-list constants (`COLORS = %w(...)`) that `{% for name in COLORS %}`
+    # loops iterate: filled while walking this index's own source.
+    @constant_word_lists = {} of String => Array(String)
+
+    # Merges several indexes into one (e.g. the project's source files).
+    # A type defined in several indexes (e.g. `Crystal::ASTNode` split
+    # across compiler files) keeps the union of its methods, parents,
+    # subtypes and ivars instead of letting the last definition win.
+    def self.merge(indexes : Array(Index)) : Index
+      merged = Index.new
+      indexes.each do |index|
+        index.types.each do |name, type|
+          if existing = merged.types[name]?
+            type.methods.each do |method|
+              if existing_index = existing.methods.index { |m| same_method?(m, method) }
+                # The compiled (semantic) def often drops the block
+                # restriction (`(T -> _)`); the source-derived one carries
+                # the real declaration. Prefer the richer method.
+                existing_restriction = existing.methods[existing_index].block_restriction
+                if existing_restriction.nil? || existing_restriction.includes?('_')
+                  new_restriction = method.block_restriction
+                  if new_restriction && !new_restriction.includes?('_')
+                    existing.methods[existing_index] = method
+                  end
+                end
+                # The semantic def also drops typed return types on free-var
+                # methods (`group_by` keeps `(T -> U)` but loses
+                # `Hash(U, Array(T))`): the source declaration wins.
+                if existing.methods[existing_index].return_type.nil? && method.return_type
+                  existing.methods[existing_index] = method
+                end
+              else
+                existing.methods << method
+              end
+            end
+            type.parent_types.each { |p| existing.parent_types << p unless existing.parent_types.includes?(p) }
+            type.subtypes.each { |s| existing.subtypes << s unless existing.subtypes.includes?(s) }
+            type.ivars.each { |k, v| (existing.ivars[k] ||= [] of String).concat(v).uniq! }
+            type.class_vars.each { |k, v| (existing.class_vars[k] ||= [] of String).concat(v).uniq! }
+            type.delegates.each { |k, v| existing.delegates[k] = v unless existing.delegates.has_key?(k) }
+            existing.forward_missing_to ||= type.forward_missing_to
+          else
+            merged.types[name] = type
+          end
+        end
+        merged.top_level_methods.concat(index.top_level_methods)
+      end
+      merged
+    end
+
+    # True when two method infos share the same name, owner and signature,
+    # so an overlay redefinition can be matched against an indexed one.
+    # The location is deliberately not compared: a same-signature method
+    # from a newer source wins when its location differs.
+    def self.same_method?(left : MethodInfo, right : MethodInfo) : Bool
+      left.name == right.name &&
+        left.owner == right.owner &&
+        left.class_method == right.class_method &&
+        left.macro == right.macro &&
+        left.args.map(&.restriction) == right.args.map(&.restriction)
+    end
+
+    def self.from_program(program : Crystal::Program) : self
+      new.tap do |index|
+        program.types.each_value do |type|
+          index.index_type(type)
+        end
+
+        if defs = program.defs
+          defs.each_value do |items|
+            items.each do |item|
+              index.top_level_methods << index.method_info_for(item.def, owner: "::")
+            end
+          end
+        end
+      end
+    end
+
+    def self.from_source(source : String, filename : String? = nil) : self?
+      parser = Crystal::Parser.new(source)
+      parser.wants_doc = true
+      # The parser defaults locations to an empty filename: leave it alone
+      # unless a real one is given, so same-source locations stay comparable.
+      parser.filename = filename if filename
+      ast = parser.parse
+
+      new.tap do |index|
+        index.index_syntax_node(ast)
+      end
+    rescue Crystal::SyntaxException
+      nil
+    end
+
+    protected def index_syntax_node(node : Crystal::ASTNode, namespace : String? = nil)
+      case node
+      when Crystal::Expressions
+        node.expressions.each { |expression| index_syntax_node(expression, namespace) }
+      when Crystal::Assign
+        # `COLORS = %w(...)` — a top-level word-list constant that macro
+        # loops iterate (`{% for name in COLORS %}`).
+        index_constant_word_list(node)
+      when Crystal::VisibilityModifier
+        if assign = node.exp.as?(Crystal::Assign)
+          index_constant_word_list(assign)
+        end
+        index_syntax_node(node.exp, namespace)
+      when Crystal::ClassDef
+        type_name = qualify_type_name(generic_type_name(node.name, node.type_vars), namespace)
+        type_info = (@types[type_name] ||= TypeInfo.new(type_name, node.struct? ? TypeKind::Struct : TypeKind::Class, node.doc, node.location, node.name_location))
+        if superclass = node.superclass
+          superclass_name = superclass.to_s
+          type_info.parent_types << superclass_name unless type_info.parent_types.includes?(superclass_name)
+        elsif node.struct?
+          # A struct without a superclass implicitly extends Struct
+          # (and thus Reference/Object): record it so `try`,
+          # `not_nil!`, ... resolve on structs.
+          type_info.parent_types << "Struct" unless type_info.parent_types.includes?("Struct")
+        else
+          # A class without a superclass implicitly extends Reference (and
+          # thus Object): record it so Object's methods (`not_nil!`, `try`,
+          # ...) resolve on every class.
+          type_info.parent_types << "Reference" unless type_info.parent_types.includes?("Reference")
+        end
+        index_syntax_type_body(type_info, node.body, type_name)
+        # `new` is compiler-synthesized from `initialize`: synthesize a
+        # class method so `Class.` completion and hovers offer it.
+        index_new_method(type_info, type_name)
+      when Crystal::ModuleDef
+        type_name = qualify_type_name(generic_type_name(node.name, node.type_vars), namespace)
+        type_info = (@types[type_name] ||= TypeInfo.new(type_name, TypeKind::Module, node.doc, node.location, node.name_location))
+        index_syntax_type_body(type_info, node.body, type_name)
+      when Crystal::EnumDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        type_info = (@types[type_name] ||= TypeInfo.new(type_name, TypeKind::Enum, node.doc, node.location, node.name_location))
+        # An enum without an explicit superclass implicitly extends Enum
+        # (and thus Value/Object): record it so `to_s`, `try`, ... resolve.
+        type_info.parent_types << "Enum" unless type_info.parent_types.includes?("Enum")
+        # Enum members are constants: record them as subtypes so
+        # `Enum::` completion offers the members. Crystal's `enum` macro
+        # also generates a `member?` predicate for every member (e.g.
+        # `DelimiterStart` -> `delimiter_start?`): synthesize them too,
+        # since macro-generated defs never appear in the source walk.
+        node.members.each do |member|
+          member_name = case member
+                        when Crystal::Arg
+                          member.name
+                        when Crystal::Path
+                          member.to_s
+                        when Crystal::Assign
+                          member.target.is_a?(Crystal::Path) ? member.target.to_s : nil
+                        end
+          next unless member_name
+          type_info.subtypes << member_name unless type_info.subtypes.includes?(member_name)
+
+          predicate = "#{member_name.underscore}?"
+          next if type_info.methods.any? { |m| m.name == predicate }
+          type_info.methods << MethodInfo.new(
+            name: predicate,
+            owner: type_name,
+            args: [] of ArgInfo,
+            return_type: "Bool",
+          )
+        end
+      when Crystal::AnnotationDef
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        @types[type_name] ||= TypeInfo.new(type_name, TypeKind::Annotation, node.doc, node.location, node.name_location)
+      when Crystal::Alias
+        # An alias is a first-class type name: methods resolve through the
+        # aliased type (its parent), so `Alias.` completes like the target.
+        type_name = qualify_type_name(node.name.to_s, namespace)
+        type_info = (@types[type_name] ||= TypeInfo.new(type_name, TypeKind::Alias, node.doc, node.location, node.name_location))
+        aliased_name = node.value.to_s
+        type_info.parent_types << aliased_name unless type_info.parent_types.includes?(aliased_name)
+      when Crystal::Def
+        return if node.receiver
+        @top_level_methods << method_info_for(node, owner: "::")
+      when Crystal::Macro
+        # `macro finished` bodies (the LSP shard's request classes)
+        # expand at compile time into real classes under the current
+        # namespace. The body is raw macro text (MacroLiterals):
+        # re-parse each literal and index whatever parses cleanly, so
+        # those classes and their accessors (`property params`) resolve
+        # before the first compile.
+        index_macro_body(node.body, namespace)
+      when Crystal::Call
+        # A top-level `record Foo, ...` parses as a call.
+        index_record_call(node, namespace)
+      end
+    end
+
+    protected def index_macro_body(node : Crystal::ASTNode, namespace : String?)
+      return unless node.is_a?(Crystal::Expressions)
+      # The macro body parses as a sequence of MacroLiterals whose
+      # boundaries do not align with the code's own structure (a
+      # `class ... end` may span several literals): concatenate the raw
+      # text and parse it as one unit.
+      text = String.build do |io|
+        node.expressions.each do |expression|
+          io << expression.value if expression.is_a?(Crystal::MacroLiteral)
+        end
+      end
+      return if text.strip.empty?
+      reparsed = Crystal::Parser.new(text).parse
+      index_syntax_node(reparsed, namespace)
+    rescue Crystal::SyntaxException
+      # Spliced interpolations (`{{ ... }}`) may not parse on their
+      # own: skip macros that do not parse cleanly.
+    end
+
+    # Macro control-flow branches (`{% if ... %}` / `{% for ... %}`)
+    # parse as raw MacroLiteral text: re-parse it and index it as
+    # type-body code, so class vars, ivars and defs inside the branch
+    # resolve before the first compile.
+    protected def index_macro_branch(node : Crystal::ASTNode, type_info : TypeInfo, type_name : String)
+      text = String.build do |io|
+        case node
+        when Crystal::Expressions
+          node.expressions.each do |expression|
+            io << expression.value if expression.is_a?(Crystal::MacroLiteral)
+          end
+        when Crystal::MacroLiteral
+          io << node.value
+        end
+      end
+      return if text.strip.empty?
+      reparsed = Crystal::Parser.new(text).parse
+      index_syntax_type_body(type_info, reparsed, type_name)
+    rescue Crystal::SyntaxException
+      # Spliced interpolations may not parse on their own: skip.
+    end
+
+    # `{% for name in %w(...) %}` loops over literal word lists generate
+    # one body per iteration (`class {{name.id}}; include ExpandableNode; end`):
+    # expand the interpolation per word and index each generated body, so
+    # loop-generated reopenings merge into the real types (the raw body
+    # cannot re-parse with the interpolation intact).
+    protected def index_macro_for(node : Crystal::MacroFor, type_info : TypeInfo, type_name : String)
+      words = macro_for_words(node.exp)
+      if words.empty?
+        index_macro_branch(node.body, type_info, type_name)
+        return
+      end
+
+      text = String.build do |io|
+        node.body.try do |body|
+          case body
+          when Crystal::Expressions
+            body.expressions.each do |expression|
+              case expression
+              when Crystal::MacroLiteral
+                io << expression.value
+              when Crystal::MacroExpression
+                # `{{ name.id }}` interpolates the loop variable: keep the
+                # marker text so the per-word expansion below can replace it.
+                io << expression.to_s
+              end
+            end
+          when Crystal::MacroLiteral
+            io << body.value
+          end
+        end
+      end
+      return if text.strip.empty?
+
+      # Single-variable loops (`{% for name in %w(...) %}`) interpolate
+      # `{{name.id}}`; multi-variable loops (a `%w` of pairs) fall back to
+      # the raw reparse below.
+      if (loop_var = node.vars.first?) && node.vars.size == 1
+        interpolation = /\{\{\s*#{Regex.escape(loop_var.name)}\.id\s*\}\}/
+        # `{{name.camelcase.id}}` (e.g. `ColorANSI::{{name.camelcase.id}}`)
+        # and `{{mode.underscore.id}}` (enum member loops): the reparse
+        # would otherwise throw on the macro expression and skip the loop.
+        camelcase_interpolation = /\{\{\s*#{Regex.escape(loop_var.name)}\.camelcase\.id\s*\}\}/
+        underscore_interpolation = /\{\{\s*#{Regex.escape(loop_var.name)}\.underscore\.id\s*\}\}/
+        words.each do |word|
+          expanded = text
+            .gsub(interpolation, word)
+            .gsub(camelcase_interpolation, word.camelcase)
+            .gsub(underscore_interpolation, word.underscore)
+          reparsed = Crystal::Parser.new(expanded).parse
+          index_syntax_type_body(type_info, reparsed, type_name)
+        end
+        return
+      end
+
+      index_macro_branch(node.body, type_info, type_name)
+    rescue Crystal::SyntaxException
+      # An iteration may not parse on its own: skip the loop.
+    end
+
+    # The word list of `{% for x in %w(a b c) %}`: parses as an array
+    # literal of strings, or as raw macro text in macro context. The
+    # collection may also name a constant (`{% for name in COLORS %}`)
+    # whose `%w(...)` value was registered by index_constant_word_list.
+    private def macro_for_words(node : Crystal::ASTNode?) : Array(String)
+      return [] of String unless node
+      case node
+      when Crystal::ArrayLiteral
+        node.elements.compact_map { |element| element.as?(Crystal::StringLiteral).try(&.value) }
+      when Crystal::MacroLiteral
+        if match = node.value.match(/^\s*%w\(([^)]*)\)/)
+          match[1].split
+        elsif words = @constant_word_lists[node.value.strip]?
+          words
+        else
+          [] of String
+        end
+      when Crystal::Path
+        @constant_word_lists[node.to_s]? || [] of String
+      when Crystal::Call
+        # `{% for mode in Mode.constants.reject {...} %}` — the enum's
+        # member names (recorded as subtypes by index_syntax_node) are the
+        # words; the stdlib's All/None sentinels never appear as members.
+        collection = node
+        collection = collection.obj if collection.name == "reject" && collection.obj
+        if collection.is_a?(Crystal::Call) && collection.name == "constants"
+          if enum_path = collection.obj.as?(Crystal::Path)
+            enum_name = @types.keys.find { |key| key == enum_path.to_s || key.ends_with?("::#{enum_path}") }
+            if enum_name && (enum_type = @types[enum_name]?)
+              return enum_type.subtypes
+            end
+          end
+        end
+        [] of String
+      else
+        [] of String
+      end
+    end
+
+    # `COLORS = %w(default red ...)` — records the word list under the
+    # constant name so `{% for name in COLORS %}` loops (the stdlib's
+    # Colorize styles, terminal ANSI names, ...) expand per word.
+    private def index_constant_word_list(node : Crystal::Assign)
+      return unless node.target.is_a?(Crystal::Path)
+      words = case value = node.value
+              when Crystal::ArrayLiteral
+                value.elements.compact_map { |element| element.as?(Crystal::StringLiteral).try(&.value) }
+              when Crystal::MacroLiteral
+                value.value.match(/^\s*%w\(([^)]*)\)/).try(&.[1].split) || [] of String
+              else
+                [] of String
+              end
+      @constant_word_lists[node.target.to_s] = words unless words.empty?
+    end
+
+    protected def index_syntax_type_body(type_info : TypeInfo, node : Crystal::ASTNode, type_name : String)
+      case node
+      when Crystal::Expressions
+        node.expressions.each do |expression|
+          case expression
+          when Crystal::Def
+            type_info.methods << method_info_for(expression, owner: type_name, class_method: !expression.receiver.nil?)
+            index_ivar_assignments(expression.body, type_info)
+            index_shorthand_ivar_args(expression, type_info)
+          when Crystal::VisibilityModifier
+            # `private def` / `protected def` wrap the def in a VisibilityModifier.
+            if inner_def = expression.exp.as?(Crystal::Def)
+              type_info.methods << method_info_for(inner_def, owner: type_name, class_method: !inner_def.receiver.nil?)
+              index_ivar_assignments(inner_def.body, type_info)
+              index_shorthand_ivar_args(inner_def, type_info)
+            elsif assign = expression.exp.as?(Crystal::Assign)
+              index_constant_word_list(assign)
+            end
+          when Crystal::ClassDef, Crystal::ModuleDef, Crystal::EnumDef, Crystal::AnnotationDef
+            index_nested_type(expression, type_info, type_name)
+          when Crystal::Call
+            index_accessor_call(expression, type_info, type_name)
+            index_record_call(expression, type_name)
+            index_delegate_call(expression, type_info)
+          when Crystal::Alias
+            index_alias(expression, type_name)
+          when Crystal::Include, Crystal::Extend
+            index_include(expression, type_info)
+          when Crystal::Macro
+            # `macro finished` bodies (the LSP shard's request classes)
+            # expand into classes under this type's namespace: index
+            # them so `LSP::HoverRequest` and its accessors resolve.
+            index_macro_body(expression.body, type_name)
+          when Crystal::TypeDeclaration
+            index_ivar_declaration(expression, type_info)
+          when Crystal::Assign
+            index_ivar_assignment(expression, type_info)
+          when Crystal::MacroIf
+            # `{% if flag?(:preview_mt) %}` branches contain real code, but
+            # the parser captures the branch as raw MacroLiteral text (it
+            # cannot evaluate the condition): re-parse each side and index
+            # it as type-body code (class vars, ivars, defs).
+            index_macro_branch(expression.then, type_info, type_name)
+            expression.else.try { |e| index_macro_branch(e, type_info, type_name) }
+          when Crystal::MacroFor
+            index_macro_for(expression, type_info, type_name)
+          end
+        end
+      when Crystal::Def
+        type_info.methods << method_info_for(node, owner: type_name, class_method: !node.receiver.nil?)
+        index_ivar_assignments(node.body, type_info)
+      when Crystal::VisibilityModifier
+        if inner_def = node.exp.as?(Crystal::Def)
+          type_info.methods << method_info_for(inner_def, owner: type_name, class_method: !inner_def.receiver.nil?)
+          index_ivar_assignments(inner_def.body, type_info)
+        end
+      when Crystal::ClassDef, Crystal::ModuleDef, Crystal::EnumDef, Crystal::AnnotationDef
+        # A body consisting of a single nested type is not wrapped in Expressions.
+        index_nested_type(node, type_info, type_name)
+      when Crystal::Call
+        # A body consisting of a single accessor macro call.
+        index_accessor_call(node, type_info, type_name)
+        index_record_call(node, type_name)
+        index_delegate_call(node, type_info)
+      when Crystal::Alias
+        index_alias(node, type_name)
+      when Crystal::Include, Crystal::Extend
+        index_include(node, type_info)
+      when Crystal::Macro
+        # A body consisting of a single `macro finished` block.
+        index_macro_body(node.body, type_name)
+      when Crystal::MacroIf
+        # A body consisting of a single `{% if %}` branch.
+        index_macro_branch(node.then, type_info, type_name)
+        node.else.try { |e| index_macro_branch(e, type_info, type_name) }
+      when Crystal::MacroFor
+        # A body consisting of a single `{% for %}` loop.
+        index_macro_for(node, type_info, type_name)
+      when Crystal::TypeDeclaration
+        index_ivar_declaration(node, type_info)
+      when Crystal::Assign
+        index_ivar_assignment(node, type_info)
+      end
+    end
+
+    # Records class-level ivar declarations (`@x : T`), so receivers resolve
+    # from the very first keystroke, before any compile.
+    private def index_ivar_declaration(node : Crystal::TypeDeclaration, type_info : TypeInfo)
+      return unless (declared_type = node.declared_type)
+      case var = node.var
+      when Crystal::InstanceVar
+        (type_info.ivars[var.name] ||= [] of String) << declared_type.to_s
+      when Crystal::ClassVar
+        (type_info.class_vars[var.name] ||= [] of String) << declared_type.to_s
+      end
+    end
+
+    # Records class-level ivar assignments (`@x = value`), which are the only
+    # declaration form for ivars without a type restriction. `||=` counts too
+    # (`@cache ||= {} of ...`).
+    private def index_ivar_assignment(node : Crystal::Assign | Crystal::OpAssign, type_info : TypeInfo)
+      return unless (value_type = syntax_value_type_name(node.value))
+      case target = node.target
+      when Crystal::InstanceVar
+        (type_info.ivars[target.name] ||= [] of String) << value_type
+      when Crystal::ClassVar
+        (type_info.class_vars[target.name] ||= [] of String) << value_type
+      end
+    end
+
+    # Best-effort type name for a class-level ivar initializer (`Mutex.new` →
+    # `Mutex`, `"str"` → `String`); the query resolves it against the merged
+    # index afterwards.
+    private def syntax_value_type_name(node : Crystal::ASTNode) : String?
+      case node
+      when Crystal::Call
+        node.obj.try { |obj| syntax_value_type_name(obj) }
+      when Crystal::Path
+        node.to_s
+      when Crystal::Generic
+        # `Hash(String, {Crystal::Type?, Crystal::Location?}).new`
+        node.to_s
+      when Crystal::StringLiteral then "String"
+      when Crystal::BoolLiteral   then "Bool"
+      when Crystal::NumberLiteral then "Number"
+      when Crystal::NilLiteral    then "Nil"
+      when Crystal::ArrayLiteral
+        # `@array = [] of Item(V)` — the `of` clause names the element
+        # type so delegated/typed receivers resolve (`Array(Item(V))`).
+        node.of.try { |of| "Array(#{of})" } || "Array"
+      when Crystal::HashLiteral
+        if entry = node.of
+          "Hash(#{entry.key}, #{entry.value})"
+        else
+          "Hash"
+        end
+      when Crystal::TupleLiteral      then "Tuple"
+      when Crystal::NamedTupleLiteral then "NamedTuple"
+      when Crystal::RangeLiteral      then "Range"
+      when Crystal::RegexLiteral      then "Regex"
+      when Crystal::SymbolLiteral     then "Symbol"
+      end
+    end
+
+    # Collects ivar assignments inside method bodies (`@x = value`), so ivars
+    # initialized in a method resolve as receivers from any other method too.
+    private def index_ivar_assignments(node : Crystal::ASTNode, type_info : TypeInfo)
+      case node
+      when Crystal::Expressions
+        node.expressions.each { |expression| index_ivar_assignments(expression, type_info) }
+      when Crystal::Assign, Crystal::OpAssign
+        index_ivar_assignment(node, type_info)
+      when Crystal::Call
+        # A block-carrying call statement (`@items.each do |item| ... end`):
+        # descend into the block so ivars assigned inside it are indexed.
+        node.block.try { |block| index_ivar_assignments(block, type_info) }
+      when Crystal::ExceptionHandler
+        index_ivar_assignments(node.body, type_info)
+        node.rescues.try { |rescues| rescues.each { |rescue_clause| index_ivar_assignments(rescue_clause.body, type_info) } }
+        node.else.try { |else_node| index_ivar_assignments(else_node, type_info) }
+      when Crystal::If
+        index_ivar_assignments(node.then, type_info)
+        index_ivar_assignments(node.else, type_info)
+      when Crystal::Unless
+        index_ivar_assignments(node.then, type_info)
+        index_ivar_assignments(node.else, type_info)
+      when Crystal::Case
+        node.whens.each { |a_when| index_ivar_assignments(a_when.body, type_info) }
+        index_ivar_assignments(node.else.not_nil!, type_info) if node.else
+      when Crystal::While, Crystal::Until
+        index_ivar_assignments(node.body, type_info)
+      when Crystal::Block
+        index_ivar_assignments(node.body, type_info)
+      end
+    end
+
+    ACCESSOR_MACROS = %w[getter setter property getter? setter? property? class_getter class_setter class_property class_getter? class_setter? class_property? getter! setter! property! class_getter! class_setter! class_property!]
+
+    # An alias (`alias Handler = Proc(...)`) inside a type or module body:
+    # index it like a top-level alias so receivers of the alias resolve.
+    private def index_alias(node : Crystal::Alias, type_name : String)
+      alias_name = qualify_type_name(node.name.to_s, type_name)
+      alias_info = (@types[alias_name] ||= TypeInfo.new(alias_name, TypeKind::Alias, node.doc, node.location, node.name_location))
+      aliased_name = node.value.to_s
+      alias_info.parent_types << aliased_name unless alias_info.parent_types.includes?(aliased_name)
+    end
+
+    # `include Foo` / `extend Foo` make the module's methods available on
+    # the type: record it as a parent so methods_for walks into it
+    # (e.g. `process_result` from `Crystal::TypedDefProcessor`).
+    private def index_include(node : Crystal::Include | Crystal::Extend, type_info : TypeInfo)
+      name = node.name.to_s
+      type_info.parent_types << name unless type_info.parent_types.includes?(name)
+    end
+
+    # `new` is compiler-synthesized from `initialize`: synthesize a class
+    # method so `Class.` completion and hovers offer it. Args come from
+    # the class's own `initialize` when present, otherwise `new` is bare.
+    private def index_new_method(type_info : TypeInfo, type_name : String)
+      return if type_info.methods.any? { |m| m.class_method && m.name == "new" }
+      initialize_method = type_info.methods.find { |m| !m.class_method && m.name == "initialize" }
+      type_info.methods << MethodInfo.new(
+        name: "new",
+        owner: type_name,
+        args: initialize_method.try(&.args) || [] of ArgInfo,
+        return_type: type_name,
+        class_method: true,
+        doc: nil,
+        location: initialize_method.try(&.location),
+      )
+    end
+
+    # A `delegate` macro-expanded def is a passthrough
+    # (`def shift(*args, **kwargs); @array.shift(*args, **kwargs); end`):
+    # the target ivar names it so the query resolves the delegated method
+    # through the target's typed methods. Requires the call name to match
+    # the def name, an ivar receiver, no block, and every argument to be a
+    # bare splat var — anything else is a real method body.
+    private def delegate_passthrough_target(definition : Crystal::Def) : String?
+      body = definition.body
+      body = body.expressions.first? if body.is_a?(Crystal::Expressions) && body.expressions.size == 1
+      call = body.as?(Crystal::Call)
+      return unless call
+      return unless call.name == definition.name.to_s
+      return if call.block
+      obj = call.obj
+      return unless obj.is_a?(Crystal::InstanceVar)
+      return unless call.args.all? do |arg|
+                      # `*args` / `**options` parse as Splat/DoubleSplat wrappers around
+                      # the vars (the semantic def's arg list drops the double-splat
+                      # arg, so only the bareness is checked here); plain args must be
+                      # bare vars matching a def arg (setter-style passthroughs).
+                      case arg
+                      when Crystal::Splat, Crystal::DoubleSplat
+                        exp = arg.is_a?(Crystal::Splat) ? arg.exp : arg.as(Crystal::DoubleSplat).exp
+                        exp.is_a?(Crystal::Var)
+                      when Crystal::Var
+                        definition.args.any? { |definition_arg| definition_arg.name == arg.name }
+                      else
+                        false
+                      end
+                    end
+      "@#{obj.name.lchop('@')}"
+    end
+
+    # `record Foo, x : Int32, y : String` parses as a call to the `record`
+    # macro: synthesize a type with the fields as getters so receivers of
+    # records resolve (`Crystal::Compiler::Result#node` etc.).
+    private def index_record_call(call : Crystal::Call, type_name : String?)
+      return if call.obj
+      return unless call.name == "record"
+
+      first = call.args.first?
+      return unless first.is_a?(Crystal::Path)
+
+      record_name = qualify_type_name(first.to_s, type_name)
+      record_info = (@types[record_name] ||= TypeInfo.new(record_name, TypeKind::Struct, call.doc, call.location, first.name_location))
+      # The record macro expands into a `Struct` subclass: record the
+      # implicit parent so `Object`/`Reference` methods (`try`,
+      # `not_nil!`, ...) resolve on records.
+      record_info.parent_types << "Struct" unless record_info.parent_types.includes?("Struct")
+
+      fields = [] of {String, String?}
+      call.args[1..].each do |arg|
+        field_name = case arg
+                     when Crystal::Arg
+                       arg.name.to_s
+                     when Crystal::TypeDeclaration
+                       var = arg.var
+                       var.is_a?(Crystal::Var) ? var.name : nil
+                     end
+        next unless field_name
+        restriction = arg.is_a?(Crystal::TypeDeclaration) ? arg.declared_type.to_s : arg.as(Crystal::Arg).restriction.try(&.to_s)
+        fields << {field_name, restriction}
+        next if record_info.methods.any? { |m| m.name == field_name }
+        record_info.methods << MethodInfo.new(
+          name: field_name,
+          owner: record_name,
+          args: [] of ArgInfo,
+          return_type: restriction,
+          class_method: false,
+          doc: nil,
+          location: call.location,
+        )
+      end
+
+      # The record macro also generates `new(field, ...)`: index it so
+      # `MethodInfo.new(...)` hovers and resolves its return type.
+      return if record_info.methods.any? { |m| m.name == "new" && m.class_method }
+      record_info.methods << MethodInfo.new(
+        name: "new",
+        owner: record_name,
+        args: fields.map { |name, restriction| ArgInfo.new(name, restriction) },
+        return_type: record_name,
+        class_method: true,
+        doc: nil,
+        location: call.location,
+      )
+    end
+
+    # Synthesize method entries for `getter`/`setter`/`property` macro calls,
+    # which the source index cannot expand without compiling.
+    protected def index_accessor_call(call : Crystal::Call, type_info : TypeInfo, type_name : String)
+      macro_name = call.name.to_s
+      return if call.obj
+      return unless ACCESSOR_MACROS.includes?(macro_name)
+
+      class_method = macro_name.starts_with?("class_")
+      base_name = macro_name.lchop("class_")
+      predicate = base_name.ends_with?("?")
+      kind = base_name.rchop("?").rchop("!")
+
+      call.args.each do |arg|
+        name, restriction = accessor_arg_info(arg, type_info)
+        next unless name
+
+        if kind == "getter" || kind == "property"
+          method_name = predicate ? "#{name}?" : name
+          type_info.methods << MethodInfo.new(
+            name: method_name,
+            owner: type_name,
+            args: [] of ArgInfo,
+            return_type: restriction,
+            class_method: class_method,
+            doc: call.doc,
+            location: call.location,
+            name_location: call.location,
+            name_size: method_name.size,
+          )
+
+          # A getter is backed by `@name`: record the ivar so `@name.`
+          # receivers resolve before any assignment is seen (the getter
+          # macro declares it, e.g. `getter root_uri : URI?`).
+          if !class_method && restriction
+            (type_info.ivars["@#{name}"] ||= [] of String) << restriction
+          end
+          # A class getter is backed by `@@name`: record the cvar too
+          # (`class_getter compilation_lock = Mutex.new`).
+          if class_method && restriction
+            (type_info.class_vars["@@#{name}"] ||= [] of String) << restriction
+          end
+        end
+
+        if kind == "setter" || kind == "property"
+          method_name = "#{name}="
+          type_info.methods << MethodInfo.new(
+            name: method_name,
+            owner: type_name,
+            args: [ArgInfo.new(name: "value", restriction: restriction)],
+            return_type: restriction,
+            class_method: class_method,
+            doc: call.doc,
+            location: call.location,
+            name_location: call.location,
+            name_size: method_name.size,
+          )
+        end
+      end
+    end
+
+    # Synthesize delegate records for `delegate foo, bar, to: @array` and
+    # `forward_missing_to @array`: the macro-generated passthrough methods
+    # never appear in the source parse, so the query resolves them against
+    # the target's indexed type (e.g. Priority::Queue's `first?`/`shift`
+    # delegating to `@array : Array(Item(V))`).
+    protected def index_delegate_call(call : Crystal::Call, type_info : TypeInfo)
+      return if call.obj
+      case call.name.to_s
+      when "delegate"
+        target = call.named_args.try(&.find { |named| named.name == "to" }).try(&.value.to_s)
+        return unless target
+        call.args.each do |arg|
+          name = case arg
+                 when Crystal::Call then arg.name.to_s
+                 when Crystal::Var  then arg.name
+                 else                    nil
+                 end
+          next unless name
+          next if name.empty? || name == "to"
+          type_info.delegates[name] = target unless type_info.delegates.has_key?(name)
+        end
+      when "forward_missing_to"
+        if target = call.args.first?.try(&.to_s)
+          type_info.forward_missing_to = target
+        end
+      end
+    end
+
+    # `def initialize(@priority : Value, @value : V)` parses the shorthand
+    # args without the sigil and pushes `@priority = priority` as the body's
+    # first statement: record the ivar with the arg's restriction, so
+    # `property :priority`-style accessors (whose symbols carry no
+    # restriction) still get a return type.
+    private def index_shorthand_ivar_args(definition : Crystal::Def, type_info : TypeInfo)
+      body = definition.body
+      return unless body.is_a?(Crystal::Expressions)
+      definition.args.each do |arg|
+        next if arg.name.empty?
+        next unless restriction = arg.restriction
+        paired = body.expressions.any? do |expression|
+          expression.is_a?(Crystal::Assign) &&
+            expression.target.is_a?(Crystal::InstanceVar) &&
+            expression.value.is_a?(Crystal::Var) &&
+            expression.value.as(Crystal::Var).name == arg.name
+        end
+        next unless paired
+        ivar_name = "@#{arg.name}"
+        restriction_name = restriction.to_s
+        ivars = (type_info.ivars[ivar_name] ||= [] of String)
+        ivars << restriction_name unless ivars.includes?(restriction_name)
+      end
+    end
+
+    private def accessor_arg_info(arg : Crystal::ASTNode, type_info : TypeInfo) : {String?, String?}
+      case arg
+      when Crystal::TypeDeclaration
+        var_name = case var = arg.var
+                   when Crystal::Var         then var.name
+                   when Crystal::InstanceVar then var.name.lchop('@')
+                   when Crystal::ClassVar    then var.name.lchop("@@")
+                   else                           nil
+                   end
+        {var_name, arg.declared_type.to_s}
+      when Crystal::Assign
+        # `getter projects = [] of Project`: the initializer names the var
+        # and its `of` clause names the element/key-value types.
+        {accessor_target_name(arg.target), accessor_initializer_type(arg.value)}
+      when Crystal::Call
+        # A bare name parses as a zero-argument call.
+        {arg.obj ? nil : arg.name.to_s, nil}
+      when Crystal::SymbolLiteral
+        # `property :priority` — the symbol names the accessor; the return
+        # type falls back to the backing ivar's recorded type (from
+        # `def initialize(@priority : Value, ...)` shorthands).
+        {arg.value, type_info.ivars["@#{arg.value}"]?.try(&.first?)}
+      else
+        {nil, nil}
+      end
+    end
+
+    private def accessor_target_name(target : Crystal::ASTNode) : String?
+      case target
+      when Crystal::Var         then target.name
+      when Crystal::InstanceVar then target.name.lchop('@')
+      when Crystal::ClassVar    then target.name.lchop("@@")
+      else                           nil
+      end
+    end
+
+    # `getter x = [] of T` / `= {} of K => V`: the initializer's `of`
+    # clause declares the element (or key/value) type of the getter.
+    private def accessor_initializer_type(node : Crystal::ASTNode) : String?
+      case node
+      when Crystal::ArrayLiteral
+        node.of.try { |of| "Array(#{of})" }
+      when Crystal::HashLiteral
+        if entry = node.of
+          "Hash(#{entry.key}, #{entry.value})"
+        end
+      when Crystal::Call
+        # `getter requires = Set(String).new`: the receiver of `new`
+        # names the getter's type (a Generic or a Path).
+        if node.name == "new"
+          node.obj.try(&.to_s)
+        end
+      end
+    end
+
+    protected def index_nested_type(node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::EnumDef | Crystal::AnnotationDef, type_info : TypeInfo, type_name : String)
+      nested_name = qualify_type_name(node.name.to_s, type_name)
+      type_info.subtypes << nested_name unless type_info.subtypes.includes?(nested_name)
+      index_syntax_node(node, type_name)
+    end
+
+    protected def qualify_type_name(name : String, namespace : String?)
+      return name if namespace.nil? || name.includes?("::")
+      "#{namespace}::#{name}"
+    end
+
+    # `class Set(T)` parses with the type vars detached from the name: rebuild
+    # the generic form (`Set(T)`) so source generics match compiled keys.
+    protected def generic_type_name(name : Crystal::Path, type_vars : Array(String)?)
+      return name.to_s unless type_vars && type_vars.any?
+      "#{name}(#{type_vars.join(", ")})"
+    end
+
+    protected def index_type(type : Crystal::NamedType)
+      type_name = type.to_s
+      type_info = (@types[type_name] ||= TypeInfo.new(type_name, kind_for(type), type.doc, type.locations.try(&.first?), type.locations.try(&.first?)))
+
+      if defs = type.defs
+        defs.each_value do |items|
+          items.each do |item|
+            type_info.methods << method_info_for(item.def, owner: type_name)
+            # `delegate` macro-expanded defs are passthroughs
+            # (`def shift(*args, **kwargs); @array.shift(*args, **kwargs); end`)
+            # carrying no return type: record them as delegates so the
+            # query resolves the target's typed methods instead.
+            if type_info.delegates[item.def.name.to_s]?.nil?
+              if target = delegate_passthrough_target(item.def)
+                type_info.delegates[item.def.name.to_s] = target
+              end
+            end
+          end
+        end
+      end
+
+      if type.is_a?(Crystal::ModuleType)
+        if macros = type.macros
+          macros.each_value do |items|
+            items.each do |macro_def|
+              type_info.methods << method_info_for(macro_def, owner: type_name, is_macro: true)
+            end
+          end
+        end
+      end
+
+      if metaclass = type.metaclass
+        if defs = metaclass.defs
+          defs.each_value do |items|
+            items.each do |item|
+              type_info.methods << method_info_for(item.def, owner: type_name, class_method: true)
+            end
+          end
+        end
+      end
+
+      type.parents.try &.each do |parent_type|
+        parent_name = parent_type.to_s
+        type_info.parent_types << parent_name unless type_info.parent_types.includes?(parent_name)
+      end
+
+      # An alias (`alias Mutex = Sync::Mutex`) carries no defs of its own:
+      # method lookups resolve through the aliased type, so record it as the
+      # single parent for the hierarchy walk.
+      if type.is_a?(Crystal::AliasType)
+        if aliased = type.remove_alias
+          aliased_name = aliased.to_s
+          type_info.parent_types << aliased_name unless type_info.parent_types.includes?(aliased_name)
+        end
+      end
+
+      if nested_types = type.types?
+        nested_types.each_value do |nested_type|
+          type_info.subtypes << nested_type.to_s unless type_info.subtypes.includes?(nested_type.to_s)
+          index_type(nested_type)
+        end
+      end
+
+      # A constant (`LSP::Log = ::Log.for(self)`) holds an instance of its
+      # value's type: record that type as the single parent so the resolver
+      # resolves `LSP::Log.info` through the value type's instance methods
+      # instead of the class-method view on the empty shell.
+      if type.is_a?(Crystal::Const)
+        # `type?` (not `type`): macro-only constants (e.g. `SI_PREFIXES`
+        # in stdlib humanize.cr) never get their value bound, and the
+        # compiler's `type` getter raises a BUG on them.
+        if value_type = type.value.try(&.type?)
+          value_type_name = value_type.to_s
+          type_info.parent_types << value_type_name unless type_info.parent_types.includes?(value_type_name)
+        end
+      end
+    end
+
+    protected def method_info_for(definition : Crystal::Def | Crystal::Macro, *, owner : String, class_method = false, is_macro = false)
+      args = definition.args.map do |arg|
+        ArgInfo.new(name: arg.name.to_s, restriction: arg.restriction.try(&.to_s))
+      end
+
+      return_type = definition.responds_to?(:return_type) ? definition.return_type.try(&.to_s) : nil
+      if return_type.nil? && definition.is_a?(Crystal::Def)
+        # An untyped def: best-effort infer the return type from the body's
+        # last expression (`@cache[entry]?.try &.[0]` → the hash value type)
+        # so callers resolve before any compile. Bare names are resolved
+        # against the merged index by the query afterwards.
+        return_type = syntax_return_type_name(definition.body, ivars_for(owner), owner)
+      end
+
+      free_vars = definition.responds_to?(:free_vars) ? (definition.free_vars || [] of String).map(&.to_s) : [] of String
+      block_restriction = definition.responds_to?(:block_arg) ? definition.block_arg.try(&.restriction.try(&.to_s)) : nil
+
+      MethodInfo.new(
+        name: definition.name.to_s,
+        owner: owner,
+        args: args,
+        return_type: return_type,
+        class_method: class_method,
+        macro: is_macro,
+        doc: definition.doc,
+        location: definition.location,
+        name_location: definition.responds_to?(:name_location) ? definition.name_location : nil,
+        name_size: definition.name.to_s.size,
+        free_vars: free_vars,
+        block_restriction: block_restriction,
+      )
+    end
+
+    private def ivars_for(type_name : String) : Hash(String, Array(String))
+      @types[type_name]?.try(&.ivars) || {} of String => Array(String)
+    end
+
+    # Best-effort return type of an untyped def, from the body's last
+    # expression. Conservative by design: anything it cannot type returns
+    # nil, and the caller keeps no return type at all.
+    private def syntax_return_type_name(node : Crystal::ASTNode, ivars : Hash(String, Array(String)), owner : String? = nil) : String?
+      case node
+      when Crystal::Expressions
+        node.expressions.last?.try { |last| syntax_return_type_name(last, ivars, owner) }
+      when Crystal::Return
+        node.exp ? syntax_return_type_name(node.exp.not_nil!, ivars, owner) : "Nil"
+      when Crystal::Assign
+        syntax_return_type_name(node.value, ivars, owner)
+      when Crystal::If
+        then_type = node.then ? syntax_return_type_name(node.then.not_nil!, ivars, owner) : nil
+        else_type = node.else ? syntax_return_type_name(node.else.not_nil!, ivars, owner) : nil
+        if then_type && else_type && then_type != else_type
+          "#{then_type} | #{else_type}"
+        else
+          then_type || else_type
+        end
+      when Crystal::StringLiteral, Crystal::StringInterpolation
+        "String"
+      when Crystal::Var
+        # A body ending in `self` (macro-generated style setters like
+        # Colorize's `def red; @fore = ...; self; end`): the "self"
+        # marker is substituted for the owner by the callers.
+        node.name == "self" ? "self" : nil
+      when Crystal::NumberLiteral
+        number_literal_type_name(node)
+      when Crystal::BoolLiteral
+        "Bool"
+      when Crystal::CharLiteral
+        "Char"
+      when Crystal::SymbolLiteral
+        "Symbol"
+      when Crystal::NilLiteral
+        "Nil"
+      when Crystal::RegexLiteral
+        "Regex"
+      when Crystal::RangeLiteral
+        "Range"
+      when Crystal::TupleLiteral
+        # `{@nodes, @context}` — a tuple-valued last expression: record
+        # the element types so multi-assigns (`a, b = ...`) split them.
+        parts = node.elements.compact_map do |element|
+          if part_type = syntax_return_type_name(element, ivars, owner)
+            part_type
+          end
+        end
+        parts.empty? ? nil : "Tuple(#{parts.join(", ")})"
+      when Crystal::ArrayLiteral
+        if of = node.of
+          "Array(#{of.to_s})"
+        elsif element = node.elements.first?
+          element_type = syntax_return_type_name(element, ivars, owner)
+          element_type ? "Array(#{element_type})" : "Array"
+        else
+          "Array"
+        end
+      when Crystal::InstanceVar
+        ivars[node.name]?.try(&.first?)
+      when Crystal::Call
+        syntax_call_return_type_name(node, ivars, owner)
+      else
+        nil
+      end
+    end
+
+    private def syntax_call_return_type_name(node : Crystal::Call, ivars : Hash(String, Array(String)), owner : String? = nil) : String?
+      if (path = node.obj).is_a?(Crystal::Path)
+        # `Foo.new` / `Foo(...)` constructors.
+        return path.to_s if node.name == "new" || node.name == path.to_s
+        return nil
+      end
+
+      if node.name.in?("try", "tap", "itself", "not_nil!")
+        receiver_type = node.obj ? syntax_return_type_name(node.obj.not_nil!, ivars, owner) : nil
+        return nil unless receiver_type
+        if node.name == "try" && node.block
+          # `x.try { ... }` returns the block's value, never x: do not
+          # fall back to the receiver type when the block's return is
+          # unknown (a wrong recorded return poisons every caller).
+          return syntax_block_return_type_name(node.block.not_nil!, receiver_type)
+        end
+        return receiver_type
+      end
+
+      if node.name.in?("has_key?", "empty?", "includes?", "nil?") && node.obj
+        return "Bool"
+      end
+
+      if node.name.in?("[]", "[]?", "fetch") && node.obj.is_a?(Crystal::InstanceVar)
+        ivar_name = node.obj.as(Crystal::InstanceVar).name
+        ivar_type = ivars[ivar_name]?.try(&.first?)
+        return nil unless ivar_type
+        if value_types = TypeUtils.hash_value_types(ivar_type)
+          return value_types.join(" | ")
+        elsif element_types = TypeUtils.array_element_types(ivar_type)
+          return element_types.join(" | ")
+        end
+      end
+
+      if node.obj.nil? && owner
+        # A bare call as the last expression (`def italic; mode Mode::Italic;
+        # end`): resolve the callee's recorded return through the owner's
+        # entry so self-returning style setters keep the chain alive.
+        if owner_type = @types[owner]?
+          if callee = owner_type.methods.find { |m| m.name == node.name && !m.class_method && m.return_type }
+            return callee.return_type
+          end
+        end
+      end
+
+      nil
+    end
+
+    private def number_literal_type_name(node : Crystal::NumberLiteral) : String?
+      literal = node.to_s
+      if literal.includes?('.') || literal.includes?('e') || literal.includes?('f')
+        literal.ends_with?("f32") ? "Float32" : "Float64"
+      elsif literal.ends_with?("u8")
+        "UInt8"
+      elsif literal.ends_with?("u16")
+        "UInt16"
+      elsif literal.ends_with?("u32")
+        "UInt32"
+      elsif literal.ends_with?("u64")
+        "UInt64"
+      elsif literal.ends_with?("i8")
+        "Int8"
+      elsif literal.ends_with?("i16")
+        "Int16"
+      elsif literal.ends_with?("i32")
+        "Int32"
+      elsif literal.ends_with?("i64")
+        "Int64"
+      else
+        "Int32"
+      end
+    end
+
+    # `x.try &.[0]` — apply the block body (`__arg0[0]`) to the receiver's
+    # type: a tuple's `[0]` yields its first element type.
+    private def syntax_block_return_type_name(block : Crystal::Block, receiver_type : String) : String?
+      body = block.body
+      return nil unless body.is_a?(Crystal::Call)
+      return nil unless body.name == "[]"
+
+      index = body.args.first?.try(&.to_s)
+      return nil unless index
+
+      if tuple_types = TypeUtils.tuple_element_types(receiver_type)
+        return tuple_types[0]?.try(&.join(" | ")) if index == "0"
+        return tuple_types[1]?.try(&.join(" | ")) if index == "1"
+      end
+
+      nil
+    end
+
+    protected def kind_for(type : Crystal::NamedType)
+      case type
+      when Crystal::Const
+        # A constant (`LSP::Log = ::Log.for(self)`) is a value, not a
+        # type: the resolver resolves it through the recorded parent (the
+        # value's type) instead of the class-method view.
+        TypeKind::Constant
+      when Crystal::AnnotationType
+        TypeKind::Annotation
+      when Crystal::AliasType
+        TypeKind::Alias
+      when Crystal::EnumType
+        TypeKind::Enum
+      when Crystal::LibType
+        TypeKind::Lib
+      when Crystal::ClassType
+        type.struct? ? TypeKind::Struct : TypeKind::Class
+      when Crystal::ModuleType
+        TypeKind::Module
+      else
+        TypeKind::Unknown
+      end
+    end
+  end
+end

--- a/src/crystalline/lightweight/inference.cr
+++ b/src/crystalline/lightweight/inference.cr
@@ -1,0 +1,2224 @@
+require "compiler/crystal/syntax"
+require "./type_utils"
+require "./query"
+
+module Crystalline::Lightweight
+  class Inference
+    getter local_types = {} of String => Array(String)
+    getter instance_var_types = {} of String => Array(String)
+    getter class_var_types = {} of String => Array(String)
+    getter current_def : Crystal::Def?
+    getter current_type_name : String?
+    getter? class_method_context = false
+    @current_type_body : Crystal::ASTNode? = nil
+    @ast : Crystal::ASTNode? = nil
+    # Call sites whose untyped-arg values need the caller's locals: one
+    # bounded walk of each caller infers them all (see
+    # collect_pending_call_site_types).
+    @pending_call_sites : Hash(Crystal::Def, Array(Crystal::Call))? = nil
+    @pending_caller : Crystal::Def? = nil
+    @pending_definition : Crystal::Def? = nil
+    @pending_untyped : Array(Crystal::Arg)? = nil
+    @pending_types : Hash(String, Array(String))? = nil
+
+    def self.for(source : String, line : Int32, column : Int32, query : Query) : self?
+      new(source, line, column, query).run
+    end
+
+    def initialize(@source : String, @line : Int32, @column : Int32, @query : Query)
+    end
+
+    def run : self?
+      parser = Crystal::Parser.new(@source)
+      parser.wants_doc = false
+      ast = parser.parse
+      @ast = ast
+
+      locate_context(ast)
+      if current_def = @current_def
+        seed_arg_types(current_def, ast)
+        seed_type_vars_from_summary
+        seed_indexed_ivar_types
+        process_initialize_defs(ast) unless class_method_context? || current_def.name == "initialize"
+        # Class-level statements before the cursor's def (constants like
+        # `ACCESSOR_MACROS = %w[...]`, ivar assignments) also seed the
+        # visible state: walk the type body without entering other defs.
+        if type_body = @current_type_body
+          process_node(type_body, apply_cursor_bounds: true)
+        end
+        process_node(current_def.body)
+      elsif @current_type_name
+        # The cursor sits directly in a type body, not inside a def: seed
+        # ivar types from the index (and from initialize arguments) so
+        # `@ivar.` receivers resolve before any method is entered.
+        seed_type_vars_from_summary
+        process_initialize_defs(ast) unless class_method_context?
+        process_node(@current_type_body.not_nil!, apply_cursor_bounds: true)
+      else
+        # Top-level code with no enclosing def: infer from the expressions
+        # that appear before the cursor.
+        process_node(ast)
+      end
+      self
+    rescue Crystal::SyntaxException
+      nil
+    end
+
+    def types_for(name : String) : Array(String)
+      # Recorded types may carry unions (`TokenSpan?`, `X | ::Nil`): expand
+      # them so receiver lookups see plain, known type names.
+      (@local_types[name]? || [] of String).flat_map { |type_name| TypeUtils.expand_type_names(type_name) }.map { |type_name| type_name.lchop("::") }.uniq
+    end
+
+    def types_for_instance_var(name : String) : Array(String)
+      # Recorded types may carry unions (`URI?`, `URI | ::Nil`): expand
+      # them so receiver lookups see plain, known type names.
+      (@instance_var_types[name]? || [] of String).flat_map { |type_name| TypeUtils.expand_type_names(type_name) }.map { |type_name| type_name.lchop("::") }.uniq
+    end
+
+    # Ivar reads without a recorded assignment still resolve when the
+    # enclosing type declares the ivar through an accessor-with-initializer
+    # (`getter local_types = {} of String => Array(String)`): the index
+    # records the getter method, so fall back to its return type.
+    def instance_var_types_for(name : String) : Array(String)
+      local_types = types_for_instance_var(name)
+      return local_types unless local_types.empty?
+
+      if type_name = @current_type_name
+        @query.methods_for(type_name, class_method: class_method_context?).each do |method|
+          if method.name == name.lchop('@') && (return_type = method.return_type)
+            return resolve_type_names(TypeUtils.expand_type_names(return_type))
+          end
+        end
+      end
+      [] of String
+    end
+
+    def class_var_types_for(name : String) : Array(String)
+      local_types = types_for_class_var(name)
+      return local_types unless local_types.empty?
+
+      if type_name = @current_type_name
+        @query.methods_for(type_name, class_method: true).each do |method|
+          if method.name == name.lchop("@@") && (return_type = method.return_type)
+            return resolve_type_names(TypeUtils.expand_type_names(return_type))
+          end
+        end
+      end
+      [] of String
+    end
+
+    def types_for_class_var(name : String) : Array(String)
+      (@class_var_types[name]? || [] of String).flat_map { |type_name| TypeUtils.expand_type_names(type_name) }.map { |type_name| type_name.lchop("::") }.uniq
+    end
+
+    def self_types : {Array(String), Bool}
+      if type_name = @current_type_name
+        {[type_name], class_method_context?}
+      else
+        {[] of String, false}
+      end
+    end
+
+    private def record_assignment_types(target : Crystal::ASTNode, types : Array(String))
+      case target
+      when Crystal::Var
+        @local_types[target.name] = types
+      when Crystal::Path
+        # A constant (`CAST_SEGMENT = "__lightweight_cast__"`): record
+        # it like a local so receivers resolve to the literal's type.
+        @local_types[target.to_s] = types
+      when Crystal::InstanceVar
+        @instance_var_types[target.name] = types
+      when Crystal::ClassVar
+        @class_var_types[target.name] = types
+      end
+    end
+
+    private def process_node(node : Crystal::ASTNode, *, apply_cursor_bounds = true)
+      case node
+      when Crystal::Expressions
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        node.expressions.each do |expression|
+          break if apply_cursor_bounds && !starts_before_or_at_cursor?(expression)
+          process_node(expression, apply_cursor_bounds: apply_cursor_bounds)
+        end
+      when Crystal::Assign
+        if contains_cursor?(node.value)
+          # The cursor sits inside the value (e.g. a proc literal whose
+          # body is being edited): record the assignment like the plain
+          # path would, then descend so the inner blocks seed.
+          types = infer_types(node.value)
+          record_assignment_types(node.target, types) unless types.empty?
+          process_node(node.value, apply_cursor_bounds: apply_cursor_bounds)
+          return
+        end
+
+        return unless !apply_cursor_bounds || before_cursor?(node)
+
+        types = infer_types(node.value)
+        return if types.empty?
+
+        record_assignment_types(node.target, types)
+      when Crystal::And, Crystal::Or
+        # `cond && (x = expr)` assigns inside the condition: process both
+        # operands so the assignment is recorded like any other statement.
+        # (Parenthesized expressions are plain `Expressions` nodes.)
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_node(node.left, apply_cursor_bounds: apply_cursor_bounds)
+        process_node(node.right, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::OpAssign
+        # `x ||= expr` (often a `||= begin ... end` block): record the
+        # assignment like a plain one, and walk the value so locals
+        # assigned inside the begin-block are typed.
+        if contains_cursor?(node.value)
+          process_node(node.value, apply_cursor_bounds: apply_cursor_bounds)
+          return
+        end
+
+        return unless !apply_cursor_bounds || before_cursor?(node)
+
+        process_node(node.value, apply_cursor_bounds: apply_cursor_bounds)
+        types = infer_types(node.value)
+        return if types.empty?
+
+        case target = node.target
+        when Crystal::Var
+          @local_types[target.name] = types
+        when Crystal::InstanceVar
+          @instance_var_types[target.name] = types
+        when Crystal::ClassVar
+          @class_var_types[target.name] = types
+        end
+      when Crystal::TypeDeclaration
+        # `@pending : Array({String, Int32}) = ...` — an ivar/cvar declared
+        # with a restriction (and often an initializer). Type it from the
+        # initializer when present, falling back to the restriction. A
+        # nil-only initializer (`@cache : Hash(...)? = nil`) still carries
+        # the restriction's real type.
+        if apply_cursor_bounds
+          if value = node.value
+            if contains_cursor?(value)
+              # The cursor sits inside the initializer (e.g. a block value
+              # like `Thread.new do ... end`): descend so locals assigned
+              # in the block type, then record the declaration itself.
+              process_node(value, apply_cursor_bounds: apply_cursor_bounds)
+            end
+          end
+        end
+        types = node.value.try { |value| infer_types(value) } || [] of String
+        if node.declared_type
+          restriction_types = resolve_type_names(node.declared_type.to_s)
+          if types.empty? || (types.all?(&.==("Nil")) && restriction_types.any?)
+            types = restriction_types
+          end
+        end
+        return if types.empty?
+
+        case var = node.var
+        when Crystal::Var
+          # A local type declaration (`t : Crystal::Type?`): type it from
+          # the restriction so later receivers resolve.
+          @local_types[var.name] = types
+        when Crystal::InstanceVar
+          @instance_var_types[var.name] = types
+        when Crystal::ClassVar
+          @class_var_types[var.name] = types
+        end
+      when Crystal::MultiAssign
+        if apply_cursor_bounds && node.values.any? { |value| contains_cursor?(value) }
+          node.values.each do |value|
+            process_node(value, apply_cursor_bounds: true) if contains_cursor?(value)
+          end
+          return
+        end
+
+        return unless !apply_cursor_bounds || before_cursor?(node)
+
+        assign_multi_types(node)
+      when Crystal::TupleLiteral
+        # A tuple literal as a statement (`{ query.top_level_methods.select
+        # {...}.flat_map {...}, false }`): descend into the elements so a
+        # cursor inside a chain nested in the tuple still seeds block args.
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        node.elements.each do |element|
+          break if apply_cursor_bounds && !starts_before_or_at_cursor?(element)
+          process_node(element, apply_cursor_bounds: apply_cursor_bounds)
+        end
+      when Crystal::Call
+        # The untyped-arg seed's pending call sites live inside this
+        # caller: infer their values with the state at the call (one
+        # bounded walk per caller instead of one per call site).
+        if pending = @pending_call_sites
+          if (current_caller = @pending_caller) && (pending_calls = pending[current_caller]?)
+            if pending_calls.includes?(node) && (definition_p = @pending_definition) && (untyped_p = @pending_untyped) && (types_p = @pending_types)
+              collect_call_site_value_types(node, definition_p, untyped_p, types_p)
+            end
+          end
+        end
+        # Descend when the cursor sits anywhere inside the call: its
+        # block (whose `&.`-chained form may lack an end location), its
+        # `&->` proc pointer, its object (`x.join { ... }` wraps the
+        # block-carrying receiver), or one of its arguments.
+        return unless !apply_cursor_bounds || before_cursor?(node) ||
+                      node.block.try { |block| block_contains_cursor?(block) } ||
+                      node.block_arg.try { |block_arg| contains_cursor?(block_arg) } ||
+                      node.obj.try { |object| contains_cursor?(object) } ||
+                      (node.args + (node.named_args || [] of Crystal::NamedArgument)).any? { |arg| contains_cursor?(arg) }
+
+        process_call(node, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::NamedArgument
+        # `foo(name: expr)` — the walk descends into the value like a
+        # positional argument.
+        return unless !apply_cursor_bounds || contains_cursor?(node.value)
+
+        process_node(node.value, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::Return
+        # `return unless (x = expr)` still assigns x before returning:
+        # process the returned expression like any other statement.
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        node.exp.try { |exp| process_node(exp, apply_cursor_bounds: apply_cursor_bounds) }
+      when Crystal::If
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_if(node, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::Unless
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_unless(node, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::Case
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_case(node, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::ProcLiteral
+        # `walker = ->(current : Crystal::ASTNode, ...) do ... end`:
+        # seed the parameter restrictions and walk the body like a def.
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        proc_def = node.def
+        proc_def.args.each do |arg|
+          next unless restriction = arg.restriction
+          @local_types[arg.name] = resolve_type_names(restriction.to_s)
+        end
+        process_node(proc_def.body, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::UninitializedVar
+        # `walker = uninitialized Proc(...)` parses directly as an
+        # UninitializedVar statement (no Assign wrapper): type the
+        # declared local so proc-typed receivers resolve.
+        return unless !apply_cursor_bounds || before_cursor?(node)
+
+        if var = node.var.as?(Crystal::Var)
+          @local_types[var.name] = [node.declared_type.to_s]
+        end
+      when Crystal::While
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_loop(node.cond, node.body, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::Until
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_loop(node.cond, node.body, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::Select
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        node.whens.each do |when_node|
+          when_node.conds.each { |cond| process_node(cond, apply_cursor_bounds: apply_cursor_bounds) }
+          process_node(when_node.body, apply_cursor_bounds: apply_cursor_bounds)
+        end
+        node.else.try { |else_node| process_node(else_node, apply_cursor_bounds: apply_cursor_bounds) }
+      when Crystal::ExceptionHandler
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_exception_handler(node, apply_cursor_bounds: apply_cursor_bounds)
+      when Crystal::MacroIf
+        # `{% if %}` / `{% else %}` branches are raw macro text: reparse
+        # and walk both so locals assigned behind a compile-time flag
+        # (`{% if flag?(:preview_mt) %}` scheduler/fiber code) type the
+        # same as plain statements.
+        return unless !apply_cursor_bounds || starts_before_or_at_cursor?(node)
+
+        process_macro_if(node, apply_cursor_bounds: apply_cursor_bounds)
+      else
+        return unless !apply_cursor_bounds || before_cursor?(node)
+      end
+    end
+
+    private def infer_types(node : Crystal::ASTNode) : Array(String)
+      case node
+      when Crystal::Expressions
+        # Parenthesized expressions: the value is the last expression.
+        node.expressions.last?.try { |last| infer_expression_result_types(last) } || [] of String
+      when Crystal::ExceptionHandler
+        # `x = begin ... rescue ... end` types from the body's value.
+        infer_expression_result_types(node.body)
+      when Crystal::UninitializedVar
+        # `x = uninitialized Proc(A, B, R)` declares the variable's
+        # type: use the declared type name so proc-typed locals
+        # (`walker.call`) resolve.
+        [node.declared_type.to_s]
+      when Crystal::ProcLiteral
+        # `x = ->(a : T, b : U) do ... end` — the literal's signature
+        # names the proc type, so proc-typed locals resolve. The params
+        # and body are proc-local: derive the body's value on a saved
+        # state so nothing leaks into the enclosing scope.
+        proc_def = node.def
+        inputs = proc_def.args.compact_map do |arg|
+          arg.restriction.try(&.to_s)
+        end
+        output = proc_literal_output_types(node).first? || "Nil"
+        ["Proc(#{inputs.join(", ")}, #{output})"]
+      when Crystal::ProcPointer
+        # `x.try &->URI.parse(String)` — the `&->` form passes a proc
+        # pointer (not a block): its value is the pointed-to method's
+        # return type (`URI.parse` returns `URI`).
+        if (object = node.obj) && (type_name = type_expression_name(object))
+          if resolved = @query.resolve_type_name(type_name, namespace: @current_type_name)
+            @query.methods_named(resolved, node.name, class_method: true).each do |method|
+              if (return_type = method.return_type)
+                expanded = TypeUtils.expand_type_names(return_type).map { |t| t == "self" ? method.owner : t }
+                return resolve_type_names(expanded, method.owner).uniq
+              end
+            end
+          end
+        end
+        [] of String
+      when Crystal::Var
+        if node.name == "self"
+          self_types[0]
+        else
+          local_types = types_for(node.name)
+          if local_types.empty? && (type_name = @current_type_name)
+            # A bare name may be a getter/method on the enclosing type
+            # (`handlers.each` where `handlers` is a `getter`).
+            @query.methods_for(type_name, class_method: class_method_context?).each do |method|
+              if method.name == node.name && (return_type = method.return_type)
+                local_types = resolve_type_names(TypeUtils.expand_type_names(return_type))
+                break
+              end
+            end
+          end
+          local_types
+        end
+      when Crystal::InstanceVar
+        instance_var_types_for(node.name)
+      when Crystal::ClassVar
+        class_var_types_for(node.name)
+      when Crystal::Self
+        self_types[0]
+      when Crystal::Path, Crystal::Generic
+        if type_name = @query.resolve_type_name(node.to_s, namespace: @current_type_name)
+          [type_name]
+        else
+          [] of String
+        end
+      when Crystal::NilLiteral
+        ["Nil"]
+      when Crystal::BoolLiteral
+        ["Bool"]
+      when Crystal::CharLiteral
+        ["Char"]
+      when Crystal::StringLiteral
+        ["String"]
+      when Crystal::NumberLiteral
+        [number_kind_name(node.kind)]
+      when Crystal::ArrayLiteral
+        infer_array_literal_types(node)
+      when Crystal::HashLiteral
+        infer_hash_literal_types(node)
+      when Crystal::NamedTupleLiteral
+        infer_named_tuple_literal_types(node)
+      when Crystal::Call
+        infer_call_types(node)
+      when Crystal::Cast, Crystal::NilableCast
+        # `x.as(T)` / `x.as?(T)` are compiler specials that parse as
+        # dedicated nodes: the target type names the result.
+        target_name = node.to.to_s
+        base = TypeUtils.split_top_level(target_name, '|').reject(&.==("Nil")).reject(&.==("::Nil")).first?
+        if base
+          resolved = @query.resolve_type_name(base, namespace: @current_type_name) || @query.find_type(base).try(&.name)
+          if resolved
+            nilable = node.is_a?(Crystal::NilableCast) || target_name.includes?("::Nil")
+            return nilable ? ["#{resolved} | Nil"] : [resolved]
+          end
+        end
+        [] of String
+      when Crystal::If, Crystal::Unless
+        # `x = if cond then a else b end` — the value is the branches' merge.
+        branch_types = [] of String
+        branch_types.concat(node.then.try { |branch| infer_expression_result_types(branch) } || [] of String)
+        branch_types.concat(node.else.try { |branch| infer_expression_result_types(branch) } || [] of String)
+        branch_types.uniq
+      when Crystal::Case
+        branch_types = [] of String
+        node.whens.each do |when_node|
+          branch_types.concat(when_node.body.try { |branch| infer_expression_result_types(branch) } || [] of String)
+        end
+        branch_types.concat(node.else.try { |branch| infer_expression_result_types(branch) } || [] of String)
+        branch_types.uniq
+      when Crystal::Or
+        infer_or_types(node)
+      when Crystal::And
+        infer_and_types(node)
+      when Crystal::TupleLiteral
+        tuple_part_types = node.elements.map do |element|
+          element_types = infer_types(element)
+          next nil if element_types.empty?
+          join_union_types(element_types)
+        end
+        resolved_parts = tuple_part_types.compact
+        return ["Tuple"] if resolved_parts.empty?
+
+        # An unresolvable element drops out of the tuple type rather than
+        # collapsing the whole literal: `{a, b, c}` keeps typing `t[0]`
+        # when only `b` is unknown.
+        ["Tuple(#{resolved_parts.join(", ")})"]
+      else
+        [] of String
+      end
+    end
+
+    # The value a proc literal produces when called — its body's last
+    # expression on a saved state (the params and body are proc-local and
+    # must not leak into the enclosing scope). Used by the `Proc(...)`
+    # literal typing and by `x.try &->...` call sites, which yield the
+    # proc's result rather than the proc itself.
+    private def proc_literal_output_types(node : Crystal::ProcLiteral) : Array(String)
+      saved_state = current_state
+      begin
+        node.def.args.each do |arg|
+          next unless restriction = arg.restriction
+          @local_types[arg.name] = resolve_type_names(restriction.to_s)
+        end
+        infer_expression_result_types(node.def.body)
+      ensure
+        restore_state(saved_state)
+      end
+    end
+
+    private def assign_multi_types(node : Crystal::MultiAssign)
+      value_types = if node.values.size == 1
+                      destructured_value_types(node.values.first)
+                    else
+                      node.values.flat_map { |value| [infer_types(value)] }
+                    end
+
+      node.targets.each_with_index do |target, index|
+        next unless types = value_types[index]?
+        next if types.empty?
+
+        case target
+        when Crystal::Var
+          # Tuple parts are bare names (`TypeInfo`): resolve them against
+          # the enclosing namespace so receiver lookups hit the
+          # fully-qualified index entry.
+          @local_types[target.name] = types.map { |type_name|
+            @query.resolve_type_name(type_name, namespace: @current_type_name) || type_name
+          }.uniq
+        when Crystal::InstanceVar
+          @instance_var_types[target.name] = types
+        when Crystal::ClassVar
+          @class_var_types[target.name] = types
+        end
+      end
+    end
+
+    private def process_call(node : Crystal::Call, *, apply_cursor_bounds : Bool)
+      # Indexed ivar assignment (`@cache[key] = value`) parses as a `[]=`
+      # call: the ivar itself is still typed by the assigned value.
+      if node.name == "[]=" && (obj = node.obj).is_a?(Crystal::InstanceVar)
+        if value = node.args.last?
+          types = infer_types(value)
+          @instance_var_types[obj.name] = types unless types.empty?
+        end
+      end
+
+      if apply_cursor_bounds
+        if object = node.obj
+          if contains_cursor?(object)
+            process_node(object, apply_cursor_bounds: true)
+            return
+          end
+        end
+
+        (node.args + (node.named_args || [] of Crystal::NamedArgument)).each do |arg|
+          if contains_cursor?(arg)
+            process_node(arg, apply_cursor_bounds: true)
+            return
+          end
+        end
+      end
+
+      block = node.block
+      return unless block
+      # A block before the cursor still assigns locals/ivars the cursor can
+      # see; only a block *after* the cursor is out of scope.
+      return unless block_contains_cursor?(block) || before_cursor?(node)
+
+      saved_local_types = @local_types.dup
+      begin
+        seeded_arg_names = seed_block_arg_types(node, block)
+        process_node(block.body, apply_cursor_bounds: apply_cursor_bounds)
+      ensure
+        # Block args are block-local: when the cursor is not inside this
+        # block, keep them out of the outer scope (only the body's effects
+        # on ivars and pre-existing locals survive).
+        merged = @local_types
+        unless contains_cursor?(block)
+          # The assignment sits in the begin block: if it raised before
+          # assigning, the variable is nil — guard with try.
+          merged = merged.reject { |name, _| seeded_arg_names.try(&.includes?(name)) == true }
+        end
+        @local_types = saved_local_types.merge(merged) { |_, old_value, new_value| (old_value + new_value).uniq }
+      end
+    end
+
+    private def seed_block_arg_types(node : Crystal::Call, block : Crystal::Block, object_types : Array(String)? = nil) : Array(String)
+      return [] of String if block.args.empty?
+
+      arg_types = block_argument_types(node, object_types)
+      return [] of String if arg_types.empty?
+
+      # A single tuple element destructured into multiple block params
+      # (`map { |k, v| ... }` on `Array(Tuple(K, V))`): split the tuple's
+      # elements across the params.
+      if block.args.size > arg_types.size
+        if first = arg_types.first?
+          if first.size == 1
+            if tuple_parts = TypeUtils.tuple_element_types(first.first)
+              arg_types = tuple_parts
+            end
+          elsif first.size == block.args.size
+            # A destructured element delivered as one entry holding the
+            # per-arg types: split it across the params.
+            arg_types = first.map { |type_name| [type_name] }
+          end
+        end
+      end
+
+      names = [] of String
+      block.args.each_with_index do |arg, index|
+        types = arg_types[index]? || [] of String
+        if arg.name.empty?
+          # `|(a, b)|` — a destructured block param: the parser gives it
+          # an empty name and keeps the sub-vars in `block.unpacks`.
+          # Split the tuple element types across the sub-params.
+          if unpacked = block.unpacks.try(&.[index]?)
+            sub_names = unpacked.expressions.compact_map { |exp| exp.as?(Crystal::Var).try(&.name) }
+            element_types = types.flat_map { |type_name| TypeUtils.tuple_element_types(type_name) || [] of Array(String) }
+            if !sub_names.empty? && sub_names.size == element_types.size
+              sub_names.each_with_index do |sub_name, sub_index|
+                @local_types[sub_name] = element_types[sub_index]
+                names << sub_name
+              end
+            end
+          end
+        elsif !types.empty?
+          @local_types[arg.name] = types.map { |type_name|
+            @query.resolve_type_name(type_name, namespace: @current_type_name) || type_name
+          }.uniq
+          names << arg.name
+        end
+      end
+      names
+    end
+
+    private def block_argument_types(node : Crystal::Call, object_types : Array(String)? = nil) : Array(Array(String))
+      # A bare call (`each_direct_def(...) do |definition|`) resolves on
+      # the enclosing type: fall back to the self types as the receiver.
+      # The caller usually already typed the receiver (chains re-enter the
+      # sub-chain here otherwise): reuse it when passed.
+      object_types = object_types || (node.obj.try { |object| infer_types(object) } || self_types[0])
+      # The receiver type may be a union string (`Array(T) | ::Nil`):
+      # split it so each branch is matched structurally below.
+      object_types = object_types.flat_map { |t| TypeUtils.expand_type_names(t) }.uniq
+
+      # The accumulator/object types depend on the call arguments, not
+      # just the receiver: these two stay name-keyed (the declaration
+      # `& : (U, T) -> U` cannot express the memo's type).
+      if node.name == "reduce"
+        return reduce_block_argument_types(node, object_types)
+      end
+
+      if node.name == "each_with_object"
+        element_types = array_block_argument_types(object_types).first?
+        memo_types = node.args.first?.try { |arg| infer_types(arg) } || [] of String
+        return [] of Array(String) if element_types.nil? || memo_types.empty?
+        return [element_types, memo_types]
+      end
+
+      # `try`/`tap` yield the receiver itself (non-nil): only the call
+      # site knows the receiver's type.
+      if node.name == "try" || node.name == "tap"
+        return [] of Array(String) if object_types.empty?
+        non_nil_types = object_types.reject(&.==("Nil")).uniq
+        return non_nil_types.empty? ? [] of Array(String) : [non_nil_types]
+      end
+
+      # `each_with_index(offset = 0, &)` / `each_char_with_index(offset = 0, &)`
+      # are declared without a block restriction: their shape cannot be
+      # derived, so they stay name-keyed.
+      if node.name == "each_with_index" || node.name == "each_char_with_index"
+        element_types = if node.name == "each_char_with_index"
+                          char_types_for(object_types)
+                        else
+                          array_block_argument_types(object_types).first?
+                        end
+        return [] of Array(String) unless element_types
+        return [element_types, ["Int32"]]
+      end
+
+      # `each_char(&)` on String yields Char.
+      if node.name == "each_char"
+        char_types = char_types_for(object_types)
+        return [] of Array(String) unless char_types
+        return [char_types]
+      end
+
+      # Structural: yield contracts derived from the method's own block
+      # restriction (`map(& : T -> U)` on an element receiver yields the
+      # element). Covers each/map/select/reject/find/compact_map/flat_map/
+      # index_by/group_by/map_with_index/each_key/each_value and any
+      # other stdlib method whose declaration carries the shape.
+      object_types.flat_map { |type_name| summary_block_argument_types(type_name, node.name) }
+    end
+
+    private def summary_block_argument_types(type_name : String, method_name : String) : Array(Array(String))
+      # A class-method call (`OptionParser.parse do |parser|`) records its
+      # contracts under class_method=true: query both views.
+      contracts = (@query.method_contracts_for(type_name, method_name, class_method: false) +
+                   @query.method_contracts_for(type_name, method_name, class_method: true)).uniq
+      return [] of Array(String) if contracts.empty?
+
+      block_types = [] of Array(String)
+      contracts.each do |contract|
+        if contract.block_args.any?
+          block_types.concat(contract.block_args.map(&.dup))
+          next
+        end
+
+        # The receiver's own types substitute the declaration's vars
+        # (`Array(T)#map` yields the receiver's element, whatever T is).
+        case contract.kind
+        when .yield_self?
+          block_types << contract.types unless contract.types.empty?
+        when .yield_element?
+          if element_types = TypeUtils.enumerable_element_types(type_name)
+            block_types << element_types
+          end
+        when .yield_element_with_index?
+          if element_types = TypeUtils.enumerable_element_types(type_name)
+            block_types << element_types
+            block_types << ["Int32"]
+          end
+        when .yield_key?
+          if key_types = TypeUtils.hash_key_types(type_name)
+            block_types << key_types
+          end
+        when .yield_value?
+          if value_types = TypeUtils.hash_value_types(type_name)
+            block_types << value_types
+          end
+        when .yield_key_value?
+          if key_types = TypeUtils.hash_key_types(type_name)
+            if value_types = TypeUtils.hash_value_types(type_name)
+              block_types << key_types
+              block_types << value_types
+            end
+          end
+        end
+      end
+      block_types
+    end
+
+    private def array_block_argument_types(object_types : Array(String)) : Array(Array(String))
+      return [] of Array(String) if object_types.empty?
+
+      element_types = object_types.flat_map { |type_name| TypeUtils.array_element_types(type_name) || [] of String }.uniq
+      element_types.empty? ? [] of Array(String) : [element_types]
+    end
+
+    # `each_char`-family methods on a String receiver yield Char (and
+    # Int32 for the indexed forms): the declarations use a bare `&`, so
+    # the yield shape is name-keyed.
+    private def char_types_for(object_types : Array(String)) : Array(String)?
+      return nil unless object_types.any?(&.==("String"))
+      ["Char"]
+    end
+
+    private def reduce_block_argument_types(node : Crystal::Call, object_types : Array(String)) : Array(Array(String))
+      element_types = object_types.flat_map { |type_name| TypeUtils.array_element_types(type_name) || [] of String }.uniq
+      return [] of Array(String) if element_types.empty?
+
+      accumulator_types = if memo = node.args.first?
+                            memo_types = infer_types(memo)
+                            memo_types.empty? ? element_types : memo_types
+                          else
+                            element_types
+                          end
+      return [] of Array(String) if accumulator_types.empty?
+
+      [accumulator_types.uniq, element_types]
+    end
+
+    private def destructured_value_types(node : Crystal::ASTNode) : Array(Array(String))
+      case node
+      when Crystal::TupleLiteral
+        node.elements.map { |element| infer_types(element) }
+      else
+        infer_types(node).flat_map do |type_name|
+          if tuple_types = TypeUtils.tuple_element_types(type_name)
+            tuple_types
+          else
+            [] of Array(String)
+          end
+        end
+      end
+    end
+
+    private def infer_or_types(node : Crystal::Or) : Array(String)
+      left_types = infer_types(node.left)
+      right_types = infer_types(node.right)
+
+      (left_types.reject(&.==("Nil")) + right_types).uniq
+    end
+
+    private def infer_and_types(node : Crystal::And) : Array(String)
+      left_types = infer_types(node.left)
+      right_types = infer_types(node.right)
+      nil_types = left_types.select(&.==("Nil"))
+
+      (nil_types + right_types).uniq
+    end
+
+    private def infer_call_types(node : Crystal::Call) : Array(String)
+      infer_call_types_inner(node)
+    end
+
+    private def infer_call_types_inner(node : Crystal::Call) : Array(String)
+      if node.name == "new"
+        if object = node.obj
+          if type_name = type_expression_name(object)
+            return [type_name] if @query.find_type(type_name)
+          end
+        elsif class_method_context?
+          # A bare `new` in a class method (`def self.from_program`):
+          # instantiates the enclosing type.
+          if (type_name = @current_type_name) && @query.find_type(type_name)
+            return [type_name]
+          end
+        end
+      end
+
+      # The receiver's types are the base of every path below: compute
+      # them once. Re-inferring per path made long block-carrying chains
+      # (`a.map {...}.reject {...}.select {...}`) re-type the whole
+      # sub-chain at every level — quadratic-to-exponential per request.
+      object_types = node.obj.try { |object| infer_types(object) } || [] of String
+
+      # `x.try { ... }` / `x.try &->URI.parse(String)`: the receiver is
+      # yielded to the block (or proc) and the call evaluates to the
+      # block's value or nil. The index records no return for Object#try,
+      # and Nil#try returns `self` (nil) — neither carries the block's
+      # value, so the call site derives it: non-nil receiver branches
+      # yield the block/proc result, the nil branch stays nil.
+      if node.name == "try" && !object_types.empty?
+        non_nil_types = object_types.reject(&.==("Nil")).uniq
+        # `nil.try { ... }` never runs the block: the value is always nil.
+        return ["Nil"] if non_nil_types.empty?
+        block_types = if (block = node.block)
+                        infer_block_result_types(node, block, object_types)
+                      elsif (block_arg = node.block_arg)
+                        case block_arg
+                        when Crystal::ProcLiteral
+                          proc_literal_output_types(block_arg)
+                        else
+                          infer_types(block_arg)
+                        end
+                      else
+                        [] of String
+                      end
+        # `try` is declared `: U?` — the block's value or nil even when
+        # the receiver itself is non-nil.
+        return (block_types + ["Nil"]).uniq unless block_types.empty?
+      end
+
+      # `File.open(..., &)`-style methods declare a bare `&` (no typed
+      # block restriction) and the no-block overload's `: self` return
+      # wins the index merge — but with a block they yield and return
+      # the block's value (`shards_yaml = File.open(path) do |file| ... end`
+      # is the opened file's parse, not the File itself). When the call
+      # has a block, no overload carries a typed block restriction, and
+      # the recorded return is the receiver itself, the block result is
+      # the value.
+      if (block = node.block) && node.name != "new"
+        unless object_types.empty?
+          methods = object_types.flat_map do |type_name|
+            @query.methods_named(type_name, node.name, class_method: false) +
+              @query.methods_named(type_name, node.name, class_method: true)
+          end
+          if methods.any? && methods.none?(&.block_restriction)
+            # Only `open`-style methods (`File.open`, `IO.open`) declare
+            # a bare `&` and return the block's value; other bare-&
+            # methods with a `: self`-annotated return (`String.build`)
+            # ignore the block's value and are structurally identical
+            # in the index, so the name is the discriminator.
+            if node.name == "open" && methods.any? { |method| method.return_type == "self" }
+              block_types = infer_block_result_types(node, block, object_types)
+              return block_types unless block_types.empty?
+            end
+          end
+        end
+      end
+
+      # A class-method call on a type path (`Inference.for(...)`,
+      # `Project.best_fit_for_file`): resolve the type against the
+      # enclosing namespace and look up the class method's return type.
+      if node.name != "new"
+        if object = node.obj
+          if type_name = type_expression_name(object)
+            if resolved = @query.resolve_type_name(type_name, namespace: @current_type_name)
+              @query.methods_named(resolved, node.name, class_method: true).each do |method|
+                if (return_type = method.return_type)
+                  # `: self?`-style returns resolve to the method's owner.
+                  return_types = TypeUtils.expand_type_names(return_type).map { |t| t == "self" ? method.owner : t }
+                  return resolve_type_names(return_types, method.owner).uniq
+                end
+              end
+            end
+          end
+        end
+      end
+
+      if object = node.obj
+        block_types = infer_block_call_types(node, object_types)
+        return block_types unless block_types.empty?
+
+        special_types = infer_special_call_types(node, object_types)
+        return special_types unless special_types.empty?
+      end
+
+      return_types = [] of String
+
+      if object = node.obj
+        object_types.each do |type_name|
+          # A constant receiver (`Project.best_fit_for_file`) resolves to a
+          # class: look up class methods alongside instance methods.
+          methods = @query.methods_named(type_name, node.name, class_method: false) +
+                    @query.methods_named(type_name, node.name, class_method: true)
+          # Prefer overloads whose arity matches the call (`shift` vs
+          # `shift(n)` on a delegated array): the exact match names the
+          # value, the other overloads would type the local as the array
+          # itself. Falls back to all methods when no arity matches
+          # (optional/default args).
+          call_arg_count = node.args.size + (node.named_args || [] of Crystal::NamedArgument).size
+          if methods.any? { |method| method.args.size == call_arg_count }
+            methods = methods.select { |method| method.args.size == call_arg_count }
+          end
+          methods.each do |method|
+            if (return_type = method.return_type)
+              # `Array(T)#+` returns `Array(T)`: substitute the receiver's
+              # concrete element types for the free vars so the local keeps
+              # `Array(X)` instead of an unresolvable `T`.
+              return_type = TypeUtils.substitute_free_vars(return_type, method.free_vars, type_name)
+              # `: self?`-style returns resolve to the method's owner.
+              expanded = TypeUtils.expand_type_names(return_type).map { |t| t == "self" ? method.owner : t }
+              # Bare names (`Block`) resolve against the method's own
+              # namespace, the way the compiler would.
+              return_types.concat(resolve_type_names(expanded, method.owner))
+            end
+          end
+        end
+      else
+        # A bare call resolves against the enclosing type first (self call),
+        # then against top-level methods.
+        if type_name = @current_type_name
+          @query.methods_named(type_name, node.name, class_method: class_method_context?).each do |method|
+            if (return_type = method.return_type)
+              return_types.concat(resolve_type_names(TypeUtils.expand_type_names(return_type), method.owner))
+            end
+          end
+        end
+
+        @query.top_level_methods.each do |method|
+          if method.name == node.name && (return_type = method.return_type)
+            return_types.concat(resolve_type_names(TypeUtils.expand_type_names(return_type)))
+          end
+        end
+
+        # A same-file self-call whose def declares no return type
+        # (`operator = preceding_period(...)` ending in a `find`): infer
+        # the def body's last expression.
+        if return_types.empty?
+          if def_node = find_same_file_def(node.name)
+            return_types.concat(same_file_def_last_expression_types(def_node))
+          end
+        end
+      end
+
+      # Compiler-semantic accessors (`ASTNode#type?`, base
+      # `Type#parents`/`types?`/`remove_alias`) exist in the index without
+      # a usable return (synthesized by the semantic pass, or base-class
+      # dummies returning nil): apply the known compiler signature so
+      # receivers of AST/type values keep their chains (`node_type.doc`,
+      # `type.parents.try &.each`).
+      if (return_types.empty? || return_types.all?(&.==("Nil"))) && node.obj
+        if object_types.any? { |type_name| type_name.starts_with?("Crystal::") }
+          if semantic_return = TypeUtils.semantic_accessor_return(node.name)
+            return_types = [semantic_return]
+          end
+        end
+      end
+
+      # Unknown block-taking method (`@mutex.synchronize { ... }`): Crystal
+      # yields return the block's value, so when the index records no
+      # return type at all, fall back to the block's inferred result.
+      if return_types.empty? && (block = node.block)
+        return_types.concat(infer_block_result_types(node, block))
+      end
+
+      return_types.uniq
+    end
+
+    # The def body's last expression's types, after processing the preceding
+    # statements so locals (a `spans` accumulator) are typed. The callee's
+    # locals must not leak into the caller's scope: the whole walk runs on a
+    # saved state that is restored before returning.
+    private def same_file_def_last_expression_types(def_node : Crystal::Def) : Array(String)
+      body = def_node.body
+      # `begin ... rescue ... ensure` bodies (compile's channel dance):
+      # the value is the body's last expression.
+      body = body.body if body.is_a?(Crystal::ExceptionHandler)
+      saved_state = current_state
+      begin
+        if body.is_a?(Crystal::Expressions) && body.expressions.any?
+          body.expressions[0...-1].each do |expression|
+            process_node(expression, apply_cursor_bounds: false)
+          end
+          infer_expression_result_types(body.expressions.last)
+        else
+          infer_expression_result_types(body)
+        end
+      ensure
+        restore_state(saved_state)
+      end
+    end
+
+    # Finds the first same-file def matching `name` (any enclosing type):
+    # used to infer the return of self-calls whose defs omit the return
+    # type restriction.
+    private def find_same_file_def(name : String) : Crystal::Def?
+      return nil unless ast = @ast
+
+      found = nil.as(Crystal::Def?)
+      finder = uninitialized Proc(Crystal::ASTNode, Nil)
+      finder = ->(node : Crystal::ASTNode) do
+        case node
+        when Crystal::Def
+          # The last overload wins: `compile`'s first overload just
+          # delegates to the second, whose body carries the value.
+          found = node if node.name == name && !node.receiver
+        when Crystal::Expressions
+          node.expressions.each { |expression| finder.call(expression) }
+        when Crystal::ClassDef, Crystal::ModuleDef
+          finder.call(node.body)
+        when Crystal::VisibilityModifier
+          finder.call(node.exp)
+        end
+      end
+      finder.call(ast)
+      found
+    end
+
+    private def resolve_type_names(type_names : Array(String), namespace : String? = @current_type_name) : Array(String)
+      type_names.map do |type_name|
+        resolve_type_name_deep(type_name, namespace)
+      end
+    end
+
+    # Resolves a type name against the enclosing type, descending into
+    # generic arguments: `Array(MethodInfo)` with bare nested names
+    # becomes `Array(Crystalline::Lightweight::MethodInfo)` so receiver
+    # lookups hit the fully-qualified index entry.
+    private def resolve_type_name_deep(type_name : String, namespace : String? = @current_type_name) : String
+      if (parts = TypeUtils.generic_type_arguments(type_name, "Array", 1)) && (element = parts[0]?)
+        resolved_element = resolve_type_name_deep(element, namespace)
+        return "Array(#{resolved_element})" if resolved_element != element
+      end
+      if (parts = TypeUtils.generic_type_arguments(type_name, "Hash", 2)) && parts.size == 2
+        resolved_key = resolve_type_name_deep(parts[0], namespace)
+        resolved_value = resolve_type_name_deep(parts[1], namespace)
+        if resolved_key != parts[0] || resolved_value != parts[1]
+          return "Hash(#{resolved_key}, #{resolved_value})"
+        end
+      end
+
+      @query.resolve_type_name(type_name, namespace: namespace) || type_name
+    end
+
+    private def type_expression_name(node : Crystal::ASTNode) : String?
+      case node
+      when Crystal::Path, Crystal::Generic
+        @query.resolve_type_name(node.to_s, namespace: @current_type_name)
+      else
+        nil
+      end
+    end
+
+    private def infer_block_call_types(node : Crystal::Call, object_types : Array(String)) : Array(String)
+      block = node.block
+      return [] of String unless block
+
+      block_result_types = infer_block_result_types(node, block, object_types)
+      return [] of String if block_result_types.empty?
+
+      contracts = object_types.flat_map { |type_name| @query.method_contracts_for(type_name, node.name) }.uniq
+      contract_result_types = apply_block_result_contracts(contracts, block_result_types, object_types)
+      return contract_result_types unless contract_result_types.empty?
+
+      [] of String
+    end
+
+    private def apply_block_result_contracts(contracts : Array(MethodContract), block_result_types : Array(String), object_types : Array(String)) : Array(String)
+      receiver_element_types = enumerable_element_types_for(object_types)
+      result_types = [] of String
+
+      contracts.each do |contract|
+        next unless result_shape = contract.result_shape
+
+        case result_shape
+        when .array_of_block_result?
+          result_types << "Array(#{join_union_types(block_result_types)})"
+        when .array_of_compact_block_result?
+          compact_types = block_result_types.reject(&.==("Nil")).uniq
+          result_types << "Array(#{join_union_types(compact_types)})" unless compact_types.empty?
+        when .array_of_flattened_block_result?
+          flattened_types = block_result_types.flat_map do |type_name|
+            TypeUtils.array_element_types(type_name) || [type_name]
+          end.uniq
+          result_types << "Array(#{join_union_types(flattened_types)})" unless flattened_types.empty?
+        when .hash_of_block_result_to_receiver_element?
+          next if receiver_element_types.empty?
+          result_types << "Hash(#{join_union_types(block_result_types)}, #{join_union_types(receiver_element_types)})"
+        when .hash_of_block_result_to_receiver_element_array?
+          next if receiver_element_types.empty?
+          result_types << "Hash(#{join_union_types(block_result_types)}, Array(#{join_union_types(receiver_element_types)}))"
+        when .block_result_or_nil?
+          result_types.concat((block_result_types + ["Nil"]).uniq)
+        end
+      end
+
+      result_types.uniq
+    end
+
+    private def enumerable_element_types_for(object_types : Array(String)) : Array(String)
+      object_types.flat_map do |type_name|
+        TypeUtils.enumerable_element_types(type_name) || [] of String
+      end.uniq
+    end
+
+    private def infer_block_result_types(node : Crystal::Call, block : Crystal::Block, object_types : Array(String)? = nil) : Array(String)
+      saved_state = current_state
+      begin
+        seed_block_arg_types(node, block, object_types)
+        infer_expression_result_types(block.body)
+      ensure
+        restore_state(saved_state)
+      end
+    end
+
+    private def infer_expression_result_types(node : Crystal::ASTNode) : Array(String)
+      case node
+      when Crystal::Assign
+        # `x = expr` / `x ||= expr` evaluate to the assigned value.
+        infer_types(node.value)
+      when Crystal::OpAssign
+        # `x ||= expr` parses as an OpAssign: same value semantics.
+        infer_types(node.value)
+      when Crystal::Expressions
+        return [] of String if node.expressions.empty?
+
+        node.expressions[0...-1].each do |expression|
+          process_node(expression, apply_cursor_bounds: false)
+        end
+        infer_types(node.expressions.last)
+      else
+        infer_types(node)
+      end
+    end
+
+    private def infer_special_call_types(node : Crystal::Call, object_types : Array(String)) : Array(String)
+      case node.name
+      when "not_nil!"
+        # The receiver type may itself be a union string (`Location | ::Nil`):
+        # split it so the nil branch is actually removed.
+        return object_types.flat_map { |t| TypeUtils.expand_type_names(t) }
+          .reject { |t| t == "Nil" || t == "::Nil" }.uniq
+      when "tap", "each", "each_with_index"
+        return object_types.uniq
+      when "reverse_each"
+        # `arr.reverse_each.find { ... }` chains on the enumerator; the
+        # indexed overload is the block form (`: Nil`).
+        return object_types.uniq if node.block.nil?
+      when "[]"
+        # `arr[1..]` slices (returns the array), `arr[1]` indexes (element).
+        return object_types.uniq if node.args.first?.is_a?(Crystal::RangeLiteral)
+      when "each_with_object"
+        return node.args.first?.try { |arg| infer_types(arg) } || [] of String
+      when "select", "reject"
+        return object_types.uniq
+      when "flatten"
+        # `Array(T)#flatten` is compiler-inferred (no indexed return):
+        # the chain still flows through the array; a tuple flattens into
+        # an array of its elements' union.
+        return object_types.flat_map do |type_name|
+          if TypeUtils.array_element_types(type_name)
+            [type_name]
+          elsif tuple_types = TypeUtils.tuple_element_types(type_name)
+            ["Array(#{tuple_types.join(" | ")})"]
+          else
+            [] of String
+          end
+        end.uniq
+      end
+
+      return_types = [] of String
+      object_types.each do |type_name|
+        return_types.concat(container_call_types(type_name, node.name))
+      end
+      return_types.uniq
+    end
+
+    private def infer_array_literal_types(node : Crystal::ArrayLiteral) : Array(String)
+      if node.elements.empty?
+        if of_type = node.of
+          resolved_types = resolve_type_names(of_type.to_s)
+          return ["Array(#{join_union_types(resolved_types)})"] unless resolved_types.empty?
+        end
+        return ["Array"]
+      end
+
+      element_types = node.elements.flat_map { |element| infer_types(element) }.uniq
+      return ["Array"] if element_types.empty?
+
+      ["Array(#{join_union_types(element_types)})"]
+    end
+
+    private def infer_hash_literal_types(node : Crystal::HashLiteral) : Array(String)
+      key_types = node.entries.flat_map { |entry| infer_types(entry.key) }.uniq
+      value_types = node.entries.flat_map { |entry| infer_types(entry.value) }.uniq
+      if key_types.empty? || value_types.empty?
+        # `{} of String => Array(String)` declares the shape on an empty
+        # literal: use it so indexed lookups keep the element types.
+        if of = node.of
+          return ["Hash(#{of.key}, #{of.value})"]
+        end
+        return ["Hash"]
+      end
+
+      ["Hash(#{join_union_types(key_types)}, #{join_union_types(value_types)})"]
+    end
+
+    private def infer_named_tuple_literal_types(node : Crystal::NamedTupleLiteral) : Array(String)
+      parts = node.entries.map do |entry|
+        value_types = infer_types(entry.value)
+        next unless value_types.present?
+        "#{entry.key}: #{join_union_types(value_types)}"
+      end.compact
+      return ["NamedTuple"] if parts.empty?
+
+      ["NamedTuple(#{parts.join(", ")})"]
+    end
+
+    private def container_call_types(type_name : String, method_name : String) : Array(String)
+      if element_types = TypeUtils.array_element_types(type_name)
+        case method_name
+        when "first", "last", "[]", "find!", "reduce"
+          return element_types
+        when "first?", "last?", "[]?", "find", "dig"
+          return (element_types + ["Nil"]).uniq
+        when "select", "reject", "each", "each_with_index"
+          return [type_name]
+        end
+      end
+
+      if value_types = TypeUtils.hash_value_types(type_name)
+        case method_name
+        when "[]", "fetch"
+          return value_types
+        when "[]?", "dig"
+          return (value_types + ["Nil"]).uniq
+        when "select", "reject", "each"
+          return [type_name]
+        end
+      end
+
+      if method_name == "dig"
+        if tuple_types = TypeUtils.tuple_element_types(type_name)
+          return (tuple_types.flatten + ["Nil"]).uniq
+        end
+
+        if value_types = TypeUtils.named_tuple_all_value_types(type_name)
+          return (value_types + ["Nil"]).uniq
+        end
+      end
+
+      if tuple_types = TypeUtils.tuple_element_types(type_name)
+        case method_name
+        when "first"
+          return tuple_types.first? || [] of String
+        when "last"
+          return tuple_types.last? || [] of String
+        when "[]"
+          # `Tuple#[]`/`[]?` have no indexed return (compiler-inferred):
+          # approximate with the union of all elements (+ Nil).
+          return tuple_types.flatten.uniq
+        when "[]?"
+          return (tuple_types.flatten.uniq + ["Nil"]).uniq
+        when "first?"
+          return ((tuple_types.first? || [] of String) + ["Nil"]).uniq
+        when "last?"
+          return ((tuple_types.last? || [] of String) + ["Nil"]).uniq
+        end
+      end
+
+      if value_types = TypeUtils.named_tuple_value_types(type_name, method_name)
+        return value_types
+      end
+
+      [] of String
+    end
+
+    private def join_union_types(type_names : Array(String)) : String
+      type_names.uniq.join(" | ")
+    end
+
+    private def number_kind_name(kind : Crystal::NumberKind) : String
+      case kind
+      when .i8?   then "Int8"
+      when .i16?  then "Int16"
+      when .i32?  then "Int32"
+      when .i64?  then "Int64"
+      when .i128? then "Int128"
+      when .u8?   then "UInt8"
+      when .u16?  then "UInt16"
+      when .u32?  then "UInt32"
+      when .u64?  then "UInt64"
+      when .u128? then "UInt128"
+      when .f32?  then "Float32"
+      when .f64?  then "Float64"
+      else             "Int32"
+      end
+    end
+
+    private def locate_context(node : Crystal::ASTNode) : Bool
+      found = false
+      walker = uninitialized Proc(Crystal::ASTNode, String?, Crystal::ASTNode?, Nil)
+      walker = ->(current : Crystal::ASTNode, type_name : String?, type_body : Crystal::ASTNode?) do
+        case current
+        when Crystal::ClassDef
+          qualified_name = qualify_type_name(current.name.to_s, type_name)
+          if contains_cursor?(current.body) || starts_before_or_at_cursor?(current.body)
+            # The cursor may sit directly in the type body (not inside a
+            # def): remember the enclosing type so ivars still resolve.
+            # Only when the cursor is truly inside the body: top-level code
+            # after the type must stay in the top-level context.
+            if contains_cursor?(current.body)
+              @current_type_name = qualified_name
+              @current_type_body = current.body
+            end
+            walker.call(current.body, qualified_name, current.body)
+          end
+        when Crystal::ModuleDef
+          qualified_name = qualify_type_name(current.name.to_s, type_name)
+          if contains_cursor?(current.body) || starts_before_or_at_cursor?(current.body)
+            if contains_cursor?(current.body)
+              @current_type_name = qualified_name
+              @current_type_body = current.body
+            end
+            walker.call(current.body, qualified_name, current.body)
+          end
+        when Crystal::EnumDef
+          qualified_name = qualify_type_name(current.name.to_s, type_name)
+          current.members.each do |member|
+            walker.call(member, qualified_name, type_body) if contains_cursor?(member) || starts_before_or_at_cursor?(member)
+          end
+        when Crystal::Expressions
+          current.expressions.each do |expression|
+            walker.call(expression, type_name, type_body) if contains_cursor?(expression) || starts_before_or_at_cursor?(expression)
+          end
+        when Crystal::Def
+          if contains_cursor?(current)
+            @current_def = current
+            @current_type_name = type_name
+            @class_method_context = !current.receiver.nil?
+            @current_type_body = type_body
+            found = true
+          end
+        when Crystal::VisibilityModifier
+          # `private def` / `protected def` wrap the def in a VisibilityModifier.
+          walker.call(current.exp, type_name, type_body) if contains_cursor?(current.exp) || starts_before_or_at_cursor?(current.exp)
+        when Crystal::If
+          walker.call(current.then, type_name, type_body) if contains_cursor?(current.then) || starts_before_or_at_cursor?(current.then)
+          walker.call(current.else, type_name, type_body) if contains_cursor?(current.else) || starts_before_or_at_cursor?(current.else)
+        when Crystal::Unless
+          walker.call(current.then, type_name, type_body) if contains_cursor?(current.then) || starts_before_or_at_cursor?(current.then)
+          walker.call(current.else, type_name, type_body) if contains_cursor?(current.else) || starts_before_or_at_cursor?(current.else)
+        when Crystal::MacroIf
+          # `{% if %}` / `{% elsif %}` / `{% else %}` branches hold raw
+          # macro text with real code (defs, class vars) that only exists
+          # behind a compile-time flag: reparse each branch and descend so
+          # the cursor still locates its enclosing def.
+          walk_macro_if_branch(current.then, type_name, type_body, walker)
+          walk_macro_if_branch(current.else, type_name, type_body, walker)
+        end
+      end
+
+      walker.call(node, nil, nil)
+      found
+    end
+
+    # Walks one macro branch during locate_context. An `{% elsif %}` chain
+    # nests as a MacroIf in the else slot: recurse directly on it. A plain
+    # branch is raw macro text whose reparse restarts at 1:1, so the cursor
+    # is translated into the branch text's coordinates first (the branch
+    # node's own location still points at the original file).
+    private def walk_macro_if_branch(branch : Crystal::ASTNode?, type_name : String?, type_body : Crystal::ASTNode?, walker : Proc(Crystal::ASTNode, String?, Crystal::ASTNode?, Nil))
+      return unless branch
+      if branch.is_a?(Crystal::MacroIf)
+        walker.call(branch, type_name, type_body)
+        return
+      end
+      return unless contains_cursor?(branch) || starts_before_or_at_cursor?(branch)
+      text = macro_branch_text(branch)
+      return unless text
+      saved_line = @line
+      saved_column = @column
+      begin
+        if location = branch.location
+          if @line == location.line_number
+            @column = @column - location.column_number + 1
+          end
+          @line = @line - location.line_number + 1
+        end
+        walker.call(Crystal::Parser.new(text).parse, type_name, type_body)
+      rescue Crystal::SyntaxException
+        # A branch may not parse on its own (spliced interpolation): skip.
+      ensure
+        @line = saved_line
+        @column = saved_column
+      end
+    end
+
+    # The raw code text of a macro branch (its body parses as MacroLiteral
+    # nodes, with MacroExpressions for `{{ ... }}` interpolations): the
+    # concatenation mirrors the indexer's index_macro_branch so a def or
+    # class var spanning several literals reparses as one unit.
+    private def macro_branch_text(branch : Crystal::ASTNode) : String?
+      text = String.build do |io|
+        case branch
+        when Crystal::Expressions
+          branch.expressions.each do |expression|
+            case expression
+            when Crystal::MacroLiteral    then io << expression.value
+            when Crystal::MacroExpression then io << expression.to_s
+            end
+          end
+        when Crystal::MacroLiteral
+          io << branch.value
+        when Crystal::MacroExpression
+          io << branch.to_s
+        end
+      end
+      text.strip.empty? ? nil : text
+    end
+
+    # Processes a loop body. The body may not have run at all, so after the
+    # loop the types are the union of the pre-loop state and the assignments
+    # made inside the body (mirroring branch merging).
+    private def process_loop(cond : Crystal::ASTNode, body : Crystal::ASTNode, *, apply_cursor_bounds : Bool)
+      base_state = current_state
+
+      process_node(cond, apply_cursor_bounds: false)
+      process_node(body, apply_cursor_bounds: apply_cursor_bounds)
+      body_state = current_state
+
+      restore_state(base_state)
+      @local_types = merge_branch_types(base_state[0], base_state[0], body_state[0])
+      @instance_var_types = merge_branch_types(base_state[1], base_state[1], body_state[1])
+      @class_var_types = merge_branch_types(base_state[2], base_state[2], body_state[2])
+    end
+
+    private def process_macro_if(node : Crystal::MacroIf, *, apply_cursor_bounds : Bool)
+      process_macro_branch(node.then, apply_cursor_bounds: apply_cursor_bounds)
+      process_macro_branch(node.else, apply_cursor_bounds: apply_cursor_bounds)
+    end
+
+    # Walks one macro branch's reparsed code. An `{% elsif %}` chain nests
+    # as a MacroIf in the else slot: recurse directly on it. The reparse
+    # restarts at 1:1 while the cursor is in file coordinates, so it is
+    # translated into the branch text's coordinates per branch (the branch
+    # node's own location still points at the original file).
+    private def process_macro_branch(branch : Crystal::ASTNode?, *, apply_cursor_bounds : Bool)
+      return unless branch
+      if branch.is_a?(Crystal::MacroIf)
+        process_macro_if(branch, apply_cursor_bounds: apply_cursor_bounds)
+        return
+      end
+      text = macro_branch_text(branch)
+      return unless text
+      saved_line = @line
+      saved_column = @column
+      begin
+        if location = branch.location
+          if @line == location.line_number
+            @column = @column - location.column_number + 1
+          end
+          @line = @line - location.line_number + 1
+        end
+        process_node(Crystal::Parser.new(text).parse, apply_cursor_bounds: apply_cursor_bounds)
+      rescue Crystal::SyntaxException
+        # A branch may not parse on its own (spliced interpolation): skip.
+      ensure
+        @line = saved_line
+        @column = saved_column
+      end
+    end
+
+    private def process_exception_handler(node : Crystal::ExceptionHandler, *, apply_cursor_bounds : Bool)
+      if !apply_cursor_bounds || contains_cursor?(node.body) || starts_before_or_at_cursor?(node.body)
+        process_node(node.body, apply_cursor_bounds: apply_cursor_bounds)
+        return if apply_cursor_bounds && contains_cursor?(node.body)
+      end
+
+      node.rescues.try &.each do |rescue_clause|
+        next unless !apply_cursor_bounds || contains_cursor?(rescue_clause.body)
+
+        saved_local_types = @local_types.dup
+        begin
+          seed_rescue_types(rescue_clause)
+          process_node(rescue_clause.body, apply_cursor_bounds: apply_cursor_bounds)
+        ensure
+          @local_types = saved_local_types.merge(@local_types) { |_, old_value, new_value| (old_value + new_value).uniq }
+        end
+        return if apply_cursor_bounds
+      end
+
+      if rescue_else = node.else
+        if !apply_cursor_bounds || contains_cursor?(rescue_else)
+          process_node(rescue_else, apply_cursor_bounds: apply_cursor_bounds)
+          return if apply_cursor_bounds
+        end
+      end
+
+      if ensure_clause = node.ensure
+        if !apply_cursor_bounds || contains_cursor?(ensure_clause)
+          process_node(ensure_clause, apply_cursor_bounds: apply_cursor_bounds)
+        end
+      end
+    end
+
+    private def seed_rescue_types(rescue_clause : Crystal::Rescue)
+      return unless name = rescue_clause.name
+
+      type_names = if types = rescue_clause.types
+                     types.flat_map { |type| resolve_type_names(type.to_s) }.uniq
+                   else
+                     [@query.resolve_type_name("Exception", namespace: @current_type_name) || "Exception"]
+                   end
+      @local_types[name] = type_names unless type_names.empty?
+    end
+
+    private def process_if(node : Crystal::If, *, apply_cursor_bounds : Bool)
+      if apply_cursor_bounds
+        if contains_cursor?(node.then)
+          process_node(node.cond, apply_cursor_bounds: false)
+          apply_condition_refinement(node.cond, truthy: true)
+          process_node(node.then, apply_cursor_bounds: true)
+          return
+        elsif contains_cursor?(node.else)
+          process_node(node.cond, apply_cursor_bounds: false)
+          apply_condition_refinement(node.cond, truthy: false)
+          process_node(node.else, apply_cursor_bounds: true)
+          return
+        end
+      end
+
+      process_conditional(node.cond, node.then, node.else, then_truthy: true, else_truthy: false, apply_cursor_bounds: apply_cursor_bounds)
+    end
+
+    private def process_unless(node : Crystal::Unless, *, apply_cursor_bounds : Bool)
+      if apply_cursor_bounds
+        if contains_cursor?(node.then)
+          process_node(node.cond, apply_cursor_bounds: false)
+          apply_condition_refinement(node.cond, truthy: false)
+          process_node(node.then, apply_cursor_bounds: true)
+          return
+        elsif contains_cursor?(node.else)
+          process_node(node.cond, apply_cursor_bounds: false)
+          apply_condition_refinement(node.cond, truthy: true)
+          process_node(node.else, apply_cursor_bounds: true)
+          return
+        end
+      end
+
+      process_conditional(node.cond, node.then, node.else, then_truthy: false, else_truthy: true, apply_cursor_bounds: apply_cursor_bounds)
+    end
+
+    private def process_conditional(cond : Crystal::ASTNode, then_branch : Crystal::ASTNode, else_branch : Crystal::ASTNode, *, then_truthy : Bool, else_truthy : Bool, apply_cursor_bounds : Bool)
+      base_state = current_state
+
+      restore_state(base_state)
+      process_node(cond, apply_cursor_bounds: false)
+      apply_condition_refinement(cond, truthy: then_truthy)
+      process_node(then_branch, apply_cursor_bounds: apply_cursor_bounds)
+      then_state = current_state
+
+      restore_state(base_state)
+      process_node(cond, apply_cursor_bounds: false)
+      apply_condition_refinement(cond, truthy: else_truthy)
+      process_node(else_branch, apply_cursor_bounds: apply_cursor_bounds)
+      else_state = current_state
+
+      restore_state(base_state)
+      @local_types = merge_branch_types(base_state[0], then_state[0], else_state[0])
+      @instance_var_types = merge_branch_types(base_state[1], then_state[1], else_state[1])
+      @class_var_types = merge_branch_types(base_state[2], then_state[2], else_state[2])
+    end
+
+    # A subject-based `case expr when TypeA, TypeB` narrows the subject
+    # to the when-types inside each branch (`case node when Crystal::Def`
+    # types `node` as `Crystal::Def` in the branch body), mirroring the
+    # if/unless branch merge for the remaining locals.
+    private def process_case(node : Crystal::Case, *, apply_cursor_bounds : Bool)
+      subject = node.cond
+      # `case target = node.target` executes the subject assignment once
+      # before any branch: record it so the when-branch narrowing has
+      # base types to intersect (and the merged state keeps the local).
+      process_node(subject, apply_cursor_bounds: false) if subject.is_a?(Crystal::Assign)
+      base_state = current_state
+
+      # When the cursor sits inside one branch, keep that branch's
+      # narrowed state (like process_if does for the taken branch):
+      # the merge below is only for statements after the case.
+      if apply_cursor_bounds
+        node.whens.each do |when_node|
+          if contains_cursor?(when_node.body)
+            restore_state(base_state)
+            if subject
+              if narrowed = narrow_case_subject(subject, when_node)
+                apply_case_subject_narrowing(subject, narrowed)
+              end
+            end
+            process_node(when_node.body, apply_cursor_bounds: true)
+            return
+          end
+        end
+        if else_branch = node.else
+          if contains_cursor?(else_branch)
+            restore_state(base_state)
+            process_node(else_branch, apply_cursor_bounds: true)
+            return
+          end
+        end
+      end
+
+      branch_states = [] of typeof(current_state)
+      node.whens.each do |when_node|
+        restore_state(base_state)
+        if subject
+          if narrowed = narrow_case_subject(subject, when_node)
+            apply_case_subject_narrowing(subject, narrowed)
+          end
+        end
+        process_node(when_node.body, apply_cursor_bounds: apply_cursor_bounds)
+        branch_states << current_state
+      end
+
+      if else_branch = node.else
+        restore_state(base_state)
+        # The else branch matches none of the when-types: the complement
+        # is not expressible from the index, so the subject keeps its
+        # pre-case types.
+        process_node(else_branch, apply_cursor_bounds: apply_cursor_bounds)
+        branch_states << current_state
+      end
+
+      restore_state(base_state)
+      merged_local = base_state[0]
+      merged_ivar = base_state[1]
+      merged_cvar = base_state[2]
+      branch_states.each do |branch_state|
+        merged_local = merge_branch_types(base_state[0], merged_local, branch_state[0])
+        merged_ivar = merge_branch_types(base_state[1], merged_ivar, branch_state[1])
+        merged_cvar = merge_branch_types(base_state[2], merged_cvar, branch_state[2])
+      end
+      @local_types = merged_local
+      @instance_var_types = merged_ivar
+      @class_var_types = merged_cvar
+    end
+
+    private def narrow_case_subject(subject : Crystal::ASTNode, when_node : Crystal::When) : Array(String)?
+      # `case target = node.target` assigns inside the subject: narrow the
+      # assigned local the same way a plain `case node` subject narrows.
+      subject = subject.target if subject.is_a?(Crystal::Assign)
+      return nil unless subject.is_a?(Crystal::Var)
+
+      current_types = @local_types[subject.name]?
+      return nil if current_types.nil? || current_types.empty?
+
+      when_types = [] of String
+      when_node.conds.each do |cond|
+        case cond
+        when Crystal::Path, Crystal::Generic
+          if resolved = @query.resolve_type_name(cond.to_s, namespace: @current_type_name)
+            when_types << resolved
+          end
+        end
+      end
+      return nil if when_types.empty?
+
+      # The subject's own types intersect first (`A | B` matched by
+      # `when A` narrows to `A`); when the when-type is a subtype of the
+      # subject (`ASTNode` matched by `when Def`), the branch simply
+      # adopts the when-type.
+      intersection = current_types & when_types
+      intersection.empty? ? when_types : intersection
+    end
+
+    private def apply_case_subject_narrowing(subject : Crystal::ASTNode, narrowed : Array(String))
+      # `case target = node.target` narrows the assigned local; a plain
+      # `case node` narrows the local variable itself.
+      var = subject.is_a?(Crystal::Assign) ? subject.target : subject
+      return unless var.is_a?(Crystal::Var)
+      @local_types[var.name] = narrowed
+    end
+
+    private def current_state
+      {@local_types.dup, @instance_var_types.dup, @class_var_types.dup}
+    end
+
+    private def restore_state(state)
+      @local_types = state[0].dup
+      @instance_var_types = state[1].dup
+      @class_var_types = state[2].dup
+    end
+
+    private def apply_condition_refinement(node : Crystal::ASTNode, *, truthy : Bool)
+      case node
+      when Crystal::Expressions
+        if expression = node.expressions.first?
+          apply_condition_refinement(expression, truthy: truthy)
+        end
+      when Crystal::Not
+        apply_condition_refinement(node.exp, truthy: !truthy)
+      when Crystal::And
+        if truthy
+          apply_condition_refinement(node.left, truthy: true)
+          apply_condition_refinement(node.right, truthy: true)
+        end
+      when Crystal::Or
+        if truthy
+          # `x.is_a?(A) || x.is_a?(B)` narrows x to A | B.
+          if (left_is_a = node.left.as?(Crystal::IsA)) && (right_is_a = node.right.as?(Crystal::IsA))
+            if left_is_a.obj.to_s == right_is_a.obj.to_s && left_is_a.obj.class == right_is_a.obj.class
+              target_types = [left_is_a, right_is_a].compact_map do |is_a_node|
+                TypeUtils.expand_type_names(is_a_node.const.to_s).map { |name|
+                  @query.resolve_type_name(name, namespace: @current_type_name) || name
+                }
+              end.flatten.uniq
+              set_reference_types(left_is_a.obj, target_types) unless target_types.empty?
+            end
+          end
+        else
+          apply_condition_refinement(node.left, truthy: false)
+          apply_condition_refinement(node.right, truthy: false)
+        end
+      when Crystal::IsA
+        refine_is_a(node, truthy: truthy)
+      when Crystal::Call
+        if node.name == "nil?" && node.args.empty?
+          refine_nil_check(node.obj, truthy: truthy)
+        end
+      when Crystal::Assign
+        refine_condition_assignment(node, truthy: truthy)
+      when Crystal::Var, Crystal::InstanceVar, Crystal::ClassVar
+        refine_truthiness(node, truthy: truthy)
+      end
+    end
+
+    private def refine_condition_assignment(node : Crystal::Assign, *, truthy : Bool)
+      type_names = infer_types(node.value)
+      return if type_names.empty?
+
+      refined_types = if truthy
+                        type_names.reject(&.==("Nil"))
+                      elsif type_names.includes?("Nil")
+                        ["Nil"]
+                      else
+                        type_names
+                      end
+      return if refined_types.empty?
+
+      set_reference_types(node.target, refined_types.map { |type_name|
+        @query.resolve_type_name(type_name, namespace: @current_type_name) || type_name
+      }.uniq)
+    end
+
+    private def refine_is_a(node : Crystal::IsA, *, truthy : Bool)
+      target_type_names = TypeUtils.expand_type_names(node.const.to_s).map { |name|
+        @query.resolve_type_name(name, namespace: @current_type_name) || name
+      }.uniq
+      return if target_type_names.empty?
+
+      if truthy
+        set_reference_types(node.obj, target_type_names)
+      else
+        remove_reference_types(node.obj, target_type_names)
+      end
+    end
+
+    private def refine_nil_check(node : Crystal::ASTNode?, *, truthy : Bool)
+      return unless node
+
+      if truthy
+        set_reference_types(node, ["Nil"])
+      else
+        remove_reference_types(node, ["Nil"])
+      end
+    end
+
+    private def refine_truthiness(node : Crystal::ASTNode, *, truthy : Bool)
+      if truthy
+        remove_reference_types(node, ["Nil"])
+      else
+        set_reference_types(node, ["Nil"])
+      end
+    end
+
+    private def reference_types(node : Crystal::ASTNode) : Array(String)?
+      case node
+      when Crystal::Expressions
+        # `(target = node.target).is_a?(Var)` — the parenthesized assign
+        # wraps the subject; look through to the assigned local.
+        node.expressions.first?.try { |expression| reference_types(expression) }
+      when Crystal::Assign
+        reference_types(node.target)
+      when Crystal::Var
+        node.name == "self" ? self_types[0] : @local_types[node.name]?
+      when Crystal::InstanceVar
+        @instance_var_types[node.name]?
+      when Crystal::ClassVar
+        @class_var_types[node.name]?
+      when Crystal::Self
+        self_types[0]
+      end
+    end
+
+    private def set_reference_types(node : Crystal::ASTNode, type_names : Array(String))
+      normalized = type_names.uniq
+      return if normalized.empty?
+
+      case node
+      when Crystal::Expressions
+        if expression = node.expressions.first?
+          set_reference_types(expression, normalized)
+        end
+      when Crystal::Assign
+        set_reference_types(node.target, normalized)
+      when Crystal::Var
+        @local_types[node.name] = normalized unless node.name == "self"
+      when Crystal::InstanceVar
+        @instance_var_types[node.name] = normalized
+      when Crystal::ClassVar
+        @class_var_types[node.name] = normalized
+      end
+    end
+
+    private def remove_reference_types(node : Crystal::ASTNode, excluded_type_names : Array(String))
+      current_types = reference_types(node)
+      return unless current_types
+
+      remaining_types = current_types.reject { |type_name| excluded_type_names.includes?(type_name) }
+      return if remaining_types == current_types
+
+      if remaining_types.empty?
+        remaining_types = excluded_type_names.includes?("Nil") ? current_types.reject(&.==("Nil")) : current_types
+      end
+
+      set_reference_types(node, remaining_types)
+    end
+
+    private def merge_branch_types(base : Hash(String, Array(String)), left : Hash(String, Array(String)), right : Hash(String, Array(String)))
+      merged = {} of String => Array(String)
+
+      (base.keys | left.keys | right.keys).each do |name|
+        candidates = [] of String
+        candidates.concat(left[name]? || base[name]? || [] of String)
+        candidates.concat(right[name]? || base[name]? || [] of String)
+        merged[name] = candidates.uniq unless candidates.empty?
+      end
+
+      merged
+    end
+
+    private def seed_arg_types(definition : Crystal::Def, ast : Crystal::ASTNode)
+      definition.args.each do |arg|
+        seed_arg_restriction(arg)
+      end
+      # The block param (`&block : -> T`) is not part of `args`: seed it
+      # separately so `block.call`-style receivers resolve.
+      definition.block_arg.try { |arg| seed_arg_restriction(arg) }
+
+      # Untyped args with default values (`accumulator = [] of T`): the
+      # default names the type when no call site provides a value.
+      # Caller-derived types overwrite these below.
+      definition.args.each do |arg|
+        next unless arg.restriction.nil? && (default = arg.default_value)
+        default_types = infer_types(default)
+        @local_types[arg.name] = default_types unless default_types.empty?
+      end
+
+      untyped = definition.args.select { |arg| arg.restriction.nil? && !arg.name.empty? }
+      return if untyped.empty?
+
+      # The call-site scan is cursor-independent: a def seeded once on
+      # this buffer is seeded for every later request (hover after hover,
+      # completion after completion) — reuse the cached result instead of
+      # re-walking every caller.
+      if cache_key = definition.location.try(&.to_s)
+        if cached = @query.cached_untyped_arg_types(cache_key)
+          cached.each { |name, types| @local_types[name] = types }
+          return
+        end
+      end
+
+      # Untyped args (`def recalculate_dependencies(server, project)`):
+      # infer their types from call sites in this file, falling back to
+      # other defs that declare the same argument name with a restriction.
+      arg_types = {} of String => Array(String)
+      collect_call_site_arg_types(ast, definition, untyped, arg_types)
+      collect_pending_call_site_types(definition, untyped, arg_types)
+      collect_same_name_arg_types(ast, untyped, arg_types) if arg_types.empty?
+      @query.cache_untyped_arg_types(cache_key, arg_types) if cache_key
+
+      untyped.each do |arg|
+        next unless types = arg_types[arg.name]?
+        @local_types[arg.name] = types.uniq
+      end
+    end
+
+    private def seed_arg_restriction(arg : Crystal::Arg)
+      return unless restriction = arg.restriction
+      restriction_text = restriction.to_s
+      if restriction.is_a?(Crystal::ProcNotation)
+        # `&block : -> T` — a Proc-typed block param: render it in the
+        # indexed `Proc(...)` form (the declaration text `-> T` is not
+        # a type name) so generic fallback resolves it.
+        parts = (restriction.inputs || [] of Crystal::ASTNode).map(&.to_s) + [restriction.output.to_s]
+        restriction_text = "Proc(#{parts.join(", ")})"
+      end
+      resolved = resolve_type_names(restriction_text)
+      if resolved.empty? && restriction.is_a?(Crystal::ProcNotation)
+        # `-> T` with a free type var renders `Proc(T)`, which does not
+        # resolve: fall back to the generic `Proc` so `block.call`-style
+        # receivers still find the indexed `Proc#call`.
+        resolved = resolve_type_names("Proc")
+      end
+      @local_types[arg.name] = resolved
+    end
+
+    private def collect_call_site_arg_types(node : Crystal::ASTNode, definition : Crystal::Def, untyped : Array(Crystal::Arg), types : Hash(String, Array(String)), enclosing_def : Crystal::Def? = nil)
+      case node
+      when Crystal::Call
+        if node.name == definition.name
+          untyped.each do |arg|
+            # Match the untyped argument by NAME: a call may pass it
+            # positionally (`foo(x)`) or as a named argument
+            # (`process_node(node, apply_cursor_bounds: true)`). Matching
+            # by position alone would type the WRONG value whenever the
+            # call omits or reorders arguments.
+            value = call_arg_value(node, definition, arg)
+            next unless value
+            if caller = enclosing_def
+              if caller == definition
+                inferred = infer_types(value)
+              elsif literal_value?(value)
+                # A literal's type does not depend on the caller's
+                # locals: no caller walk needed.
+                inferred = infer_types(value)
+              else
+                # The value's type depends on the caller's locals: defer
+                # to one bounded walk of the caller per call site (see
+                # collect_pending_call_site_types), not a full caller
+                # body walk per site.
+                pending_sites = (@pending_call_sites ||= {} of Crystal::Def => Array(Crystal::Call))
+                (pending_sites[caller] ||= [] of Crystal::Call) << node
+                next
+              end
+            else
+              inferred = infer_types(value)
+            end
+            next if inferred.empty?
+            types[arg.name] = (types[arg.name]? || [] of String) + inferred
+          end
+        end
+        if (obj = node.obj)
+          collect_call_site_arg_types(obj, definition, untyped, types, enclosing_def)
+        end
+        node.args.each { |arg| collect_call_site_arg_types(arg, definition, untyped, types, enclosing_def) }
+        node.block.try { |block| collect_call_site_arg_types(block, definition, untyped, types, enclosing_def) }
+      when Crystal::Expressions
+        node.expressions.each { |exp| collect_call_site_arg_types(exp, definition, untyped, types, enclosing_def) }
+      when Crystal::Def
+        collect_call_site_arg_types(node.body, definition, untyped, types, node)
+      when Crystal::ClassDef, Crystal::ModuleDef
+        collect_call_site_arg_types(node.body, definition, untyped, types, enclosing_def)
+      when Crystal::VisibilityModifier
+        collect_call_site_arg_types(node.exp, definition, untyped, types, enclosing_def)
+      when Crystal::If, Crystal::Unless
+        collect_call_site_arg_types(node.cond, definition, untyped, types, enclosing_def)
+        collect_call_site_arg_types(node.then, definition, untyped, types, enclosing_def)
+        node.else.try { |e| collect_call_site_arg_types(e, definition, untyped, types, enclosing_def) }
+      when Crystal::While, Crystal::Until
+        collect_call_site_arg_types(node.cond, definition, untyped, types, enclosing_def)
+        collect_call_site_arg_types(node.body, definition, untyped, types, enclosing_def)
+      when Crystal::Case
+        node.cond.try { |cond| collect_call_site_arg_types(cond, definition, untyped, types, enclosing_def) }
+        node.whens.each { |w| collect_call_site_arg_types(w, definition, untyped, types, enclosing_def) }
+        node.else.try { |e| collect_call_site_arg_types(e, definition, untyped, types, enclosing_def) }
+      when Crystal::ExceptionHandler
+        node.body.try { |body| collect_call_site_arg_types(body, definition, untyped, types, enclosing_def) }
+        node.rescues.try { |rescues| rescues.each { |r| collect_call_site_arg_types(r, definition, untyped, types, enclosing_def) } }
+      when Crystal::Block
+        collect_call_site_arg_types(node.body, definition, untyped, types, enclosing_def)
+      when Crystal::Assign
+        collect_call_site_arg_types(node.value, definition, untyped, types, enclosing_def)
+      end
+    end
+
+    # The deferred call-site values (`@pending_call_sites`): one bounded
+    # walk of each caller def infers them all. The walk stops at the
+    # caller's deepest target call, and the hook in `process_node`
+    # records each call's values with the caller's state at that point.
+    private def collect_pending_call_site_types(definition : Crystal::Def, untyped : Array(Crystal::Arg), types : Hash(String, Array(String)))
+      pending = @pending_call_sites
+      return unless pending
+      pending.each do |caller, calls|
+        deepest = calls.max_by { |call| call.location.try(&.line_number) || 0 }
+        location = deepest.location
+        next unless location
+
+        saved_line = @line
+        saved_column = @column
+        saved_state = current_state
+        @line = location.line_number
+        @column = location.column_number
+        @pending_caller = caller
+        @pending_definition = definition
+        @pending_untyped = untyped
+        @pending_types = types
+        begin
+          process_node(caller.body, apply_cursor_bounds: true)
+        ensure
+          @pending_caller = nil
+          @pending_definition = nil
+          @pending_untyped = nil
+          @pending_types = nil
+          @line = saved_line
+          @column = saved_column
+          restore_state(saved_state)
+        end
+      end
+      @pending_call_sites = nil
+    end
+
+    # The value a call passes for *arg*: the named argument when the
+    # call passes it by name, else the positional argument at the arg's
+    # signature index (nil when the call omits it).
+    private def call_arg_value(call : Crystal::Call, definition : Crystal::Def, arg : Crystal::Arg) : Crystal::ASTNode?
+      if named = call.named_args.try(&.find { |named_arg| named_arg.name == arg.name })
+        named.value
+      elsif arg_index = definition.args.index(arg)
+        call.args[arg_index]?
+      end
+    end
+
+    # Infers one deferred call's untyped-arg values with the CURRENT
+    # state (the caller's locals at the call site during the pending
+    # walk).
+    private def collect_call_site_value_types(call : Crystal::Call, definition : Crystal::Def, untyped : Array(Crystal::Arg), types : Hash(String, Array(String)))
+      untyped.each do |arg|
+        value = call_arg_value(call, definition, arg)
+        next unless value
+        inferred = infer_types(value)
+        next if inferred.empty?
+        types[arg.name] = (types[arg.name]? || [] of String) + inferred
+      end
+    end
+
+    # Whether the value's type is independent of the caller's locals:
+    # literal nodes need no caller-context walk in the call-site scan.
+    private def literal_value?(node : Crystal::ASTNode) : Bool
+      node.is_a?(Crystal::BoolLiteral) || node.is_a?(Crystal::NumberLiteral) ||
+        node.is_a?(Crystal::StringLiteral) || node.is_a?(Crystal::CharLiteral) ||
+        node.is_a?(Crystal::SymbolLiteral) || node.is_a?(Crystal::NilLiteral)
+    end
+
+    private def collect_same_name_arg_types(node : Crystal::ASTNode, untyped : Array(Crystal::Arg), types : Hash(String, Array(String)))
+      case node
+      when Crystal::Def
+        node.args.each do |arg|
+          next unless untyped.any? { |u| u.name == arg.name }
+          next unless restriction = arg.restriction
+          types[arg.name] = (types[arg.name]? || [] of String) + resolve_type_names(restriction.to_s)
+        end
+        collect_same_name_arg_types(node.body, untyped, types)
+      when Crystal::Expressions
+        node.expressions.each { |exp| collect_same_name_arg_types(exp, untyped, types) }
+      when Crystal::ClassDef, Crystal::ModuleDef
+        collect_same_name_arg_types(node.body, untyped, types)
+      when Crystal::If, Crystal::Unless
+        collect_same_name_arg_types(node.cond, untyped, types)
+        collect_same_name_arg_types(node.then, untyped, types)
+        node.else.try { |e| collect_same_name_arg_types(e, untyped, types) }
+      when Crystal::Assign
+        # A same-name local in another def is a good hint too
+        # (`project = Project.best_fit_for_file(...)`).
+        if (target = node.target).is_a?(Crystal::Var) && untyped.any? { |u| u.name == target.name }
+          inferred = infer_types(node.value)
+          types[target.name] = (types[target.name]? || [] of String) + inferred unless inferred.empty?
+        end
+        collect_same_name_arg_types(node.value, untyped, types)
+      end
+    end
+
+    private def resolve_type_names(type_name : String, namespace : String? = @current_type_name) : Array(String)
+      TypeUtils.expand_type_names(type_name).map { |name|
+        resolve_type_name_deep(name, namespace)
+      }.uniq
+    end
+
+    private def seed_type_vars_from_summary
+      return unless type_name = @current_type_name
+
+      if class_method_context?
+        @class_var_types = merge_branch_types(@class_var_types, @class_var_types, query_class_var_types(type_name))
+      else
+        @instance_var_types = merge_branch_types(@instance_var_types, @instance_var_types, query_instance_var_types(type_name))
+        @class_var_types = merge_branch_types(@class_var_types, @class_var_types, query_class_var_types(type_name))
+      end
+    end
+
+    private def query_instance_var_types(type_name : String)
+      @query.instance_vars_for(type_name)
+    end
+
+    private def query_class_var_types(type_name : String)
+      @query.class_vars_for(type_name)
+    end
+
+    # Seeds ivar types from the enclosing type's indexed declarations
+    # (`@x : T` class-body lines and `@x = value` assignments), which the
+    # def-body walk never sees.
+    private def seed_indexed_ivar_types
+      type_name = @current_type_name
+      return unless type_name
+      return unless type = @query.find_type_info(type_name)
+
+      type.ivars.each do |name, type_names|
+        next if @instance_var_types.has_key?(name)
+        # Raw declarations carry unions (`URI?`, `URI | ::Nil`): expand and
+        # namespace-resolve them so receiver lookups see plain type names.
+        @instance_var_types[name] = type_names.flat_map { |type_name| resolve_type_names(TypeUtils.expand_type_names(type_name)) }.uniq
+      end
+      type.class_vars.each do |name, type_names|
+        next if @class_var_types.has_key?(name)
+        @class_var_types[name] = type_names.flat_map { |type_name| resolve_type_names(TypeUtils.expand_type_names(type_name)) }.uniq
+      end
+    end
+
+    private def process_initialize_defs(ast : Crystal::ASTNode)
+      type_body = @current_type_body
+      return unless type_body
+
+      each_direct_def(type_body) do |definition|
+        next unless definition.name == "initialize"
+        next if definition.receiver
+
+        saved_local_types = @local_types.dup
+        begin
+          @local_types.clear
+          seed_arg_types(definition, ast)
+          process_node(definition.body, apply_cursor_bounds: false)
+        ensure
+          @local_types = saved_local_types
+        end
+      end
+    end
+
+    private def each_direct_def(node : Crystal::ASTNode, & : Crystal::Def ->)
+      case node
+      when Crystal::Expressions
+        node.expressions.each do |expression|
+          yield expression if expression.is_a?(Crystal::Def)
+        end
+      when Crystal::Def
+        yield node
+      end
+    end
+
+    private def qualify_type_name(name : String, parent_type_name : String?) : String
+      return name if name.includes?("::") || parent_type_name.nil?
+      "#{parent_type_name}::#{name}"
+    end
+
+    private def contains_cursor?(node : Crystal::ASTNode)
+      # A named argument's location covers its name only (`args: expr`):
+      # the value's span decides containment.
+      if node.is_a?(Crystal::Arg)
+        if value = node.default_value
+          return contains_cursor?(value)
+        end
+      elsif node.is_a?(Crystal::NamedArgument)
+        return contains_cursor?(node.value)
+      end
+
+      start_loc = node.location
+      end_loc = node.end_location || start_loc
+      return false unless start_loc && end_loc
+
+      compare_position(start_loc.line_number, start_loc.column_number, @line, @column) <= 0 &&
+        compare_position(end_loc.line_number, end_loc.column_number, @line, @column) >= 0
+    end
+
+    # `&.map { ... }` chains parse as a call whose block has no end
+    # location (the nested call carries it): fall back to the block's
+    # body so cursor containment still descends into the chain.
+    private def block_contains_cursor?(block : Crystal::Block)
+      contains_cursor?(block) || contains_cursor?(block.body)
+    end
+
+    private def before_cursor?(node : Crystal::ASTNode)
+      end_loc = node.end_location || node.location
+      return false unless end_loc
+
+      compare_position(end_loc.line_number, end_loc.column_number, @line, @column) < 0
+    end
+
+    private def starts_before_or_at_cursor?(node : Crystal::ASTNode)
+      start_loc = node.location
+      return false unless start_loc
+
+      compare_position(start_loc.line_number, start_loc.column_number, @line, @column) <= 0
+    end
+
+    private def compare_position(line_a : Int32, col_a : Int32, line_b : Int32, col_b : Int32)
+      return line_a <=> line_b unless line_a == line_b
+      col_a <=> col_b
+    end
+  end
+end

--- a/src/crystalline/lightweight/prelude_index.cr
+++ b/src/crystalline/lightweight/prelude_index.cr
@@ -1,0 +1,331 @@
+require "./index"
+
+module Crystalline::Lightweight
+  # A disk-cached index of the standard library prelude, so that lightweight
+  # queries over a single file (before the project's top-level pass finishes)
+  # can still resolve stdlib receivers like `String` or `Array`.
+  #
+  # The index is generated once per Crystal version by compiling a trivial
+  # program with top-level semantics, and cached under the user's cache
+  # directory in a compact binary format. Loading the cache takes a few
+  # milliseconds; generating it takes a few seconds and happens in the
+  # background.
+  module PreludeIndex
+    @@mutex = Mutex.new
+    @@index : Index? = nil
+    @@loading = false
+
+    MAGIC          = "CPLI"
+    FORMAT_VERSION = 9_u8
+
+    # Returns the prelude index, or nil while it is being generated on the
+    # first run. Never blocks.
+    def self.get : Index?
+      @@mutex.synchronize { @@index }
+    end
+
+    # Loads the cached index, or generates it in the background. Safe to call
+    # from the startup path.
+    def self.ensure_loaded
+      @@mutex.synchronize do
+        return if @@loading
+        @@loading = true
+      end
+
+      spawn do
+        begin
+          if index = load_from_cache
+            @@mutex.synchronize { @@index = index }
+            LSP::Log.info { "[prelude] loaded #{index.types.size} types from cache" }
+          else
+            LSP::Log.info { "[prelude] generating prelude index (first run)..." }
+            if index = generate
+              save_to_cache(index)
+              @@mutex.synchronize { @@index = index }
+              LSP::Log.info { "[prelude] generated and cached #{index.types.size} types" }
+            end
+          end
+        rescue ex
+          LSP::Log.warn(exception: ex) { "[prelude] failed: #{ex.message}" }
+        ensure
+          @@mutex.synchronize { @@loading = false }
+        end
+      end
+    end
+
+    private def self.cache_path : String
+      home = ENV["HOME"]?
+      cache_dir = ENV["XDG_CACHE_HOME"]? || (home ? File.join(home, ".cache") : Dir.tempdir)
+      dir = File.join(cache_dir, "crystalline")
+      Dir.mkdir_p(dir)
+      # The prelude content depends on the indexer itself, not just the
+      # Crystal version: key the cache by the LSP's own version so an
+      # upgraded build regenerates instead of reusing a stale prelude.
+      key = {% if Crystalline.has_constant?(:VERSION) %}
+              "#{Crystal::VERSION}-#{Crystalline::VERSION}"
+            {% else %}
+              Crystal::VERSION
+            {% end %}
+      File.join(dir, "prelude_index-#{key}.bin")
+    end
+
+    private def self.load_from_cache(path : String = cache_path) : Index?
+      return unless File.exists?(path)
+
+      io = IO::Memory.new(File.read(path))
+      return unless io.read_string(4) == MAGIC
+      return unless io.read_bytes(UInt8) == FORMAT_VERSION
+
+      index = Index.new
+      type_count = io.read_bytes(UInt32)
+      type_count.times do
+        name = read_string(io)
+        kind = TypeKind.from_value(io.read_bytes(UInt8))
+        # Type locations let go-to-definition jump into the stdlib.
+        location = read_optional_location(io)
+        name_location = read_optional_location(io)
+        type = TypeInfo.new(name, kind, nil, location, name_location)
+        method_count = io.read_bytes(UInt32)
+        method_count.times do
+          method_name = read_string(io)
+          return_type = read_optional_string(io)
+          class_method = io.read_bytes(UInt8) == 1
+          is_macro = io.read_bytes(UInt8) == 1
+          args = [] of ArgInfo
+          arg_count = io.read_bytes(UInt8)
+          arg_count.times do
+            arg_name = read_string(io)
+            restriction = read_optional_string(io)
+            args << ArgInfo.new(name: arg_name, restriction: restriction)
+          end
+          type.methods << MethodInfo.new(
+            name: method_name,
+            owner: name,
+            args: args,
+            return_type: return_type,
+            class_method: class_method,
+            macro: is_macro,
+            free_vars: read_string_list(io),
+            block_restriction: read_optional_string(io),
+            # Method locations let go-to-definition jump into the stdlib.
+            location: read_optional_location(io),
+          )
+        end
+        parent_count = io.read_bytes(UInt32)
+        parent_count.times { type.parent_types << read_string(io) }
+        delegate_count = io.read_bytes(UInt32)
+        delegate_count.times do
+          delegate_name = read_string(io)
+          type.delegates[delegate_name] = read_string(io)
+        end
+        if target = read_optional_string(io)
+          type.forward_missing_to = target
+        end
+        index.types[name] = type
+      end
+
+      top_level_count = io.read_bytes(UInt32)
+      top_level_count.times do
+        method_name = read_string(io)
+        return_type = read_optional_string(io)
+        class_method = io.read_bytes(UInt8) == 1
+        args = [] of ArgInfo
+        arg_count = io.read_bytes(UInt8)
+        arg_count.times do
+          arg_name = read_string(io)
+          restriction = read_optional_string(io)
+          args << ArgInfo.new(name: arg_name, restriction: restriction)
+        end
+        index.top_level_methods << MethodInfo.new(
+          name: method_name,
+          owner: "::",
+          args: args,
+          return_type: return_type,
+          class_method: class_method,
+          free_vars: read_string_list(io),
+          block_restriction: read_optional_string(io),
+          location: read_optional_location(io),
+        )
+      end
+
+      index
+    rescue ex
+      LSP::Log.warn(exception: ex) { "[prelude] cache load failed: #{ex.message}" }
+      nil
+    end
+
+    private def self.save_to_cache(index : Index, path : String = cache_path)
+      io = IO::Memory.new
+      io << MAGIC
+      io.write_bytes(FORMAT_VERSION)
+      io.write_bytes(index.types.size.to_u32)
+
+      index.types.each_value do |type|
+        write_string(io, type.name)
+        io.write_bytes(type.kind.value.to_u8)
+        # Type locations let go-to-definition jump into the stdlib.
+        write_optional_location(io, type.location)
+        write_optional_location(io, type.name_location)
+        io.write_bytes(type.methods.size.to_u32)
+        type.methods.each do |method|
+          write_string(io, method.name)
+          write_optional_string(io, method.return_type)
+          io.write_bytes(method.class_method ? 1_u8 : 0_u8)
+          io.write_bytes(method.macro ? 1_u8 : 0_u8)
+          io.write_bytes(method.args.size.to_u8)
+          method.args.each do |arg|
+            write_string(io, arg.name)
+            write_optional_string(io, arg.restriction)
+          end
+          write_string_list(io, method.free_vars)
+          write_optional_string(io, method.block_restriction)
+          write_optional_location(io, method.location)
+        end
+        io.write_bytes(type.parent_types.size.to_u32)
+        type.parent_types.each { |parent_name| write_string(io, parent_name) }
+        io.write_bytes(type.delegates.size.to_u32)
+        type.delegates.each do |delegate_name, target|
+          write_string(io, delegate_name)
+          write_string(io, target)
+        end
+        write_optional_string(io, type.forward_missing_to)
+      end
+
+      io.write_bytes(index.top_level_methods.size.to_u32)
+      index.top_level_methods.each do |method|
+        write_string(io, method.name)
+        write_optional_string(io, method.return_type)
+        io.write_bytes(method.class_method ? 1_u8 : 0_u8)
+        io.write_bytes(method.args.size.to_u8)
+        method.args.each do |arg|
+          write_string(io, arg.name)
+          write_optional_string(io, arg.restriction)
+        end
+        write_string_list(io, method.free_vars)
+        write_optional_string(io, method.block_restriction)
+        write_optional_location(io, method.location)
+      end
+
+      temp_path = "#{path}.tmp"
+      File.write(temp_path, io.to_s)
+      File.rename(temp_path, path)
+    rescue ex
+      LSP::Log.warn(exception: ex) { "[prelude] cache save failed: #{ex.message}" }
+    end
+
+    private def self.read_string(io : IO::Memory) : String
+      length = io.read_bytes(UInt16)
+      io.read_string(length)
+    end
+
+    private def self.read_optional_string(io : IO::Memory) : String?
+      present = io.read_bytes(UInt8) == 1
+      present ? read_string(io) : nil
+    end
+
+    # A source location (filename, line, column), or nothing when the
+    # def carries none (macro-generated methods without a source span).
+    private def self.read_optional_location(io : IO::Memory) : Crystal::Location?
+      present = io.read_bytes(UInt8) == 1
+      return unless present
+      filename = read_string(io)
+      line = io.read_bytes(UInt32).to_i32
+      column = io.read_bytes(UInt32).to_i32
+      Crystal::Location.new(filename, line, column)
+    end
+
+    private def self.read_string_list(io : IO::Memory) : Array(String)
+      count = io.read_bytes(UInt8)
+      Array.new(count) { read_string(io) }
+    end
+
+    private def self.write_string(io : IO::Memory, string : String)
+      io.write_bytes(string.size.to_u16)
+      io << string
+    end
+
+    private def self.write_optional_string(io : IO::Memory, string : String?)
+      if string
+        io.write_bytes(1_u8)
+        write_string(io, string)
+      else
+        io.write_bytes(0_u8)
+      end
+    end
+
+    private def self.write_optional_location(io : IO::Memory, location : Crystal::Location?)
+      if location && (filename = location.original_filename)
+        io.write_bytes(1_u8)
+        write_string(io, filename)
+        io.write_bytes(location.line_number.to_u32)
+        io.write_bytes(location.column_number.to_u32)
+      else
+        io.write_bytes(0_u8)
+      end
+    end
+
+    private def self.write_string_list(io : IO::Memory, strings : Array(String))
+      io.write_bytes(strings.size.to_u8)
+      strings.each { |string| write_string(io, string) }
+    end
+
+    # Compiles a trivial program with top-level semantics: the resulting
+    # program contains the full stdlib prelude without any project code.
+    # The Crystal compiler's own types (`Crystal::ASTNode`,
+    # `Crystal::Compiler::Result`, ...) are not part of that prelude, so the
+    # distribution's compiler sources are parsed and merged in too: projects
+    # built on the compiler (like this LSP itself) would otherwise have no
+    # lightweight info for those receivers until the first compile.
+    def self.generate : Index?
+      path = File.join(Dir.tempdir, "crystalline-prelude-#{Random::Secure.hex(8)}.cr")
+      File.write(path, "puts \"hello\"\n")
+      Crystalline::EnvironmentConfig.run
+      server = LSP::Server.new(IO::Memory.new, IO::Memory.new)
+      result = Crystalline::Analysis.compile(
+        server,
+        URI.parse("file://#{path}"),
+        top_level: true,
+        ignore_diagnostics: true,
+      )
+      index = result.try { |r| Index.from_program(r.program) }
+      return unless index
+
+      compiler_indexes = [] of Index
+      Crystal::CrystalPath.default_path_without_lib.split(Process::PATH_DELIMITER).each do |path_entry|
+        # The distribution's stdlib and compiler sources: parsing them (in
+        # addition to the compiled snapshot) covers types the trivial
+        # program never instantiates (`URI`, `Set`, `Channel`, ...) with
+        # their full method lists.
+        Dir.glob(File.join(path_entry, "**", "*.cr")).sort.each do |file|
+          next if file.includes?("/compiler/")
+          if file_index = Index.from_source(File.read(file), file)
+            compiler_indexes << file_index
+          end
+        end
+
+        compiler_dir = File.join(path_entry, "compiler")
+        next unless Dir.exists?(compiler_dir)
+
+        Dir.glob(File.join(compiler_dir, "**", "*.cr")).sort.each do |file|
+          if file_index = Index.from_source(File.read(file), file)
+            compiler_indexes << file_index
+          end
+        end
+      end
+      index = Index.merge([index] + compiler_indexes) unless compiler_indexes.empty?
+
+      index
+    ensure
+      File.delete(path) if path && File.exists?(path)
+    end
+
+    # Test hooks: exercise the cache format with an explicit path.
+    def self.save_to_cache_for_test(index : Index, path : String)
+      save_to_cache(index, path)
+    end
+
+    def self.load_from_cache_for_test(path : String) : Index?
+      load_from_cache(path)
+    end
+  end
+end

--- a/src/crystalline/lightweight/query.cr
+++ b/src/crystalline/lightweight/query.cr
@@ -1,0 +1,831 @@
+require "./index"
+require "./contracts"
+require "./type_utils"
+require "./summary"
+
+module Crystalline::Lightweight
+  # Answers lookup queries over a project index, optionally overlaid with a
+  # per-file source index (a dirty buffer diverging from the compiled
+  # sources). The overlay is consulted first so redefinitions in the buffer
+  # win, without copying or merging the whole project index per keystroke.
+  class Query
+    # Compiler hierarchy roots whose own indexed methods lack the
+    # accessors defined on their subclasses: `Crystal::ASTNode` carries
+    # no `name`/`body`/`args` while `Var`/`Def`/`Block` do. Only these
+    # bases get the subtype-method fallback (see methods_named).
+    def self.subtype_fallback_type?(type_name : String) : Bool
+      case type_name
+      when "Crystal::ASTNode", "Crystal::Type", "Crystal::NamedType"
+        true
+      else
+        false
+      end
+    end
+
+    # Memoized lookups; queries are immutable after construction.
+    @methods_cache : Hash(String, Array(MethodInfo))? = nil
+    @contracts_cache : Hash(String, Array(MethodContract))? = nil
+    @all_type_names_cache : Array(String)? = nil
+    @subtype_methods_cache : Hash(String, Array(MethodInfo))? = nil
+    @subtypes_index : Hash(String, Array(String))? = nil
+    # The inference walker's untyped-arg seeding result per def (keyed by
+    # the def's source location): cursor-independent, so repeated
+    # requests on the same buffer skip the whole call-site scan.
+    @untyped_arg_types : Hash(String, Hash(String, Array(String)))? = nil
+
+    def initialize(@index : Index, @summary : Summary? = nil, @overlay : Index? = nil, @secondary : Index? = nil)
+    end
+
+    def cached_untyped_arg_types(key : String) : Hash(String, Array(String))?
+      @untyped_arg_types.try(&.[key]?)
+    end
+
+    def cache_untyped_arg_types(key : String, types : Hash(String, Array(String)))
+      (@untyped_arg_types ||= {} of String => Hash(String, Array(String)))[key] = types
+    end
+
+    def find_type(name : String) : TypeInfo?
+      overlay_type(name) || preferred_type(name) || generic_specialization_for(name).try(&.[0])
+    end
+
+    # The compiled-program index keys generic classes twice: the bare name
+    # carries only a few synthesized methods (`==`, `new`, `to_json`, ...)
+    # while the template (`Hash(K, V)`) carries the real defs. When both
+    # exist, prefer the template so `Hash#empty?`-style lookups resolve.
+    private def preferred_type(name : String) : TypeInfo?
+      exact = @index.types[name]? || @secondary.try(&.types[name]?)
+      return exact unless exact
+
+      candidate_name = generic_candidate_names(name).sort_by(&.size).first?
+      return exact unless candidate_name
+
+      candidate = @index.types[candidate_name]? || @secondary.try(&.types[candidate_name]?)
+      candidate && candidate.methods.size > exact.methods.size ? candidate : exact
+    end
+
+    # Finds a type by its bare name, falling back to the first generic
+    # specialization (`Dispatcher` → `Dispatcher(T)`), which is how the
+    # source index keys generic classes.
+    def find_type_info(name : String) : TypeInfo?
+      find_type(name) || begin
+        found = nil
+        # Try every candidate, not just the shortest: the summary's
+        # generic keys (`Proc(T)`) can shadow the real template
+        # (`Proc(*T, R)`) in an index, and the shadow may not resolve.
+        generic_candidate_names(name.split('(').first? || name).sort_by(&.size).each do |candidate|
+          if type = find_type(candidate)
+            found = type
+            break
+          end
+        end
+        found
+      end
+    end
+
+    def resolve_type_name(name : String, namespace : String? = nil) : String?
+      normalized = name.strip
+      normalized = normalized.lchop("::")
+
+      # Lexical resolution: a name defined in the enclosing namespace
+      # shadows the top-level one (`Priority::Value` beats the stdlib's
+      # root `struct Value`), so try the qualified candidates before the
+      # bare-known fast path.
+      if namespace
+        namespace_candidates(namespace).each do |prefix|
+          candidate = "#{prefix}::#{normalized}"
+          return candidate if known_type_name?(candidate)
+        end
+      end
+
+      return normalized if known_type_name?(normalized)
+
+      suffix_matches = all_type_names.select do |candidate|
+        candidate == normalized || candidate.ends_with?("::#{normalized}")
+      end
+      if suffix_matches.size == 1
+        suffix_matches.first
+      elsif suffix_matches.size > 1 && namespace
+        # Ambiguous bare name (`Location` is both `Crystal::Location` and
+        # `Time::Location`): prefer the candidate sharing the longest
+        # namespace prefix with the enclosing type, the way the compiler's
+        # lexical resolution would pick the closest definition.
+        best = suffix_matches.first
+        best_score = common_prefix_length(best, namespace.not_nil!)
+        suffix_matches.each do |candidate|
+          score = common_prefix_length(candidate, namespace.not_nil!)
+          if score > best_score
+            best = candidate
+            best_score = score
+          end
+        end
+        common_prefix_length(best, namespace) > 0 ? best : nil
+      elsif suffix_matches.empty? && !normalized.includes?('(')
+        # A bare generic name (`Channel`) resolves to its first
+        # specialization (`Channel(T)`), like the index keys it.
+        generic_candidate_names(normalized).sort_by(&.size).first?
+      end
+    end
+
+    private def common_prefix_length(name_a : String, name_b : String) : Int32
+      index = 0
+      while index < name_a.size && index < name_b.size && name_a[index] == name_b[index]
+        index += 1
+      end
+      index
+    end
+
+    def methods_for(type_name : String, *, class_method = false, include_macros = false) : Array(MethodInfo)
+      # Queries are immutable after construction: memoize the hierarchy walk
+      # so repeated lookups for the same type in one request are free.
+      cache_key = "#{type_name}:#{class_method}:#{include_macros}"
+      if cached = (@methods_cache ||= {} of String => Array(MethodInfo))[cache_key]?
+        return cached
+      end
+
+      methods = methods_for(type_name, class_method: class_method, include_macros: include_macros, visited: Set(String).new)
+      if methods.empty?
+        if !type_name.includes?('(')
+          # The source index keys generic classes as `Dispatcher(T)`: a bare
+          # `Dispatcher` lookup falls back to the first specialization so
+          # self-calls, getters and hovers resolve on generic types too.
+          generic_candidate_names(type_name).sort_by(&.size).each do |candidate|
+            methods = methods_for(candidate, class_method: class_method, include_macros: include_macros, visited: Set(String).new)
+            break unless methods.empty?
+          end
+        end
+        if methods.empty? && (base_name = type_name.split('(').first?) && base_name != type_name
+          # A specialization like `Proc(String, URI, String)` (e.g. the
+          # target of an alias) resolves through the generic template
+          # `Proc(*T, R)`.
+          methods = methods_for(base_name, class_method: class_method, include_macros: include_macros, visited: Set(String).new)
+        end
+      end
+      # The compiled index records macro-generated defs (delegate
+      # passthroughs like `def shift(*args, **kwargs)`) with no declared
+      # return type; the semantic summary captured the compiler-inferred
+      # returns per instantiation. Fill the nil returns so chains through
+      # delegated methods keep resolving post-compile.
+      methods = fill_summary_returns(methods, type_name)
+      @methods_cache.not_nil![cache_key] = methods
+      methods
+    end
+
+    # Replaces nil method returns with the summary's compiler-inferred
+    # returns for the same name and arity (the summary is keyed per
+    # instantiation, so its returns are already concrete — no free-var
+    # substitution; the arity guard keeps overloads distinct).
+    private def fill_summary_returns(methods : Array(MethodInfo), type_name : String) : Array(MethodInfo)
+      return methods unless @summary
+      summary_methods = summary_types_for(type_name).flat_map(&.methods)
+      if summary_methods.empty? && type_name.includes?("(::")
+        # Compiled returns render generic args `::`-prefixed
+        # (`Priority::Item(::Tuple(...))`) while the summary keys them
+        # plain: retry with the normalized name.
+        summary_methods = summary_types_for(type_name.gsub("(::", "(")).flat_map(&.methods)
+      end
+      return methods if summary_methods.empty?
+      summary_returns = {} of String => String
+      summary_methods.each do |sm|
+        next unless return_type = sm.return_type
+        key = "#{sm.name}:#{sm.class_method}:#{sm.args.size}"
+        summary_returns[key] = return_type unless summary_returns.has_key?(key)
+      end
+      methods.map do |method|
+        next method unless method.return_type.nil?
+        key = "#{method.name}:#{method.class_method}:#{method.args.size}"
+        if return_type = summary_returns[key]?
+          method.copy_with(return_type: return_type)
+        else
+          method
+        end
+      end
+    end
+
+    def subtypes_for(type_name : String) : Array(String)
+      subtypes = [] of String
+      if type = overlay_type(type_name)
+        subtypes.concat(type.subtypes)
+      end
+      if type = @index.types[type_name]?
+        subtypes.concat(type.subtypes)
+      elsif secondary = @secondary.try(&.types[type_name]?)
+        subtypes.concat(secondary.subtypes)
+      end
+      subtypes.uniq
+    end
+
+    # The BFS distance from *from* to every reachable type in the
+    # recorded parent graph (0 = the type itself, 1 = a direct parent or
+    # included module, ...). Completion ranks methods by their owner's
+    # distance — computed once per receiver type per request instead of
+    # once per method (per-method BFSes with a find_type_info miss scan
+    # made completion O(methods × type-key scan)).
+    def type_hierarchy_depths(from : String) : Hash(String, Int32)
+      depths = {from => 0}
+      queue = [from]
+      until queue.empty?
+        current = queue.shift
+        depth = depths[current]
+        type = find_type_info(current)
+        next unless type
+        type.parent_types.each do |parent|
+          next if depths.has_key?(parent)
+          depths[parent] = depth + 1
+          queue << parent
+        end
+      end
+      depths
+    end
+
+    def top_level_methods : Array(MethodInfo)
+      methods = @index.top_level_methods.dup
+      if secondary_methods = @secondary.try(&.top_level_methods)
+        secondary_methods.each do |method|
+          next if methods.any? { |existing| Index.same_method?(existing, method) }
+          methods << method
+        end
+      end
+      if overlay_methods = @overlay.try(&.top_level_methods)
+        overlay_methods.each do |method|
+          next if methods.any? { |existing| Index.same_method?(existing, method) }
+          methods << method
+        end
+      end
+      methods
+    end
+
+    def all_types : Array(TypeInfo)
+      types = @index.types.values.to_a
+      [@overlay, @secondary].each do |extra|
+        next unless extra
+        extra.types.each do |name, type|
+          next if types.any? { |existing| existing.name == name }
+          types << type
+        end
+      end
+      types
+    end
+
+    def method_contracts_for(type_name : String, method_name : String, *, class_method = false) : Array(MethodContract)
+      # A union receiver (`first?` → `Greeter | Nil`) has no entry of its
+      # own: the contracts are the union of each member's. Only top-level
+      # separators split (`Array(A | B)` keeps its nested union intact),
+      # and the recursion only fires when the split actually happened.
+      if type_name.includes?(" | ")
+        top_parts = TypeUtils.split_top_level(type_name, '|')
+        if top_parts.size > 1
+          return top_parts.flat_map { |part| method_contracts_for(part, method_name, class_method: class_method) }.uniq
+        end
+      end
+
+      cache_key = "#{type_name}:#{method_name}:#{class_method}"
+      if cached = (@contracts_cache ||= {} of String => Array(MethodContract))[cache_key]?
+        return cached
+      end
+
+      contracts = [] of MethodContract
+      summary_types_for(type_name).each do |summary_type|
+        summary_type.method_contracts[method_name]?.try(&.each do |contract|
+          next unless contract.class_method == class_method
+          contracts << contract unless contracts.includes?(contract)
+        end)
+      end
+
+      methods_for(type_name, class_method: class_method).select(&.name.==(method_name)).each do |method|
+        Contracts.derive(type_name, method).each do |contract|
+          contracts << contract unless contracts.includes?(contract)
+        end
+
+        # A compiled concrete def may have lost its block restriction
+        # (the compiler drops it after typing): derive from the generic
+        # declaration (`Hash(K, V)` for `Hash(String, Greeter)`).
+        if method.block_restriction.nil?
+          if specialization = generic_specialization_for(type_name)
+            generic_type, mapping = specialization
+            generic_method = generic_type.methods.find do |candidate|
+              candidate.name == method.name && candidate.class_method == method.class_method
+            end
+            if generic_method
+              Contracts.derive(type_name, specialize_method(generic_method, owner_name: type_name, mapping: mapping)).each do |contract|
+                contracts << contract unless contracts.includes?(contract)
+              end
+            end
+          end
+        end
+      end
+
+      @contracts_cache.not_nil![cache_key] = contracts
+      contracts
+    end
+
+    def instance_var_types_for(type_name : String, var_name : String) : Array(String)
+      summary_types_for(type_name).each do |summary_type|
+        if types = summary_type.instance_vars[var_name]?
+          return types
+        end
+      end
+      [] of String
+    end
+
+    def class_var_types_for(type_name : String, var_name : String) : Array(String)
+      summary_types_for(type_name).each do |summary_type|
+        if types = summary_type.class_vars[var_name]?
+          return types
+        end
+      end
+      [] of String
+    end
+
+    def instance_vars_for(type_name : String) : Hash(String, Array(String))
+      summary_types_for(type_name).each do |summary_type|
+        return normalize_ivar_keys(summary_type.instance_vars, class_var: false) if summary_type.instance_vars.any?
+      end
+
+      ivars = (overlay_type(type_name) || @index.types[type_name]? || @secondary.try(&.types[type_name]?)).try(&.ivars)
+      return {} of String => Array(String) unless ivars
+
+      # Parsed types are best-effort (`Mutex` for `Mutex.new`): resolve them
+      # against the merged index so they match what methods_for expects.
+      ivars.transform_values { |types| types.map { |t| resolve_type_name(t, namespace: type_name) || t }.uniq }
+    end
+
+    def class_vars_for(type_name : String) : Hash(String, Array(String))
+      summary_types_for(type_name).each do |summary_type|
+        return normalize_ivar_keys(summary_type.class_vars, class_var: true) if summary_type.class_vars.any?
+      end
+
+      class_vars = (overlay_type(type_name) || @index.types[type_name]? || @secondary.try(&.types[type_name]?)).try(&.class_vars)
+      return {} of String => Array(String) unless class_vars
+
+      class_vars.transform_values { |types| types.map { |t| resolve_type_name(t, namespace: type_name) || t }.uniq }
+    end
+
+    # The compiled program keys ivars without the `@` prefix; the inference
+    # looks them up with it. Normalize so both sources line up.
+    private def normalize_ivar_keys(vars : Hash(String, Array(String)), *, class_var : Bool) : Hash(String, Array(String))
+      vars.transform_keys { |key| key.starts_with?("@") ? key : (class_var ? "@@#{key}" : "@#{key}") }.transform_values(&.dup)
+    end
+
+    private def known_type_name?(name : String) : Bool
+      find_type(name) != nil
+    end
+
+    private def all_type_names : Array(String)
+      @all_type_names_cache ||= begin
+        names = @index.types.keys
+        if secondary = @secondary
+          names += secondary.types.keys
+        end
+        if overlay = @overlay
+          names += overlay.types.keys
+        end
+        if summary = @summary
+          names += summary.types.keys
+        end
+        names.uniq
+      end
+    end
+
+    private def namespace_candidates(namespace : String) : Array(String)
+      parts = namespace.split("::")
+      candidates = [] of String
+      while parts.any?
+        candidates << parts.join("::")
+        parts.pop
+      end
+      candidates
+    end
+
+    private def summary_types_for(type_name : String) : Array(SummaryType)
+      types = [] of SummaryType
+      if summary_type = @summary.try(&.type(type_name))
+        types << summary_type
+      end
+
+      if specialization = generic_summary_specialization_for(type_name)
+        summary_type, _ = specialization
+        types << summary_type unless types.includes?(summary_type)
+      end
+
+      types
+    end
+
+    private def methods_for(type_name : String, *, class_method : Bool, include_macros : Bool, visited : Set(String)) : Array(MethodInfo)
+      visit_key = "#{type_name}:#{class_method}:#{include_macros}"
+      return [] of MethodInfo if visited.includes?(visit_key)
+      visited << visit_key
+
+      methods = [] of MethodInfo
+      parent_types = [] of String
+
+      if type = @index.types[type_name]?
+        methods.concat(select_methods(type.methods, type, class_method, include_macros))
+        parent_types.concat(type.parent_types)
+        merge_delegated_methods(type, methods, class_method, include_macros, visited, nil, type_name)
+      elsif specialization = generic_specialization_for(type_name)
+        generic_type, mapping = specialization
+        methods.concat(select_methods(generic_type.methods, generic_type, class_method, include_macros).map { |method|
+          specialize_method(method, owner_name: type_name, mapping: mapping)
+        })
+        parent_types.concat(generic_type.parent_types.map do |parent_type|
+          substitute_type_vars(parent_type, mapping).not_nil!
+        end)
+        merge_delegated_methods(generic_type, methods, class_method, include_macros, visited, mapping, type_name)
+      elsif type = find_type(type_name)
+        methods.concat(select_methods(type.methods, type, class_method, include_macros))
+        parent_types.concat(type.parent_types)
+      end
+
+      # A project type may shadow a stdlib type of the same name (e.g. the
+      # `class URI` extension in ext/uri.cr, which has no superclass):
+      # merge the secondary's methods and parents so the full stdlib
+      # surface stays available on the extended type.
+      if secondary_type = @secondary.try(&.types[type_name]?)
+        methods = merge_methods(methods, select_methods(secondary_type.methods, secondary_type, class_method, include_macros))
+        parent_types.concat(secondary_type.parent_types)
+      end
+
+      # A dirty-buffer overlay redefines methods of a type: a same-signature
+      # method wins when its location differs from the indexed one (the
+      # user edited the definition), otherwise the indexed method is kept.
+      if overlay_type = @overlay.try(&.types[type_name]?)
+        overlay_methods = select_methods(overlay_type.methods, overlay_type, class_method, include_macros)
+        overlay_methods.each do |method|
+          next unless method.class_method == class_method && (include_macros || !method.macro)
+
+          if existing_index = methods.index { |existing| Index.same_method?(existing, method) }
+            existing = methods[existing_index]
+            methods[existing_index] = method if existing.location != method.location
+          else
+            methods << method
+          end
+        end
+        parent_types.concat(overlay_type.parent_types)
+      end
+
+      parent_types.uniq!
+      parent_types.each do |parent_type|
+        resolved_parent = resolve_parent_name(parent_type, type_name)
+        # An alias to a union (`alias Value = Int8 | Int16 | ...`): split
+        # it so each member's inherited methods (`Number#to_i32`) resolve
+        # on the alias's receivers.
+        if resolved_parent.includes?(" | ")
+          union_parts = TypeUtils.split_top_level(resolved_parent, '|')
+          if union_parts.size > 1
+            union_parts.each do |part|
+              methods = merge_methods(methods, methods_for(part.strip, class_method: class_method, include_macros: include_macros, visited: visited))
+            end
+            next
+          end
+        end
+        methods = merge_methods(methods, methods_for(resolved_parent, class_method: class_method, include_macros: include_macros, visited: visited))
+      end
+
+      summary_types_for(type_name).each do |summary_type|
+        methods = merge_methods(methods, summary_type.methods.select(&.class_method.==(class_method)))
+      end
+      if methods.empty? && parent_types.empty?
+        if !type_name.includes?('(')
+          # The source index keys generic classes as `Dispatcher(T)`: a
+          # bare `Dispatcher` lookup falls back to the first
+          # specialization so self-calls, getters and hovers resolve on
+          # generic types too.
+          generic_candidate_names(type_name).sort_by(&.size).each do |candidate|
+            methods = methods_for(candidate, class_method: class_method, include_macros: include_macros, visited: visited)
+            break unless methods.empty?
+          end
+        end
+        if methods.empty? && (base_name = type_name.split('(').first?) && base_name != type_name
+          # A specialization like `Proc(String, URI, String)` (e.g. the
+          # target of an alias) resolves through the generic template
+          # `Proc(*T, R)`.
+          methods = methods_for(base_name, class_method: class_method, include_macros: include_macros, visited: visited)
+        end
+      end
+
+      methods
+    end
+
+    # `delegate foo, to: @array` / `forward_missing_to @array` synthesize
+    # no defs in the source parse: resolve the delegated names against the
+    # target ivar's indexed type (`Array(Item(V))` → `first?`, `shift`, ...).
+    private def merge_delegated_methods(type : TypeInfo, methods : Array(MethodInfo), class_method : Bool, include_macros : Bool, visited : Set(String), mapping : Hash(String, String)? = nil, receiver_name : String? = nil)
+      return if type.delegates.empty? && type.forward_missing_to.nil?
+
+      type.delegates.each do |delegate_name, target|
+        delegate_target_methods(type, target, class_method, include_macros, visited, mapping, receiver_name).each do |method|
+          next unless method.name == delegate_name
+          methods << method unless methods.any? { |existing| Index.same_method?(existing, method) }
+        end
+      end
+
+      if target = type.forward_missing_to
+        delegate_target_methods(type, target, class_method, include_macros, visited, mapping, receiver_name).each do |method|
+          methods << method unless methods.any? { |existing| Index.same_method?(existing, method) }
+        end
+      end
+    end
+
+    private def delegate_target_methods(type : TypeInfo, target : String, class_method : Bool, include_macros : Bool, visited : Set(String), mapping : Hash(String, String)? = nil, receiver_name : String? = nil) : Array(MethodInfo)
+      return [] of MethodInfo unless target.starts_with?('@')
+      target_types = type.ivars[target]? || type.class_vars[target]? || [] of String
+      if target_types.empty?
+        # The compiled index carries no ivars; the semantic summary does
+        # (concrete per instantiation when the receiver is a
+        # specialization).
+        if receiver_name && receiver_name != type.name
+          target_types = instance_vars_for(receiver_name)[target]? || [] of String
+        end
+        if target_types.empty?
+          target_types = instance_vars_for(type.name)[target]? || type.class_vars[target]? || [] of String
+        end
+      end
+      # The target's element type is usually a bare name (`Item(V)` inside
+      # `Array(Item(V))`): resolve it against the receiver's namespace so
+      # the delegated methods carry fully-qualified types.
+      namespace = type.name.rpartition("::").first?
+      target_types.flat_map do |target_type|
+        # A generic receiver (`Priority::Queue(Change)`) specializes the
+        # target's ivar type (`@array : Array(Priority::Item(V))` →
+        # `Array(Priority::Item(Change))`) so the delegated methods return
+        # the concrete element instead of the raw type var (`first?` →
+        # `Priority::Item(Change) | ::Nil`).
+        resolved_target = resolve_type_name_deep(target_type, namespace)
+        substituted = mapping ? (substitute_type_vars(resolved_target, mapping) || resolved_target) : resolved_target
+        # A fresh visited copy per call: the first delegate name's lookup
+        # marks the target type as visited, which would silently empty every
+        # later delegate's lookup (cycles are still guarded by the caller's
+        # own key, which the copy carries over).
+        methods_for(substituted, class_method: false, include_macros: include_macros, visited: visited.dup)
+      end
+    end
+
+    # Resolves a type name against *namespace*, descending into generic
+    # arguments: `Array(Item(V))` with bare nested names becomes
+    # `Array(Priority::Item(V))` so the target lookups hit the
+    # fully-qualified index entries.
+    private def resolve_type_name_deep(type_name : String, namespace : String?) : String
+      if (parts = TypeUtils.generic_type_arguments(type_name, "Array", 1)) && (element = parts[0]?)
+        resolved_element = resolve_type_name_deep(element, namespace)
+        return "Array(#{resolved_element})" if resolved_element != element
+      end
+      if (parts = TypeUtils.generic_type_arguments(type_name, "Hash", 2)) && parts.size == 2
+        resolved_key = resolve_type_name_deep(parts[0], namespace)
+        resolved_value = resolve_type_name_deep(parts[1], namespace)
+        if resolved_key != parts[0] || resolved_value != parts[1]
+          return "Hash(#{resolved_key}, #{resolved_value})"
+        end
+      end
+
+      resolve_type_name(type_name, namespace: namespace) || type_name
+    end
+
+    # A base type's own methods may lack accessors that only exist on
+    # its subclasses (`Crystal::ASTNode` carries no `name`/`body`/`args`
+    # while `Var`/`Def`/`Block` do): when the direct lookup has no match
+    # for *method_name*, fall back to the indexed subtypes' methods so
+    # `node.name`-style receivers on compiler hierarchy roots still
+    # resolve. Best effort: the dynamic type is unknown, but every
+    # returned method is valid for some subtype.
+    def methods_named(type_name : String, method_name : String, *, class_method : Bool, include_macros : Bool = false) : Array(MethodInfo)
+      found = methods_for(type_name, class_method: class_method, include_macros: include_macros).select { |method| method.name == method_name }
+      return found unless found.empty?
+      return found unless Query.subtype_fallback_type?(type_name)
+
+      subtype_methods_for(type_name, class_method: class_method, include_macros: include_macros).select { |method| method.name == method_name }
+    end
+
+    # A reverse-parent map built once: parent name (as recorded, plus its
+    # bare last segment) -> direct subtype names. Bare keys let
+    # `Crystal::ASTNode` find subtypes that record their parent as
+    # `ASTNode`.
+    private def subtypes_index : Hash(String, Array(String))
+      @subtypes_index ||= begin
+        index = {} of String => Array(String)
+        all_indexes = [@index]
+        @secondary.try { |secondary| all_indexes << secondary }
+        @overlay.try { |overlay| all_indexes << overlay }
+        all_indexes.each do |idx|
+          idx.types.each do |name, type|
+            type.parent_types.each do |parent|
+              bare = parent.split("::").last?
+              (index[parent] ||= [] of String) << name
+              if bare && bare != parent
+                (index[bare] ||= [] of String) << name
+              end
+            end
+          end
+        end
+        index
+      end
+    end
+
+    # The methods of a type's indexed subtypes (see methods_named). Exposed
+    # for completion, which lists the full surface of hierarchy roots.
+    def subtype_methods_for(type_name : String, *, class_method : Bool, include_macros : Bool) : Array(MethodInfo)
+      cache_key = "#{type_name}:#{class_method}:#{include_macros}"
+      cache = (@subtype_methods_cache ||= {} of String => Array(MethodInfo))
+      if cached = cache[cache_key]?
+        cached
+      else
+        collected = [] of MethodInfo
+        visited = Set(String).new
+        collect_subtype_methods(type_name, class_method: class_method, include_macros: include_macros, visited: visited, collected: collected)
+        cache[cache_key] = collected
+        collected
+      end
+    end
+
+    private def collect_subtype_methods(type_name : String, *, class_method : Bool, include_macros : Bool, visited : Set(String), collected : Array(MethodInfo))
+      return if visited.includes?(type_name)
+      visited << type_name
+
+      keys = [type_name, type_name.split("::").last?].compact
+      subtype_names = keys.flat_map { |key| subtypes_index[key]? || [] of String }.uniq
+      subtype_names.each do |subtype_name|
+        next if visited.includes?(subtype_name)
+        if subtype = @index.types[subtype_name]? || @secondary.try(&.types[subtype_name]?) || @overlay.try(&.types[subtype_name]?)
+          collected.concat(select_methods(subtype.methods, subtype, class_method, include_macros))
+        end
+        collect_subtype_methods(subtype_name, class_method: class_method, include_macros: include_macros, visited: visited, collected: collected)
+      end
+    end
+
+    private def overlay_type(name : String) : TypeInfo?
+      @overlay.try(&.types[name]?)
+    end
+
+    # A module's instance methods are callable on the module itself
+    # (`extend self`): offer them in the class-method view too, so
+    # `Resolver.` and `TypeUtils.` completions work.
+    private def select_methods(methods : Array(MethodInfo), type : TypeInfo, class_method : Bool, include_macros : Bool) : Array(MethodInfo)
+      methods.select do |method|
+        matches = method.class_method == class_method || (class_method && type.kind == TypeKind::Module)
+        matches && (include_macros || !method.macro)
+      end
+    end
+
+    private def generic_specialization_for(type_name : String) : {TypeInfo, Hash(String, String)}?
+      generic_specialization(type_name) do |candidate_name|
+        @overlay.try(&.types[candidate_name]?) || @index.types[candidate_name]? || @secondary.try(&.types[candidate_name]?)
+      end
+    end
+
+    private def generic_summary_specialization_for(type_name : String) : {SummaryType, Hash(String, String)}?
+      generic_specialization(type_name) do |candidate_name|
+        @summary.try(&.type(candidate_name))
+      end
+    end
+
+    private def generic_specialization(type_name : String, &resolver : String -> T?) forall T
+      normalized = type_name.strip
+      return unless open_index = normalized.index('(')
+      return unless normalized.ends_with?(')')
+
+      # The args between the first `(` and the last `)` must be balanced:
+      # a nested-path name (`Priority::Queue(::Tuple(...))::Item(...)`)
+      # has an extra `)` that would otherwise build a garbage 1:1 mapping
+      # against the `Priority::Queue(V)` template.
+      depth = 0
+      normalized[open_index + 1...-1].each_char do |char|
+        depth += 1 if char == '('
+        depth -= 1 if char == ')'
+        return if depth < 0
+      end
+      return unless depth == 0
+
+      base_name = normalized[0, open_index]
+      actual_args = TypeUtils.split_top_level(normalized[open_index + 1...-1], ',')
+
+      generic_candidate_names(base_name).each do |candidate_name|
+        candidate_params = TypeUtils.split_top_level(candidate_name[base_name.size + 1...-1], ',')
+        mapping = build_generic_mapping(candidate_params, actual_args)
+        next unless mapping
+
+        if candidate = yield candidate_name
+          return {candidate, mapping}
+        end
+      end
+
+      nil
+    end
+
+    private def build_generic_mapping(candidate_params : Array(String), actual_args : Array(String)) : Hash(String, String)?
+      if candidate_params.size == actual_args.size
+        mapping = {} of String => String
+        candidate_params.each_with_index do |param, index|
+          mapping[param] = actual_args[index]
+        end
+        return mapping
+      end
+
+      # A leading splat with trailing params (`Proc(*T, R)`): the splat
+      # takes the leading args, the trailing params the last ones.
+      if (splat_param = candidate_params.first?) && splat_param.starts_with?('*')
+        trailing = candidate_params.size - 1
+        return unless actual_args.size >= trailing
+
+        mapping = {} of String => String
+        mapping[splat_param] = actual_args[0, actual_args.size - trailing].join(" | ")
+        candidate_params[1..].each_with_index do |param, index|
+          mapping[param] = actual_args[actual_args.size - trailing + index]
+        end
+        return mapping
+      end
+
+      nil
+    end
+
+    private def generic_candidate_names(base_name : String) : Array(String)
+      candidates = @index.types.keys.select { |name| name.starts_with?("#{base_name}(") }
+      if overlay = @overlay
+        candidates.concat(overlay.types.keys.select { |name| name.starts_with?("#{base_name}(") })
+      end
+      if secondary = @secondary
+        candidates.concat(secondary.types.keys.select { |name| name.starts_with?("#{base_name}(") })
+      end
+      if summary = @summary
+        candidates.concat(summary.types.keys.select { |name| name.starts_with?("#{base_name}(") })
+      end
+      candidates.uniq
+    end
+
+    private def specialize_method(method : MethodInfo, owner_name : String, mapping : Hash(String, String)) : MethodInfo
+      MethodInfo.new(
+        name: method.name,
+        owner: owner_name,
+        args: method.args.map { |arg|
+          ArgInfo.new(name: arg.name, restriction: substitute_type_vars(arg.restriction, mapping))
+        },
+        return_type: substitute_type_vars(method.return_type, mapping),
+        class_method: method.class_method,
+        macro: method.macro,
+        doc: method.doc,
+        location: method.location,
+        name_location: method.name_location,
+        name_size: method.name_size,
+        free_vars: method.free_vars,
+        block_restriction: method.block_restriction.try { |restriction| substitute_type_vars(restriction, mapping) },
+      )
+    end
+
+    private def substitute_type_vars(type_name : String?, mapping : Hash(String, String)) : String?
+      return unless type_name
+
+      TypeUtils.substitute_generic_params(type_name, mapping)
+    end
+
+    # The prelude records parent types by their bare name (`ASTNode`),
+    # while types are keyed fully qualified (`Crystal::ASTNode`): resolve
+    # the parent against the enclosing type's namespace so the hierarchy
+    # walk reaches the indexed entry instead of silently returning empty.
+    private def resolve_parent_name(parent_type : String, type_name : String) : String
+      base_name = parent_type.split('(').first?
+      return parent_type if base_name && base_name.includes?("::")
+      namespace = type_name.rpartition("::").first?
+      resolve_type_name(parent_type, namespace: namespace) || parent_type
+    end
+
+    private def merge_methods(base_methods : Array(MethodInfo), summary_methods : Array(MethodInfo)) : Array(MethodInfo)
+      merged = base_methods.dup
+      return merged if summary_methods.empty?
+
+      # Index the base by identity so the merge is O(n + m) instead of a
+      # linear scan per method (the subtype fallback merges thousands).
+      existing_index = {} of String => Int32
+      merged.each_with_index do |method, index|
+        existing_index[method_merge_key(method)] = index
+      end
+
+      summary_methods.each do |summary_method|
+        key = method_merge_key(summary_method)
+        if index = existing_index[key]?
+          existing = merged[index]
+          merged[index] = MethodInfo.new(
+            name: existing.name,
+            owner: existing.owner,
+            args: existing.args.empty? ? summary_method.args : existing.args,
+            return_type: summary_method.return_type || existing.return_type,
+            class_method: existing.class_method,
+            macro: existing.macro,
+            doc: existing.doc || summary_method.doc,
+            location: existing.location || summary_method.location,
+            name_location: existing.name_location || summary_method.name_location,
+            name_size: existing.name_size.zero? ? summary_method.name_size : existing.name_size,
+            free_vars: existing.free_vars.empty? ? summary_method.free_vars : existing.free_vars,
+            block_restriction: existing.block_restriction || summary_method.block_restriction,
+          )
+        else
+          existing_index[key] = merged.size
+          merged << summary_method
+        end
+      end
+
+      merged
+    end
+
+    private def method_merge_key(method : MethodInfo) : String
+      "#{method.name}:#{method.class_method}:#{method.args.map(&.restriction).join("|")}"
+    end
+  end
+end

--- a/src/crystalline/lightweight/resolver.cr
+++ b/src/crystalline/lightweight/resolver.cr
@@ -1,0 +1,834 @@
+require "./inference"
+require "./type_utils"
+require "./query"
+require "../position_utils"
+
+module Crystalline::Lightweight
+  module Resolver
+    extend self
+
+    SAFE_TRY_SEGMENT = "__lightweight_try__"
+    INDEX_SEGMENT = "__lightweight_index__"
+    RANGE_SEGMENT = "__lightweight_range__"
+    CAST_SEGMENT = "__lightweight_cast__"
+
+    def receiver_types(source : String, line_number : Int32, analysis_column : Int32, receiver : String, query : Query) : {Array(String), Bool}
+      # A quoted-string root (`"= #{a.b}".colorize`) contains dots inside
+      # the interpolation: split on dots only outside quotes so the root
+      # stays the whole literal.
+      segments = [] of String
+      if receiver.starts_with?('"')
+        start = 0
+        in_quote = false
+        receiver.each_char_with_index do |char, index|
+          if char == '"'
+            in_quote = !in_quote
+          elsif char == '.' && !in_quote
+            segments << receiver[start...index]
+            start = index + 1
+          end
+        end
+        tail = receiver[start..]
+        segments << tail unless tail.empty?
+      else
+        segments = receiver.split('.').reject(&.empty?)
+      end
+      return {[] of String, false} if segments.empty?
+
+      type_names, class_method = root_receiver_types(source, line_number, analysis_column, segments.shift, query)
+      return {[] of String, class_method} if type_names.empty?
+
+      index = 0
+      while index < segments.size
+        segment = segments[index]
+        if segment == SAFE_TRY_SEGMENT
+          safe_method = segments[index + 1]?
+          unless safe_method
+            safe_receiver_types = type_names.reject(&.==("Nil")).uniq
+            return {safe_receiver_types, false}
+          end
+
+          # `x.try(&.foo[1]?)` — the nilable index after the try.
+          safe_method = "[]" if safe_method == INDEX_SEGMENT
+          safe_method = "[]?" if safe_method == "#{INDEX_SEGMENT}?"
+          type_names, class_method = safe_chained_call_types(type_names, class_method, safe_method, query)
+          return {[] of String, class_method} if type_names.empty?
+          index += 2
+        else
+          segment = "[]" if segment == INDEX_SEGMENT
+          # `types[type_name]?` — a nilable index — normalizes to the
+          # index segment with a `?` suffix: resolve it like `[]?`.
+          segment = "[]?" if segment == "#{INDEX_SEGMENT}?"
+          if segment == RANGE_SEGMENT
+            # `arr[1..]` / `arr[1...]` — a range index returns the
+            # array itself (a slice), not an element: keep the receiver
+            # types flowing through the chain.
+            type_names = type_names.reject(&.==("Nil")).uniq
+            class_method = false
+          elsif segment == "#{RANGE_SEGMENT}?"
+            # `arr[1..]?` — the nilable slice: the array or nil.
+            type_names = (type_names.reject(&.==("Nil")).uniq + ["Nil"]).uniq
+            class_method = false
+          elsif segment == "as" || segment == "as?"
+            # `as`/`as?` casts are compiler specials: this segment is the
+            # method-name half of a preserved cast call, and the cast-target
+            # segment that follows overrides the receiver types.
+          elsif segment.starts_with?(CAST_SEGMENT)
+            # `as`/`as?` casts are compiler specials, not indexed methods:
+            # the normalizer kept the target type in this segment, and the
+            # target names the cast result.
+            if target = segment[CAST_SEGMENT.size + 1..]?
+              target = target.rchop(')')
+              type_names = [target]
+              class_method = false
+            else
+              return {[] of String, class_method}
+            end
+          else
+            # A call segment with args (`Crystal::Parser.new(text)` splits
+            # on '.' into `Crystal::Parser` + `new(text)`): the args group
+            # is not part of the method name.
+            segment = segment.split('(').first? || segment
+            type_names, class_method = chained_call_types(type_names, class_method, segment, query)
+            return {[] of String, class_method} if type_names.empty?
+          end
+          index += 1
+        end
+      end
+
+      {type_names, class_method}
+    end
+
+    def receiver_from_prefix(prefix : String) : String
+      # `rstrip` also clears trailing whitespace: a chain continuation
+      # (`greeter\n    .method`) leaves only whitespace between the
+      # previous line's receiver and the trigger dot, and without the
+      # strip the walk-back stops at the whitespace, producing an empty
+      # receiver (or one that drags the whitespace along).
+      normalized_prefix = normalize_receiver_prefix(prefix).rstrip('.').rstrip
+
+      start = normalized_prefix.size
+      while start > 0 && receiver_expression_char?(normalized_prefix[start - 1])
+        start -= 1
+      end
+
+      # A quoted-string receiver (`"✅ #{project_name}".colorize`): the
+      # closing quote stops the expression-char scan, so extend back to
+      # the opening quote (the last one before it). Applies both when the
+      # prefix ends at the quote (first hop) and mid-chain (`"x".foo.bar`:
+      # the scan stops at the quote after the leading dot).
+      if start > 0 && normalized_prefix[start - 1] == '"'
+        if open_quote = normalized_prefix.rindex('"', start - 2)
+          start = open_quote
+        end
+      end
+
+      # A `do ... end` block tail (`flat_map do |x| ... end.uniq`, with
+      # the `end` possibly followed by a chain suffix: `... end.flatten.`):
+      # the trailing call's receiver starts at the block's `end`, so cut
+      # the block text at the matching `do` and keep any suffix.
+      receiver = normalized_prefix[start..]? || ""
+      if receiver.size >= 3 && receiver.starts_with?("end") && (receiver.size == 3 || receiver[3]? == '.')
+        # Scan backward from just before the closer: the closer itself is
+        # the anchor and must not be counted (its matching `do` is the one
+        # that brings the depth back to zero).
+        # `String#[](index : Int)` is O(n) (a character-index scan), so
+        # index the char array instead of the raw string.
+        chars = normalized_prefix.chars
+        depth = 1
+        index = start - 1
+        do_index = -1
+        # An `end` followed (going back) by `else`/`elsif` closes an
+        # `if`/`case`, not a `do` block: undo its depth contribution.
+        else_seen = false
+        while index >= 0 && depth > 0
+          if token_char?(chars[index])
+            token_end = index + 1
+            token_start = index
+            while token_start > 0 && token_char?(chars[token_start - 1])
+              token_start -= 1
+            end
+            # `String#[](start, count)` is O(start): build the token from
+            # the char array (the same reason the loops index `chars`).
+            token = String.build(token_end - token_start) do |io|
+              (token_start...token_end).each { |i| io << chars[i] }
+            end
+            if token == "end"
+              depth += 1
+              else_seen = false
+            elsif token == "do"
+              depth -= 1
+              do_index = token_start if depth == 0
+            elsif (token == "else" || token == "elsif") && !else_seen
+              depth -= 1
+              else_seen = true
+            end
+            index = token_start - 1
+          else
+            index -= 1
+          end
+        end
+        if do_index >= 0
+          suffix = normalized_prefix[start + 3..]? || ""
+          normalized_prefix = normalized_prefix[0, do_index].rstrip + suffix
+          start = normalized_prefix.size
+          while start > 0 && receiver_expression_char?(normalized_prefix[start - 1])
+            start -= 1
+          end
+        end
+      end
+
+      # A cast segment (`.__lightweight_cast__(T)`) ends with a balanced
+      # group. Walk back through it so the receiver keeps the cast target
+      # instead of stopping at the closing paren. Only cast segments leave
+      # a `)` in the normalized prefix — other groups are dropped — so the
+      # segment marker must be present, otherwise the paren is an orphan
+      # (e.g. a `try(&...)` call nested in a dropped group) and the
+      # receiver stays empty.
+      if start > 0 && normalized_prefix[start - 1] == ')' && normalized_prefix[0, start]?.try(&.includes?(CAST_SEGMENT))
+        depth = 0
+        while start > 0
+          char = normalized_prefix[start - 1]
+          start -= 1
+          depth += 1 if char == ')'
+          depth -= 1 if char == '('
+          break if depth == 0
+        end
+        while start > 0 && receiver_expression_char?(normalized_prefix[start - 1])
+          start -= 1
+        end
+      end
+
+      receiver = normalized_prefix[start..]? || ""
+      # A range operator inside the receiver (`range.start.line..range.end`)
+      # is not a method call: the receiver of the trailing call is the
+      # part after the last `..` (`a..b.foo` parses as `a..(b.foo)`, so
+      # `foo`'s receiver is `b`). Skipped when a quote is present (a
+      # `..` inside a string literal must stay intact).
+      if !receiver.includes?('"') && !receiver.includes?('\'') && (range_index = receiver.rindex(".."))
+        receiver = receiver[range_index + 2..]? || ""
+      end
+
+      receiver
+    end
+
+    # The receiver may span lines (`... end.uniq` with the `end` on its
+    # own line after a do-block): walk back over the whole source up to
+    # the cursor when the single-line receiver suggests a block closer
+    # (`end...`) or a continuation (`.foo` on its own line); otherwise
+    # the current line's prefix is enough.
+    def receiver_from_line_prefix(source : String, line_number : Int32, prefix : String) : String
+      single = receiver_from_prefix(prefix)
+      if single.empty? || (single.starts_with?("end") && (single.size == 3 || single[3]? == '.')) || single.starts_with?('.')
+        full_prefix = String.build do |io|
+          source.lines(chomp: false)[0...line_number].each { |l| io << l }
+          io << prefix
+        end
+        receiver_from_prefix(full_prefix)
+      else
+        single
+      end
+    end
+
+    def receiver_expression_char?(char : Char)
+      token_char?(char) || char == '.'
+    end
+
+    private def normalize_receiver_prefix(prefix : String) : String
+      normalized_prefix = prefix
+        # `try(&.x)` / `try &.x` / mid-edit `try(&` — the `&.`-form block
+        # is not a parseable group, so it gets a dedicated segment (the
+        # block receiver of try is the call's own receiver).
+        .gsub(/\.try\s*(?:\(\s*)?&\s*\./, ".#{SAFE_TRY_SEGMENT}.")
+        .gsub(/\.try\s*(?:\(\s*)?&\s*$/, ".#{SAFE_TRY_SEGMENT}.")
+        .gsub(/[ \t]+\(/, "(")
+
+      result = String.build do |str|
+        # `String#[](index : Int)` is O(n) (a character-index scan), so
+        # indexing the raw string inside these loops would be quadratic
+        # on multi-line prefixes: index the char array instead.
+        chars = normalized_prefix.chars
+        index = 0
+        quote = nil.as(Char?)
+        while index < chars.size
+          char = chars[index]
+          if quote
+            # Inside a string: copy verbatim — a paren or bracket in the
+            # text (`"Array(#{...})"`) is not code and must not open a group.
+            str << char
+            if char == '\\'
+              if escaped = chars[index + 1]?
+                str << escaped
+                index += 2
+                next
+              end
+            elsif char == quote
+              quote = nil
+            end
+            index += 1
+          elsif char.in?('"', '\'')
+            quote = char
+            str << char
+            index += 1
+          elsif char == '#'
+            # A comment is not code: copy it verbatim so a paren or
+            # bracket inside it (e.g. `(only the body's effects`) never
+            # opens a group that swallows the rest of the prefix.
+            comment_start = index
+            index += 1
+            while index < chars.size && chars[index] != '\n'
+              index += 1
+            end
+            str << normalized_prefix[comment_start...index]
+          elsif char == '['
+            group_start = index
+            depth = 1
+            quote = nil.as(Char?)
+            index += 1
+            while index < chars.size && depth > 0
+              current = chars[index]
+              if quote
+                if current == '\\'
+                  index += 2
+                  next
+                elsif current == quote
+                  quote = nil
+                end
+              elsif current.in?('"', '\'')
+                quote = current
+              elsif current == '['
+                depth += 1
+              elsif current == ']'
+                depth -= 1
+              elsif current == '#'
+                # Skip comment text inside the group (e.g. a `# [note`
+                # between call args): it must not affect group balance.
+                # Strings are handled by the quote branch above, so an
+                # interpolation `#{...}` never reaches here.
+                index += 1
+                while index < chars.size && chars[index] != '\n'
+                  index += 1
+                end
+              end
+              index += 1
+            end
+            if depth > 0
+              # Unclosed bracket (mid-edit, e.g. `@local_types[target.`):
+              # keep the remainder (the `[` stops the receiver walk-back)
+              # so the receiver inside the brackets is still found.
+              (group_start...chars.size).each { |i| str << chars[i] }
+              index = chars.size
+            else
+              # `arr[1..]` / `arr[i..j]` — a range index slices the
+              # array, so the chain continues on the array itself (the
+              # resolver treats the range segment as identity). String
+              # literals inside the brackets (`arr[".."]`) are not ranges.
+              inner = String.build(index - group_start - 2) do |io|
+                (group_start + 1...index - 1).each { |i| io << chars[i] }
+              end
+              str << if inner.gsub(/"[^"]*"|'[^']*'/, "").includes?("..")
+                       ".#{RANGE_SEGMENT}"
+                     else
+                       ".#{INDEX_SEGMENT}"
+                     end
+              # `[] of String` — an array literal's of-clause: consume it
+              # so the walk-back lands on the index segment (the receiver
+              # root resolves it to `Array(T)`), not on the element type.
+              if chars[index]? == ' ' && chars[index + 1]? == 'o' && chars[index + 2]? == 'f' && (chars[index + 3]? == ' ' || chars[index + 3]? == nil)
+                index += 3
+                while chars[index]? == ' '
+                  index += 1
+                end
+                while chars[index]? && token_char?(chars[index])
+                  index += 1
+                end
+              end
+            end
+          elsif char == '('
+            # Call arguments are dropped from the receiver expression so that
+            # chains like `factory.build("hi").sh` resolve through `build`.
+            # `as`/`as?` casts are the exception: the target type names the
+            # result, so it survives in a special segment.
+            group_start = index
+            depth = 1
+            index += 1
+            quote = nil.as(Char?)
+            while index < chars.size && depth > 0
+              current = chars[index]
+              if quote
+                if current == '\\'
+                  index += 2
+                  next
+                elsif current == quote
+                  quote = nil
+                end
+              elsif current.in?('"', '\'')
+                quote = current
+              elsif current == '#'
+                # Skip comment text inside the group: an apostrophe in a
+                # comment (e.g. `(only the body's effects`) must not be
+                # mistaken for a quote that swallows the rest of the file.
+                index += 1
+                while index < chars.size && chars[index] != '\n'
+                  index += 1
+                end
+              elsif current == '('
+                depth += 1
+              elsif current == ')'
+                depth -= 1
+              end
+              index += 1
+            end
+            if depth > 0
+              # Unclosed group (mid-edit, e.g. `unless (x = foo.b`): keep
+              # the remainder so the receiver inside the parens is still found.
+              (group_start...chars.size).each { |i| str << chars[i] }
+              index = chars.size
+            else
+              method_end = group_start
+              method_start = method_end
+              while method_start > 0 && token_char?(chars[method_start - 1])
+                method_start -= 1
+              end
+              # `String#[](start, count)` is O(start) (a character-index
+              # scan), so a slice near the end of a multi-line prefix
+              # would be quadratic across all groups: build from chars.
+              method_name = String.build(method_end - method_start) do |io|
+                (method_start...method_end).each { |i| io << chars[i] }
+              end
+              if method_name == "as" || method_name == "as?"
+                target = String.build(index - group_start - 2) do |io|
+                  (group_start + 1...index - 1).each { |i| io << chars[i] }
+                end
+                str << ".#{CAST_SEGMENT}(#{target})"
+              elsif method_name.empty? || method_name.in?("if", "unless", "while", "until", "return", "case", "?") || method_name.ends_with?(':')
+                # A parenthesized expression as receiver — `(expr).m`, or
+                # `(expr).try(&.m)` where the parens group the try receiver
+                # itself, or a control-flow condition `if (x = y).m` (the
+                # keyword is not a call, so the group is not its args):
+                # keep the inner expression so the chain still resolves.
+                # A bare `?` is the ternary operator (`x ? (a || b).m : c`)
+                # and a trailing `:` a keyword-arg label (`sort_text:
+                # (nesting + 1).chr`): neither is a call, so the group is
+                # the value, not call arguments.
+                # For a multi-expression inner (`a || b`) the walk-back
+                # keeps its last sub-expression, the usual approximation.
+                # The inner may itself contain groups and brackets
+                # (`(a || b[1]?).try(&.x)`): normalize it recursively so
+                # the walk-back does not stop at a raw `[`/`(`.
+                inner = String.build(index - group_start - 2) do |io|
+                  (group_start + 1...index - 1).each { |i| io << chars[i] }
+                end
+                str << normalize_receiver_prefix(inner)
+              end
+            end
+          elsif char == ')'
+            # A stray closer left by the `try(&.x)` rewrite above (it
+            # consumes the opening paren but not its match): a `)` that
+            # reaches the top level is never part of a receiver.
+            index += 1
+          else
+            str << char
+            index += 1
+          end
+        end
+      end
+
+      result
+    end
+
+    def token_char?(char : Char)
+      char.ascii_alphanumeric? || char.in?('_', '?', '!', '@', ':')
+    end
+
+    # The token span around the cursor column (character-based), or nil
+    # when the cursor is not on a token.
+    def token_span(line : String, column_number : Int32) : {Int32, Int32}?
+      index = normalized_column(line, column_number)
+      return unless index
+      return unless token_char?(line[index])
+
+      start_index = index
+      while start_index > 0 && token_char?(line[start_index - 1])
+        start_index -= 1
+      end
+
+      end_index = index + 1
+      while (char = line[end_index]?) && token_char?(char)
+        end_index += 1
+      end
+
+      {start_index, end_index}
+    end
+
+    # The character index under the cursor, snapping to the token when the
+    # cursor sits just past it (end-of-token hovers), or nil when the
+    # cursor is on whitespace/punctuation.
+    def normalized_column(line : String, column_number : Int32) : Int32?
+      return if line.empty?
+
+      index = PositionUtils.utf16_to_char_index(line, column_number)
+      index = line.size - 1 if index >= line.size
+      return if index < 0
+
+      return index if token_char?(line[index])
+      return index - 1 if index > 0 && token_char?(line[index - 1])
+
+      nil
+    end
+
+    def instance_var_name?(name : String)
+      !!(name =~ /\A@[a-zA-Z_][a-zA-Z0-9_?!]*\z/)
+    end
+
+    def class_var_name?(name : String)
+      !!(name =~ /\A@@[a-zA-Z_][a-zA-Z0-9_?!]*\z/)
+    end
+
+    def local_name?(name : String)
+      !!(name =~ /\A[a-z_][a-zA-Z0-9_?!]*\z/)
+    end
+
+    def type_name?(name : String)
+      !!(name =~ /\A[A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*\z/)
+    end
+
+    private def root_receiver_types(source : String, line_number : Int32, analysis_column : Int32, receiver : String, query : Query) : {Array(String), Bool}
+      # A negation receiver (`!@result_cache`) resolves like the operand.
+      receiver = receiver.lchop('!')
+
+      if receiver == "__lightweight_index__" || receiver == "[]"
+        # An array literal receiver (`[a, b].compact_map`): the normalizer
+        # turned the bracket group into the index segment. The element
+        # type is not recoverable from the string, so fall back to the
+        # generic array — the chain still flows through `Array(T)`.
+        return {["Array(T)"], false}
+      end
+
+      if receiver == "nil"
+        return {["Nil"], false}
+      end
+
+      # Literal receivers (`120.seconds`, `"x".size`, `'c'.ord`, `true`):
+      # type them from the literal form so stdlib methods resolve.
+      if receiver == "true" || receiver == "false"
+        return {["Bool"], false}
+      end
+      if receiver =~ /\A-?\d+_\d+\z/ || receiver =~ /\A-?\d+\z/
+        return {["Int32"], false}
+      end
+      if receiver =~ /\A-?\d+\.\d+\z/ || receiver =~ /\A-?\d+[eE][+-]?\d+\z/
+        return {["Float64"], false}
+      end
+      if receiver =~ /\A"[^"]*"\z/
+        return {["String"], false}
+      end
+      if receiver =~ /\A'[^']*'\z/
+        return {["Char"], false}
+      end
+
+      inference = Inference.for(
+        source,
+        line_number + 1,
+        analysis_column + 1,
+        query,
+      )
+
+      if type_name?(receiver)
+        resolved_name = query.resolve_type_name(receiver, namespace: inference.try(&.current_type_name))
+        if resolved_name
+          # A compiled constant (`LSP::Log = ::Log.for(self)`) is recorded
+          # as a Constant-kind shell whose parent is the value's type: the
+          # constant holds an instance, so its methods are the value type's
+          # instance methods (`LSP::Log.info`).
+          if constant_types = constant_value_types(resolved_name, query)
+            return {constant_types, false}
+          end
+          # The compiled index records constants (`CAST_SEGMENT = "..."`)
+          # as bare type entries with no methods and no parents: a
+          # capitalized receiver resolving to such a shell is a constant
+          # value, not a type — fall through to the constant-type path.
+          return {[resolved_name], true} unless constant_shell_type?(resolved_name, query)
+        end
+        # A capitalized name can also be a constant
+        # (`CAST_SEGMENT = "__lightweight_cast__"`): when it is not a
+        # type, fall back to the recorded constant type.
+        if inference
+          constant_types = inference.types_for(receiver).reject(&.==("Nil")).select { |type_name| receiver_type_known?(type_name, query) }
+          return {constant_types, false} unless constant_types.empty?
+        end
+        return {[] of String, true}
+      end
+
+      if receiver == "self"
+        return inference.try(&.self_types) || {[] of String, false}
+      end
+
+      if instance_var_name?(receiver)
+        return {
+          (inference ? inference.types_for_instance_var(receiver) : [] of String).reject(&.==("Nil")).select { |type_name| receiver_type_known?(type_name, query) },
+          false,
+        }
+      end
+
+      if class_var_name?(receiver)
+        # A class var holds an instance value (`@@compilation_lock =
+        # Mutex.new`), so its methods are instance methods — unlike a
+        # type-path receiver.
+        return {
+          (inference ? inference.types_for_class_var(receiver) : [] of String).reject(&.==("Nil")).select { |type_name| receiver_type_known?(type_name, query) },
+          false,
+        }
+      end
+
+      return {[] of String, false} unless local_name?(receiver)
+
+      if inference
+        namespace = inference.current_type_name
+        local_types = inference.types_for(receiver).reject(&.==("Nil")).flat_map { |type_name|
+          if receiver_type_known?(type_name, query)
+            [type_name]
+          elsif resolved = query.resolve_type_name(type_name, namespace: namespace)
+            [resolved]
+          else
+            [] of String
+          end
+        }.uniq
+        return {local_types, false} unless local_types.empty?
+      end
+
+      # The receiver may be a self-call (e.g. a `getter!` used without an
+      # explicit receiver): resolve the method on the enclosing type. The
+      # return type is resolved against that type's namespace, so a bare
+      # `Workspace` in `Crystalline::Controller` picks the project type even
+      # when another `::Workspace` exists elsewhere.
+      if inference
+        if self_type_names = inference.self_types[0]?
+          return_types = self_type_names.flat_map do |type_name|
+            query.methods_for(type_name, class_method: inference.class_method_context?).select(&.name.==(receiver)).flat_map { |method|
+              return_type_names(method.return_type, query, namespace: type_name)
+            }
+          end.reject(&.==("Nil")).uniq
+          return {return_types, false} unless return_types.empty?
+        end
+      end
+
+      {
+        query.top_level_methods.select { |method| method.name == receiver }.flat_map { |method|
+          return_type_names(method.return_type, query)
+        }.reject(&.==("Nil")).uniq,
+        false,
+      }
+    end
+
+    private def safe_chained_call_types(type_names : Array(String), class_method : Bool, method_name : String, query : Query) : {Array(String), Bool}
+      non_nil_types = type_names.reject(&.==("Nil")).uniq
+      return {type_names.includes?("Nil") ? ["Nil"] : [] of String, false} if non_nil_types.empty?
+
+      resolved_types, _ = chained_call_types(non_nil_types, class_method, method_name, query)
+      resolved_types = (resolved_types + ["Nil"]).uniq if type_names.includes?("Nil")
+      {resolved_types, false}
+    end
+
+    private def chained_call_types(type_names : Array(String), class_method : Bool, method_name : String, query : Query) : {Array(String), Bool}
+      if class_method
+        valid_types = type_names.select { |type_name| receiver_type_known?(type_name, query) }.uniq
+        return {valid_types, false} if method_name == "new"
+        return {valid_types, true} if method_name == "class"
+      elsif method_name == "class"
+        return {type_names.select { |type_name| receiver_type_known?(type_name, query) }.uniq, true}
+      end
+
+      special_types = type_names.flat_map { |type_name| special_return_type_names(type_name, method_name, query) }.uniq
+      return {special_types, false} unless special_types.empty?
+
+      return_types = type_names.flat_map do |type_name|
+        query.methods_named(type_name, method_name, class_method: class_method).flat_map do |method|
+          # `Array(T)#+` returns `Array(T)`: substitute the receiver's
+          # concrete element types for the free vars so the chain keeps
+          # `Array(X)` instead of an unresolvable `T`.
+          return_type = TypeUtils.substitute_free_vars(method.return_type, method.free_vars, type_name)
+          # A `def ...; self; end` return (Colorize's macro-generated
+          # style setters) names the owner type.
+          return_type = method.owner if return_type == "self"
+          # Resolve bare return types (e.g. `ASTNode`) against the method's
+          # own namespace, the way the compiler would.
+          return_type_names(return_type, query, namespace: method.owner)
+        end
+      end
+
+      # Compiler-semantic accessors (`ASTNode#type?`, base
+      # `Type#parents`/`types?`/`remove_alias`) carry no usable indexed
+      # return: apply the known compiler signature so chains through them
+      # keep resolving (`n.type?.to_s`, `type.parents.try &.each`).
+      if (return_types.empty? || return_types.all?(&.==("Nil"))) && type_names.any? { |t| t.starts_with?("Crystal::") }
+        if semantic_return = TypeUtils.semantic_accessor_return(method_name)
+          return_types = TypeUtils.expand_type_names(semantic_return)
+        end
+      end
+
+      {return_types.uniq, false}
+    end
+
+    private def receiver_type_known?(type_name : String, query : Query) : Bool
+      # find_type_info falls back to the first generic specialization
+      # (`Dispatcher` → `Dispatcher(T)`), so generic-class receivers like
+      # `LSP::RequestMessage` resolve even though the index keys them
+      # with their type vars.
+      query.find_type_info(type_name) != nil ||
+        TypeUtils.array_element_types(type_name) != nil ||
+        TypeUtils.hash_value_types(type_name) != nil ||
+        TypeUtils.tuple_element_types(type_name) != nil ||
+        TypeUtils.named_tuple_type?(type_name)
+    end
+
+    # A recorded type entry that carries no methods and no parents is a
+    # constant shell (the compiled index stores constants that way), not
+    # a real type.
+    private def constant_shell_type?(resolved_name : String, query : Query) : Bool
+      type = query.find_type_info(resolved_name)
+      return false unless type
+      type.methods.empty? && type.parent_types.empty?
+    end
+
+    # A Constant-kind entry (`LSP::Log = ::Log.for(self)`) carries the
+    # value's type as its single parent: the constant is an instance
+    # value, so the receiver resolves to the value type's instance
+    # methods.
+    private def constant_value_types(resolved_name : String, query : Query) : Array(String)?
+      type = query.find_type_info(resolved_name)
+      return nil unless type && type.kind == TypeKind::Constant
+      return nil if type.parent_types.empty?
+      [type.parent_types.first]
+    end
+
+    # Container element/value types can be bare names (`Array(ArgInfo)`):
+    # resolve them against the receiver's namespace so the chain keeps
+    # fully-qualified entries. Bare elements from compiler generics
+    # (`Array(Arg)` → `Arg`) fail the ambiguous-name tie-break, so fall
+    # back to the `Crystal::`-prefixed name when it exists.
+    private def resolve_types(types : Array(String), type_name : String, query : Query) : Array(String)
+      types.map do |t|
+        query.resolve_type_name(t, namespace: type_name) ||
+          (query.find_type_info("Crystal::#{t}") ? "Crystal::#{t}" : nil) ||
+          t
+      end
+    end
+
+    private def special_return_type_names(type_name : String, method_name : String, query : Query) : Array(String)
+      case method_name
+      when "not_nil!"
+        return TypeUtils.expand_type_names(type_name).reject(&.==("Nil"))
+      when "tap", "each", "each_with_index", "select", "reject", "reverse_each"
+        # `reverse_each` chains on the enumerator; the indexed overload is
+        # the block form (`: Nil`), so treat it as identity like `each`.
+        return [type_name]
+      when "compact_map"
+        # The indexed overload's return (`Array(U)` with U from the block)
+        # is unresolvable: the chain still flows through an array, so keep
+        # the receiver's array shape.
+        return [type_name] if TypeUtils.array_element_types(type_name)
+      when "flat_map"
+        # `Enumerable#flat_map(& : T -> _)` declares no return restriction
+        # (`Array(U)` is compiler-inferred), so the index records none:
+        # the chain still flows through an array of the block's flattened
+        # results, so approximate with an array of the receiver's elements.
+        if element_types = TypeUtils.enumerable_element_types(type_name)
+          return ["Array(#{resolve_types(element_types, type_name, query).join(" | ")})"]
+        end
+      when "flatten"
+        if TypeUtils.array_element_types(type_name)
+          # `arr.flatten` is still the array.
+          return [type_name]
+        elsif tuple_types = TypeUtils.tuple_element_types(type_name)
+          # `tuple.flatten` becomes an array of the elements' union.
+          return ["Array(#{resolve_types(tuple_types.flatten.uniq, type_name, query).join(" | ")})"]
+        end
+      when "first", "last", "[]", "find!", "reduce"
+        if element_types = TypeUtils.array_element_types(type_name)
+          return resolve_types(element_types, type_name, query).select { |item| receiver_type_known?(item, query) || query.find_type(item) != nil }
+        elsif tuple_types = TypeUtils.tuple_element_types(type_name)
+          if method_name == "first"
+            return resolve_types(tuple_types.first? || [] of String, type_name, query)
+          elsif method_name == "last"
+            return resolve_types(tuple_types.last? || [] of String, type_name, query)
+          end
+          return resolve_types(tuple_types.flatten.uniq, type_name, query)
+        elsif value_types = TypeUtils.hash_value_types(type_name)
+          return resolve_types(value_types, type_name, query).select { |item| receiver_type_known?(item, query) || query.find_type(item) != nil }
+        end
+      when "first?", "last?", "[]?", "find", "dig"
+        if element_types = TypeUtils.array_element_types(type_name)
+          return (resolve_types(element_types, type_name, query) + ["Nil"]).uniq
+        elsif tuple_types = TypeUtils.tuple_element_types(type_name)
+          selected = if method_name == "first?"
+                       tuple_types.first? || [] of String
+                     elsif method_name == "last?"
+                       tuple_types.last? || [] of String
+                     else
+                       tuple_types.flatten.uniq
+                     end
+          return (resolve_types(selected, type_name, query) + ["Nil"]).uniq
+        elsif value_types = TypeUtils.hash_value_types(type_name)
+          return (resolve_types(value_types, type_name, query) + ["Nil"]).uniq
+        elsif value_types = TypeUtils.named_tuple_all_value_types(type_name)
+          return (resolve_types(value_types, type_name, query) + ["Nil"]).uniq
+        end
+      when "fetch"
+        if value_types = TypeUtils.hash_value_types(type_name)
+          return resolve_types(value_types, type_name, query)
+        end
+      else
+        if value_types = TypeUtils.named_tuple_value_types(type_name, method_name)
+          return resolve_types(value_types, type_name, query).select { |item| receiver_type_known?(item, query) || query.find_type(item) != nil }
+        end
+      end
+
+      if contracts = query.method_contracts_for(type_name, method_name)
+        contract_types = [] of String
+        contracts.each do |contract|
+          case contract.kind
+          when .preserve_receiver?
+            contract_types.concat(contract.types)
+          when .return_element?, .return_value?
+            contract_types.concat(contract.types)
+          when .return_element_or_nil?, .return_value_or_nil?
+            contract_types.concat(contract.types)
+            contract_types << "Nil"
+          end
+        end
+        contract_types = contract_types.uniq
+        unless contract_types.empty?
+          # A Nil-only contract on a compiler accessor (`Crystal::Type#parents`
+          # returns nil on the base class) is not the real signature: fall
+          # through so chained_call_types applies the semantic one.
+          unless contract_types.all?(&.==("Nil")) && type_name.starts_with?("Crystal::") && TypeUtils.semantic_accessor_return(method_name)
+            # Contracts come from the compiled program, whose return types
+            # are bare (e.g. `ASTNode`): resolve them against the receiver's
+            # namespace before returning.
+            return contract_types.flat_map { |contract_type| return_type_names(contract_type, query, namespace: type_name) }.uniq
+          end
+        end
+      end
+
+      [] of String
+    end
+
+    private def return_type_names(return_type : String?, query : Query, namespace : String? = nil) : Array(String)
+      return [] of String unless return_type
+
+      TypeUtils.expand_type_names(return_type).compact_map do |type_name|
+        # `: self?`-style returns resolve to the method's owner.
+        if type_name == "self"
+          next namespace ? namespace : nil
+        end
+        # Resolve plain names against the query (and the enclosing namespace
+        # when known, e.g. a getter's `Workspace` in `Crystalline::Controller`);
+        # generic/structured names (Array(T), Tuple(...)) are known as-is.
+        resolved = query.resolve_type_name(type_name, namespace) || type_name
+        next unless receiver_type_known?(resolved, query)
+        resolved
+      end
+    end
+  end
+end

--- a/src/crystalline/lightweight/summary.cr
+++ b/src/crystalline/lightweight/summary.cr
@@ -1,0 +1,132 @@
+require "./contracts"
+require "./type_utils"
+
+module Crystalline::Lightweight
+  class SummaryType
+    getter name : String
+    getter methods = [] of MethodInfo
+    getter method_contracts = {} of String => Array(MethodContract)
+    getter instance_vars = {} of String => Array(String)
+    getter class_vars = {} of String => Array(String)
+
+    def initialize(@name : String)
+    end
+  end
+
+  class Summary
+    getter types = {} of String => SummaryType
+    @visited_types = Set(String).new
+
+    def self.from_result(result : Crystal::Compiler::Result) : self
+      new.tap do |summary|
+        summary.process_type(result.program)
+      end
+    end
+
+    def type(name : String) : SummaryType?
+      @types[name]?
+    end
+
+    protected def process_type(type : Crystal::Type)
+      # The type graph can contain cycles (metaclasses, generic
+      # instantiations): never process the same type twice.
+      return unless @visited_types.add?(type.to_s)
+      if type.is_a?(Crystal::NamedType) || type.is_a?(Crystal::Program) || type.is_a?(Crystal::FileModule)
+        type.types?.try &.each_value do |inner_type|
+          process_type(inner_type)
+        end
+      end
+
+      if type.is_a?(Crystal::GenericType)
+        type.each_instantiated_type do |instance|
+          process_type(instance)
+        end
+      end
+
+      summarize_type(type)
+      process_type(type.metaclass) if type.metaclass != type
+
+      if type.is_a?(Crystal::DefInstanceContainer)
+        type.def_instances.each_value do |typed_def|
+          summarize_typed_def(type, typed_def)
+        end
+      end
+    end
+
+    private def summarize_type(type : Crystal::Type)
+      return unless type.is_a?(Crystal::NamedType)
+
+      summary_type = ensure_type(type.to_s)
+
+      begin
+        if type.allows_instance_vars?
+          type.all_instance_vars.each do |name, ivar|
+            summary_type.instance_vars[name] = TypeUtils.expand_type_names(ivar.type.to_s)
+          end
+        end
+      rescue
+      end
+
+      metaclass = type.metaclass
+      if metaclass.is_a?(Crystal::MetaclassType)
+        begin
+          metaclass.all_class_vars.each do |name, cvar|
+            summary_type.class_vars[name] = TypeUtils.expand_type_names(cvar.type.to_s)
+          end
+        rescue
+        end
+      end
+    end
+
+    private def summarize_typed_def(type : Crystal::Type, typed_def : Crystal::Def)
+      owner_name, class_method = owner_info(type)
+      return_type = typed_def.type?.try(&.to_s) || typed_def.body.type?.try(&.to_s)
+      return unless return_type
+
+      summary_type = ensure_type(owner_name)
+      method = MethodInfo.new(
+        name: typed_def.name.to_s,
+        owner: owner_name,
+        args: typed_def.args.map { |arg|
+          restriction = arg.type?.try(&.to_s) || arg.restriction.try(&.to_s)
+          ArgInfo.new(name: arg.name.to_s, restriction: restriction)
+        },
+        return_type: return_type,
+        class_method: class_method,
+        doc: typed_def.doc,
+        location: typed_def.location,
+        name_location: typed_def.name_location,
+        name_size: typed_def.name.to_s.size,
+      )
+
+      existing_index = summary_type.methods.index do |existing|
+        existing.name == method.name &&
+          existing.class_method == method.class_method &&
+          existing.args.map(&.restriction) == method.args.map(&.restriction)
+      end
+
+      if existing_index
+        summary_type.methods[existing_index] = method
+      else
+        summary_type.methods << method
+      end
+
+      contracts = summary_type.method_contracts[method.name] ||= [] of MethodContract
+      Contracts.derive(owner_name, method).each do |contract|
+        contracts << contract unless contracts.includes?(contract)
+      end
+    end
+
+    private def owner_info(type : Crystal::Type) : {String, Bool}
+      if type.is_a?(Crystal::MetaclassType)
+        {type.instance_type.to_s, true}
+      else
+        {type.to_s, false}
+      end
+    end
+
+    private def ensure_type(name : String) : SummaryType
+      @types[name] ||= SummaryType.new(name)
+    end
+  end
+end

--- a/src/crystalline/lightweight/type_utils.cr
+++ b/src/crystalline/lightweight/type_utils.cr
@@ -1,0 +1,292 @@
+module Crystalline::Lightweight::TypeUtils
+  extend self
+
+  def substitute_generic_params(value : String, mapping : Hash(String, String)) : String
+    return value if mapping.empty?
+
+    String.build do |result|
+      index = 0
+      while index < value.size
+        char = value[index]
+
+        if char == '*' && (next_char = value[index + 1]?) && token_start_char?(next_char)
+          token_end = token_end_index(value, index + 1)
+          token = value[index..token_end]
+          result << (mapping[token]? || token)
+          index = token_end + 1
+        elsif token_start_char?(char)
+          token_end = token_end_index(value, index)
+          token = value[index..token_end]
+          result << (mapping[token]? || token)
+          index = token_end + 1
+        else
+          result << char
+          index += 1
+        end
+      end
+    end
+  end
+
+  def expand_type_names(type_name : String) : Array(String)
+    normalized = unwrap_outer_parens(type_name.strip)
+    parts = split_top_level(normalized, '|')
+    # `T?` is shorthand for `T | ::Nil`: split it so lookups on nilable
+    # receivers (`t.try`, `node_type.doc`) reach the base type.
+    if parts.size == 1 && normalized.ends_with?('?') && normalized.size > 1
+      base = normalized[0...-1].rstrip
+      unless base.empty? || base.ends_with?('?')
+        return [strip_virtual_suffix(base), "::Nil"]
+      end
+    end
+    (parts.empty? ? [normalized] : parts).map { |part| strip_virtual_suffix(part) }
+  end
+
+  # Compiled semantic return types use the virtual-type notation
+  # (`Crystal::Def+` for the hierarchy root): the index keys the plain
+  # name, so strip the suffix before any lookup.
+  private def strip_virtual_suffix(name : String) : String
+    name.ends_with?('+') ? name[0...-1].rstrip : name
+  end
+
+  def split_top_level(value : String, delimiter : Char) : Array(String)
+    parts = [] of String
+    paren_depth = 0
+    brace_depth = 0
+    bracket_depth = 0
+    start = 0
+
+    value.each_char_with_index do |char, index|
+      case char
+      when '('
+        paren_depth += 1
+      when ')'
+        paren_depth -= 1 if paren_depth > 0
+      when '{'
+        brace_depth += 1
+      when '}'
+        brace_depth -= 1 if brace_depth > 0
+      when '['
+        bracket_depth += 1
+      when ']'
+        bracket_depth -= 1 if bracket_depth > 0
+      when delimiter
+        next unless paren_depth == 0 && brace_depth == 0 && bracket_depth == 0
+
+        parts << value[start...index].strip
+        start = index + 1
+      end
+    end
+
+    parts << value[start..].to_s.strip
+    parts.reject(&.empty?)
+  end
+
+  private def token_start_char?(char : Char) : Bool
+    char.ascii_letter? || char == '_'
+  end
+
+  private def token_end_index(value : String, start_index : Int32) : Int32
+    index = start_index
+    while (char = value[index + 1]?) && (char.ascii_alphanumeric? || char.in?('_', '?', '!'))
+      index += 1
+    end
+    index
+  end
+
+  private def unwrap_outer_parens(value : String) : String
+    return value unless value.starts_with?('(') && value.ends_with?(')')
+    return value unless wraps_whole_expression?(value)
+
+    value[1...-1]
+  end
+
+  private def wraps_whole_expression?(value : String) : Bool
+    depth = 0
+
+    value.each_char_with_index do |char, index|
+      case char
+      when '('
+        depth += 1
+      when ')'
+        depth -= 1
+        return false if depth == 0 && index < value.size - 1
+      end
+    end
+
+    depth == 0
+  end
+
+  # Extracts the top-level type arguments of a generic type string, e.g.
+  # `Array(Int32)` for ("Array(Int32)", "Array", 1). Returns nil when the
+  # name does not match *generic_name* or the arity differs.
+  def generic_type_arguments(type_name : String, generic_name : String, arity : Int32?) : Array(String)?
+    normalized = type_name.strip
+    # An absolute path marker (`::Tuple(...)`) must not defeat the match.
+    normalized = normalized.lchop("::")
+    prefix = "#{generic_name}("
+    return unless normalized.starts_with?(prefix) && normalized.ends_with?(')')
+
+    parts = split_top_level(normalized[prefix.size...-1], ',')
+    return unless arity.nil? || parts.size == arity
+
+    parts
+  end
+
+  def array_element_types(type_name : String) : Array(String)?
+    generic_type_arguments(type_name, "Array", 1).try { |parts| expand_type_names(parts[0]) }
+  end
+
+  def hash_key_types(type_name : String) : Array(String)?
+    generic_type_arguments(type_name, "Hash", 2).try { |parts| expand_type_names(parts[0]) }
+  end
+
+  def hash_value_types(type_name : String) : Array(String)?
+    generic_type_arguments(type_name, "Hash", 2).try { |parts| expand_type_names(parts[1]) }
+  end
+
+  def tuple_element_types(type_name : String) : Array(Array(String))?
+    if parts = generic_type_arguments(type_name, "Tuple", nil)
+      return parts.map { |part| expand_type_names(part) }
+    end
+
+    normalized = type_name.strip
+    if normalized.starts_with?('{') && normalized.ends_with?('}')
+      return split_top_level(normalized[1...-1], ',').map { |part| expand_type_names(part) }
+    end
+
+    nil
+  end
+
+  def named_tuple_type?(type_name : String) : Bool
+    normalized = type_name.strip
+    normalized.starts_with?("NamedTuple(") && normalized.ends_with?(')')
+  end
+
+  def named_tuple_value_types(type_name : String, field_name : String) : Array(String)?
+    return unless named_tuple_type?(type_name)
+
+    normalized = type_name.strip
+    split_top_level(normalized["NamedTuple(".size...-1], ',').each do |part|
+      key, value = part.split(":", 2)
+      next unless value
+      return expand_type_names(value.strip) if key.strip == field_name
+    end
+
+    nil
+  end
+
+  def named_tuple_all_value_types(type_name : String) : Array(String)?
+    return unless named_tuple_type?(type_name)
+
+    normalized = type_name.strip
+    value_types = split_top_level(normalized["NamedTuple(".size...-1], ',').flat_map do |part|
+      _, value = part.split(":", 2)
+      next [] of String unless value
+      expand_type_names(value.strip)
+    end.uniq
+
+    value_types.empty? ? nil : value_types
+  end
+
+  # The element type of an enumerable receiver (Array, Tuple, ...), or nil
+  # when the type string is not an enumerable.
+  def enumerable_element_types(type_name : String) : Array(String)?
+    array_element_types(type_name) || tuple_element_types(type_name).try(&.flatten.uniq)
+  end
+
+  # Compiler-semantic accessors whose indexed form carries no usable
+  # return type: `ASTNode#type?` is synthesized by the semantic pass (the
+  # source carries no def), and the base `Type#parents`/`types?`/`remove_alias`
+  # return nil on the base class while subclasses return real values. The
+  # lightweight cannot run the semantic pass, so these carry the
+  # compiler-level signatures, applied only when the index records no
+  # return for a method that exists on a `Crystal::*` receiver.
+  SEMANTIC_ACCESSOR_RETURNS = {
+    "type?"        => "Crystal::Type | ::Nil",
+    "parents"      => "Array(Crystal::Type) | ::Nil",
+    "types?"       => "Hash(String, Crystal::Type) | ::Nil",
+    "remove_alias" => "Crystal::Type",
+    # `Parser#parse` has no declared return in the compiler source and is
+    # never instantiated by the prelude driver program, so the index
+    # records no type for it; the parsed node is the AST root.
+    "parse" => "Crystal::ASTNode",
+  }
+
+  def semantic_accessor_return(method_name : String) : String?
+    SEMANTIC_ACCESSOR_RETURNS[method_name]?
+  end
+
+  # Substitutes a method's generic free vars (`Array(T)#+` returning
+  # `Array(T)`) with the receiver's concrete element types (`Array(X)`
+  # yields `Array(X)`), so chains keep the real element type instead of
+  # a bare `T` that no lookup can resolve. Class-level vars (`T` in
+  # `Array(T | U)` where only `U` is recorded as a free var) are mapped
+  # from the receiver's elements as well. Returns the original return
+  # type when nothing can be substituted.
+  def substitute_free_vars(return_type : String?, free_vars : Array(String), receiver_type_name : String) : String?
+    return return_type if return_type.nil? || free_vars.empty?
+
+    substitutions = {} of String => String
+    if elements = array_element_types(receiver_type_name)
+      free_vars.each_with_index do |var, index|
+        substitutions[var] = elements[index]? || elements.first? || var
+      end
+    elsif (keys = hash_key_types(receiver_type_name)) && (values = hash_value_types(receiver_type_name))
+      if (key_var = free_vars[0]?) && (key_type = keys.first?)
+        substitutions[key_var] = key_type
+      end
+      if (value_var = free_vars[1]?) && (value_type = values.first?)
+        substitutions[value_var] = value_type
+      end
+    elsif tuples = tuple_element_types(receiver_type_name)
+      free_vars.each_with_index do |var, index|
+        substitutions[var] = tuples[index]?.try(&.join(" | ")) || var
+      end
+    end
+
+    # Class-level vars are not listed in the method's free vars: map any
+    # remaining single-letter var in the return to the receiver's
+    # elements (by order of appearance).
+    element_pool = array_element_types(receiver_type_name) ||
+                   hash_key_types(receiver_type_name) ||
+                   hash_value_types(receiver_type_name) ||
+                   tuple_element_types(receiver_type_name).try(&.flatten)
+    if element_pool && !element_pool.empty?
+      pool_index = 0
+      return_type.scan(/\b([A-Z])\b/) do |match|
+        var = match[1]
+        next if var.nil? || substitutions.has_key?(var)
+        substitutions[var] = element_pool[pool_index % element_pool.size]
+        pool_index += 1
+      end
+    end
+    return return_type if substitutions.empty?
+
+    pattern = substitutions.keys.map { |var| Regex.escape(var) }.join("|")
+    substituted = return_type.gsub(/\b(#{pattern})\b/) { |match| substitutions[match] }
+    return return_type if substituted == return_type
+
+    deduplicate_substituted_unions(substituted)
+  end
+
+  # Substitution can collapse a union (`T | U` both mapping to the same
+  # element): collapse the duplicate members so the result stays
+  # resolvable (`Array(MethodInfo | MethodInfo)` -> `Array(MethodInfo)`).
+  private def deduplicate_substituted_unions(type_name : String) : String
+    if (parts = generic_type_arguments(type_name, "Array", 1)) && (element = parts[0]?)
+      expanded = expand_type_names(element)
+      if expanded.size > 1
+        deduped = expanded.uniq
+        return "Array(#{deduped.join(" | ")})" if deduped.size < expanded.size
+      end
+    end
+
+    expanded = expand_type_names(type_name)
+    if expanded.size > 1
+      deduped = expanded.uniq
+      return deduped.join(" | ") if deduped.size < expanded.size
+    end
+
+    type_name
+  end
+end

--- a/src/crystalline/main.cr
+++ b/src/crystalline/main.cr
@@ -1,18 +1,28 @@
 require "log"
 require "lsp/server"
+require "./version"
+# Load the compiler modules before the ext extensions: ext/compiler.cr
+# reopens Crystal compiler classes (Program, Compiler, ...) whose base
+# types live in those modules, and a consumer requiring main.cr without
+# requires.cr first (e.g. a spec) would otherwise compile the extensions
+# against an empty compiler namespace.
+require "./requires"
 require "./ext/*"
+require "./lightweight/*"
 require "./*"
 
 module Crystalline
-  VERSION = {{ (`shards version #{__DIR__}`.strip + "+" +
-                system("git rev-parse --short HEAD || echo unknown").stringify).stringify.strip }}
   # Supported server capabilities.
   SERVER_CAPABILITIES = LSP::ServerCapabilities.new(
     text_document_sync: LSP::TextDocumentSyncKind::Incremental,
     document_formatting_provider: true,
     document_range_formatting_provider: true,
     completion_provider: LSP::CompletionOptions.new(
-      trigger_characters: [".", ":", "@"],
+      # Identifier characters included so clients fire completion while the
+      # user is typing a plain word (not just after `.`, `::` or `@`). The
+      # lightweight path answers in tens of milliseconds, so per-keystroke
+      # requests are cheap.
+      trigger_characters: [".", ":", "@"] + ('a'..'z').to_a.map(&.to_s) + ('A'..'Z').to_a.map(&.to_s) + ["_"],
     ),
     hover_provider: true,
     definition_provider: true,
@@ -31,10 +41,46 @@ module Crystalline
     end
 
     private def self.initialize_from_crystal_env
-      crystal_env
+      parse_crystal_env_output(crystal_env)
+    end
+
+    # Parses `crystal env` output (bare `KEY=value` lines, values shell-
+    # quoted) into an env map. Split on the first `=` only: a value may
+    # contain `=` itself (`CRYSTAL_OPTS='-Dfoo=1'`), and a full split would
+    # truncate it and leak the opening quote into the imported env — which
+    # the next `crystal env` run re-escapes, growing the variable
+    # exponentially until subprocess spawning fails with E2BIG.
+    def self.parse_crystal_env_output(output : String) : Hash(String, String)
+      output
         .lines
-        .map(&.split('='))
+        .map { |line| line.split('=', 2) }
         .to_h
+        .transform_values { |value| unquote_env_value(value) }
+    end
+
+    # `crystal env` shell-quotes values (e.g. `CRYSTAL_OPTS=''`). Import them
+    # verbatim would re-import the quotes, which the next `crystal env` run
+    # escapes again — growing the value exponentially until subprocess
+    # spawning fails with E2BIG. Decode the shell quoting instead: values are
+    # wrapped in single quotes, and a single quote inside the value is escaped
+    # as `'"'"'` (close quote, double-quoted quote, reopen quote).
+    def self.unquote_env_value(value : String) : String
+      return value unless value.starts_with?('\'') && value.ends_with?('\'') && value.size >= 2
+
+      String.build do |result|
+        index = 1
+        while index < value.size - 1
+          char = value[index]
+          if char == '\'' && value[index + 1]? == '"' && value[index + 2]? == '\'' && value[index + 3]? == '"' && value[index + 4]? == '\''
+            # A single quote inside single quotes is escaped as `'"'"'`.
+            result << '\''
+            index += 5
+          else
+            result << char
+            index += 1
+          end
+        end
+      end
     end
 
     private def self.crystal_env

--- a/src/crystalline/position_utils.cr
+++ b/src/crystalline/position_utils.cr
@@ -1,0 +1,33 @@
+module Crystalline::PositionUtils
+  extend self
+
+  # LSP positions are UTF-16 code units while Crystal source positions
+  # (lexer/parser columns, String#[]) are character-based. Both are identical
+  # unless the line contains astral-plane characters (e.g. emoji), which
+  # occupy one character but two UTF-16 code units.
+  #
+  # Convert a UTF-16 column to a character index within *line*.
+  def utf16_to_char_index(line : String, utf16_index : Int32) : Int32
+    return utf16_index if utf16_index <= 0
+
+    char_index = 0
+    line.each_char do |char|
+      break if utf16_index <= 0
+      utf16_index -= (char.ord > 0xFFFF ? 2 : 1)
+      char_index += 1
+    end
+    char_index
+  end
+
+  # Convert a character index within *line* back to a UTF-16 column.
+  def char_to_utf16_index(line : String, char_index : Int32) : Int32
+    return char_index if char_index <= 0
+
+    utf16_index = 0
+    line.each_char_with_index do |char, index|
+      break if index >= char_index
+      utf16_index += (char.ord > 0xFFFF ? 2 : 1)
+    end
+    utf16_index
+  end
+end

--- a/src/crystalline/project.cr
+++ b/src/crystalline/project.cr
@@ -1,10 +1,32 @@
 require "yaml"
+require "uri"
+require "./ext/uri"
+require "./lightweight/index"
+require "./lightweight/summary"
 
 class Crystalline::Project
   # The project root filesystem uri.
   getter root_uri : URI
+  # Lightweight top-level semantic index for interactive features.
+  property lightweight_index : Crystalline::Lightweight::Index?
+  # Compiler-backed semantic summary built from the last successful full compile.
+  property semantic_summary : Crystalline::Lightweight::Summary?
   # The dependencies of the project, meaning the list of files required by the compilation target (entry point).
   property dependencies : Set(String) = Set(String).new
+  # Parse-only index of the project's own source files (src/ + lib/), built
+  # lazily before the first compile so receivers of project types resolve
+  # during the cold-start window. Invalidated when a project file is saved
+  # or closed.
+  @source_index : Crystalline::Lightweight::Index?
+
+  def source_index : Crystalline::Lightweight::Index?
+    @source_index ||= build_source_index
+  end
+
+  def source_index=(index : Crystalline::Lightweight::Index?)
+    @source_index = index
+  end
+
   # Determines the project entry point.
   getter? entry_point : URI? do
     shard_name = shard_yaml["name"].as_s
@@ -21,7 +43,7 @@ class Crystalline::Project
   rescue e
     nil
   end
-  # Flags to pass to the underlying compiler (-Dpreview_mt, etc).
+  # Flags to pass to the underlying compiler (e.g. -Dexecution_context).
   getter flags : Array(String) do
     (shard_yaml.dig?("crystalline", "flags").try(&.as_a.map(&.as_s)) || [] of String).tap do |flags|
       LSP::Log.info { "Flags for project #{root_uri}: #{flags}" }
@@ -73,13 +95,16 @@ class Crystalline::Project
   end
 
   # Finds the path-wise distance to the given file URI. If the file URI is not a
-  # dependency of this workspace's entry point, returns nil.
-  def distance_to_dependency(file_uri : URI) : Int32?
+  # dependency of this workspace's entry point, returns nil unless
+  # *require_dependency* is false (a pure path-based fit used by lightweight
+  # queries, which never drives compile targeting or cache invalidation).
+  def distance_to_dependency(file_uri : URI, *, require_dependency = true) : Int32?
     relative = Path[file_uri.decoded_path].relative_to?(root_uri.decoded_path)
+    return nil if relative.nil?
 
-    # If we can't get a relative path, give it the maximum distance possible, so
-    # it's the lowest priority.
-    return Int32::MAX if relative.nil?
+    if require_dependency && dependencies.present? && !dependencies.includes?(file_uri.decoded_path)
+      return nil
+    end
 
     relative.parts.size
   end
@@ -89,10 +114,39 @@ class Crystalline::Project
     Path[@root_uri.decoded_path, "lib"].to_s
   end
 
-  # Finds the best-fitting project to use for the given file.
-  def self.best_fit_for_file(projects : Array(Project), file_uri : URI) : Project?
+  # Parses every project source file (src/ + lib/) into a single index.
+  # No semantic pass: type names, method signatures and docs only, which is
+  # enough to complete receivers like `workspace` before the first compile.
+  private def build_source_index : Crystalline::Lightweight::Index?
+    files = [] of String
+    root = @root_uri.decoded_path
+
+    src_dir = Path[root, "src"]
+    files.concat(Dir.glob(Path[src_dir, "**", "*.cr"]).sort) if Dir.exists?(src_dir)
+
+    lib_dir = Path[root, "lib"]
+    files.concat(Dir.glob(Path[lib_dir, "*", "src", "**", "*.cr"]).sort) if Dir.exists?(lib_dir)
+
+    indexes = [] of Crystalline::Lightweight::Index
+    files.each do |file|
+      next unless File.file?(file)
+      if index = Crystalline::Lightweight::Index.from_source(File.read(file), file)
+        indexes << index
+      end
+    end
+
+    return if indexes.empty?
+
+    LSP::Log.info { "[project] source index: #{indexes.size} files for #{root}" }
+    Crystalline::Lightweight::Index.merge(indexes)
+  end
+
+  # Finds the best-fitting project to use for the given file. By default only
+  # files that are dependencies of a project's entry point match; pass
+  # *require_dependency* = false for a pure path-based fit.
+  def self.best_fit_for_file(projects : Array(Project), file_uri : URI, *, require_dependency = true) : Project?
     project_distances = projects.compact_map do |p|
-      distance = p.distance_to_dependency(file_uri)
+      distance = p.distance_to_dependency(file_uri, require_dependency: require_dependency)
       {p, distance} if distance
     end
 

--- a/src/crystalline/requires.cr
+++ b/src/crystalline/requires.cr
@@ -1,5 +1,6 @@
 require "llvm/lib_llvm"
 require "compiler/crystal/annotatable"
+require "compiler/crystal/program"
 require "compiler/crystal/tools/dependencies"
 require "compiler/crystal/compiler"
 require "compiler/crystal/config"
@@ -9,7 +10,6 @@ require "compiler/crystal/exception"
 require "compiler/crystal/formatter"
 require "compiler/crystal/loader"
 require "compiler/crystal/macros"
-require "compiler/crystal/program"
 require "compiler/crystal/progress_tracker"
 require "compiler/crystal/semantic"
 require "compiler/crystal/syntax"
@@ -20,3 +20,22 @@ require "compiler/crystal/macros/**"
 require "compiler/crystal/codegen/**"
 require "compiler/crystal/tools/implementations"
 require "compiler/crystal/tools/context"
+
+# Crystal >= 1.21.0 references `Crystal::Command::Exit` from `CompilerError`
+# overloads in the compiler, but `compiler/crystal/command` — which defines it —
+# drags in the CLI's optional tooling (e.g. the `markd` shard for `crystal docs`).
+# Define the enum here so the compiler can be required without the full CLI —
+# unless the compiler already provides it (a future version might).
+{% unless Crystal::Command.has_constant?(:Exit) %}
+  module Crystal
+    class Command
+      enum Exit
+        OK             = 0
+        FAILURE        = 1
+        USAGE_ERROR    = 1
+        CODE_ERROR     = 1
+        SOFTWARE_ERROR = 1
+      end
+    end
+  end
+{% end %}

--- a/src/crystalline/source_mask.cr
+++ b/src/crystalline/source_mask.cr
@@ -1,0 +1,108 @@
+module Crystalline
+  # Records which parts of a source file are comments, string literals or
+  # heredoc bodies, so interactive features do not try to resolve prose as
+  # code (hovering the word "requests" inside a comment must be a graceful
+  # miss, not a resolution attempt).
+  class SourceMask
+    @ranges = {} of Int32 => Array(Range(Int32, Int32))
+    @heredoc_terminators = [] of String
+
+    def initialize(source : String)
+      scan(source)
+    end
+
+    def comment_or_string?(line : Int32, column : Int32) : Bool
+      @ranges[line]?.try(&.any? { |range| range.covers?(column) }) || false
+    end
+
+    private def scan(source : String)
+      source.lines(chomp: false).each_with_index do |line, line_index|
+        # Heredoc bodies span lines: mask everything until the terminator.
+        if terminator = @heredoc_terminators.first?
+          if line.strip == terminator
+            @heredoc_terminators.delete_at(0)
+          else
+            (@ranges[line_index] ||= [] of Range(Int32, Int32)) << (0...line.size)
+            next
+          end
+        end
+
+        mask_line(line, line_index)
+        detect_heredoc(line)
+      end
+    end
+
+    # Masks comments, double-quoted strings and char literals on one line.
+    private def mask_line(line : String, line_index : Int32)
+      ranges = [] of Range(Int32, Int32)
+      index = 0
+      while index < line.size
+        case line[index]
+        when '#'
+          ranges << (index...line.size)
+          break
+        when '"'
+          index += 1
+          string_start = index - 1
+          interpolation_start = -1
+          interpolation_depth = 0
+          while index < line.size
+            if line[index] == '\\'
+              index += 2
+              next
+            end
+            if interpolation_depth > 0
+              if line[index] == '{'
+                interpolation_depth += 1
+              elsif line[index] == '}'
+                interpolation_depth -= 1
+                if interpolation_depth == 0
+                  # The interpolation body is code, not string content:
+                  # leave it unmasked.
+                  ranges << (string_start...interpolation_start) if string_start < interpolation_start
+                  string_start = index + 1
+                end
+              end
+              index += 1
+              next
+            end
+            if line[index] == '#' && line[index + 1]? == '{'
+              interpolation_start = index
+              interpolation_depth = 1
+              index += 2
+              next
+            end
+            break if line[index] == '"'
+            index += 1
+          end
+          index += 1 if index < line.size
+          ranges << (string_start...index) if string_start < index
+        when '\''
+          start = index
+          index += 1
+          while index < line.size
+            if line[index] == '\\'
+              index += 2
+              next
+            end
+            break if line[index] == '\''
+            index += 1
+          end
+          index += 1 if index < line.size
+          ranges << (start...index)
+        else
+          index += 1
+        end
+      end
+      @ranges[line_index] = ranges unless ranges.empty?
+    end
+
+    # Detects `<<-IDENT` / `<<~IDENT` heredoc openers (the unambiguous forms;
+    # a bare `<<IDENT` is indistinguishable from a shift-left expression).
+    private def detect_heredoc(line : String)
+      if match = line.match(/\<\<[-~]([A-Za-z_]\w*)\s*$/)
+        @heredoc_terminators << match[1]
+      end
+    end
+  end
+end

--- a/src/crystalline/text_document.cr
+++ b/src/crystalline/text_document.cr
@@ -6,11 +6,19 @@ class Crystalline::TextDocument
   getter uri : URI
   @inner_contents : Array(String) = [] of String
   getter! version : Int32
+
+  # The client-assigned version, or 0 when the client never sent one.
+  def version_number : Int32
+    @version || 0
+  end
+
   @pending_changes : Priority::Queue({String, LSP::Range}) = Priority::Queue({String, LSP::Range}).new
   getter? project : Project?
+  getter? dirty = false
 
   def initialize(@uri, @project, contents : String)
     self.contents = contents
+    @dirty = false
   end
 
   def contents=(contents : String)
@@ -48,6 +56,12 @@ class Crystalline::TextDocument
       item = @pending_changes.shift
       partial_update(item.value[0], item.value[1], version: item.priority.to_i32)
     end
+
+    @dirty = true
+  end
+
+  def mark_saved
+    @dirty = false
   end
 
   private def update_contents(contents : String, range : LSP::Range? = nil, version : Int32? = nil)

--- a/src/crystalline/version.cr
+++ b/src/crystalline/version.cr
@@ -1,0 +1,8 @@
+module Crystalline
+  # The LSP's own version (shard version + build commit), kept in its own
+  # file so it is defined before the lightweight files are required: the
+  # prelude cache is keyed on it, so upgraded builds regenerate their
+  # prelude instead of reusing a stale one forever.
+  VERSION = {{ (`shards version #{__DIR__}`.strip + "+" +
+                system("git rev-parse --short HEAD || echo unknown").stringify).stringify.strip }}
+end

--- a/src/crystalline/workspace.cr
+++ b/src/crystalline/workspace.cr
@@ -4,11 +4,28 @@ require "./text_document"
 require "./progress"
 require "./project"
 require "./result_cache"
+require "./lightweight/completion"
+require "./lightweight/hover"
+require "./lightweight/definitions"
 require "./analysis/*"
 
 class Crystalline::Workspace
   # The previous compilation results, indexed by compilation entry point.
   @result_cache : Crystalline::ResultCache = Crystalline::ResultCache.new
+  # Last successful semantic analysis results, used as a fast fallback for interactive features.
+  # The cache survives document edits (only the compile-result dedup cache is invalidated);
+  # semantic_cache_allowed? refuses to serve files that changed on disk after the compile.
+  @semantic_cache : Hash(String, Crystal::Compiler::Result) = {} of String => Crystal::Compiler::Result
+  # On-disk modification time of every source file at the last successful compile.
+  @compiled_source_mtimes : Hash(String, Time) = {} of String => Time
+  # Lightweight queries per open document, keyed by (uri, version). Each one
+  # shares the project index and overlays only the document's own source, so
+  # rebuilding one is cheap and must not happen per request.
+  @query_cache = {} of String => {Int32, Crystalline::Lightweight::Query}
+  @query_cache_lock = Mutex.new
+  # Guards @opened_documents against the background query warm-up, which runs
+  # on the compile execution context while the main context mutates the map.
+  @documents_mutex = Mutex.new
   # The workspace filesystem uri.
   getter root_uri : URI?
   # A list of documents that are openened in the text editor.
@@ -33,37 +50,52 @@ class Crystalline::Workspace
   def open_document(params : LSP::DidOpenTextDocumentParams)
     raw_uri = params.text_document.uri
     uri = URI.parse(raw_uri)
-    project = Project.best_fit_for_file(@projects, uri)
+    project = project_for_file(uri)
     document = TextDocument.new(uri, project, params.text_document.text)
-    @opened_documents[raw_uri] = document
+    @documents_mutex.synchronize { @opened_documents[raw_uri] = document }
   end
 
   def update_document(server : LSP::Server, params : LSP::DidChangeTextDocumentParams)
     file_uri = params.text_document.uri
-    @opened_documents[file_uri]?.try { |document|
+    parsed_uri = URI.parse(file_uri)
+    document = @opened_documents[file_uri]?
+
+    document.try { |opened_document|
       content_changes = params.content_changes.map { |change|
         {change.text, change.range}
       }
-      document.update_contents(content_changes, version: params.text_document.version)
-
-      document.project?.try(&.entry_point?).try { |entry|
-        @result_cache.invalidate(entry.to_s)
-      }
+      opened_document.update_contents(content_changes, version: params.text_document.version)
     }
+
     @result_cache.invalidate(file_uri)
-    # spawn self.compile(server, URI.parse(file_uri), in_memory: true )
+    invalidate_project_caches(parsed_uri, document)
+    @query_cache_lock.synchronize { @query_cache.delete(file_uri) }
   end
 
   def close_document(server : LSP::Server, params : LSP::DidCloseTextDocumentParams)
     file_uri = params.text_document.uri
-    document = @opened_documents.delete(params.text_document.uri)
+    parsed_uri = URI.parse(file_uri)
+    document = @documents_mutex.synchronize { @opened_documents.delete(params.text_document.uri) }
     @result_cache.invalidate(file_uri)
+    # The parsed source index snapshots disk state: a saved or closed file
+    # may have changed on disk, so the next query rebuilds it.
+    project_for_file(parsed_uri).try(&.source_index = nil)
+    invalidate_project_caches(parsed_uri, document)
+    @query_cache_lock.synchronize { @query_cache.delete(file_uri) }
     Diagnostics.new.init_value(file_uri).publish(server) unless document.try(&.project?)
   end
 
   def save_document(server : LSP::Server, params : LSP::DidSaveTextDocumentParams)
     file_uri = params.text_document.uri
+    parsed_uri = URI.parse(file_uri)
+    document = @opened_documents[file_uri]?
+
+    document.try &.mark_saved
     @result_cache.invalidate(file_uri)
+    # The file changed on disk: the parsed source index is stale until it
+    # is rebuilt (or the compile replaces it with the semantic index).
+    project_for_file(parsed_uri).try(&.source_index = nil)
+    invalidate_project_caches(parsed_uri, document)
   end
 
   def format_document(params : LSP::DocumentFormattingParams) : {String, TextDocument}?
@@ -90,9 +122,24 @@ class Crystalline::Workspace
   def recalculate_dependencies(server, project)
     return unless (target = project.entry_point?)
 
+    LSP::Log.info { "[compile] dependency recalculation: #{target.decoded_path}" }
     lib_path = project.default_lib_path
-    Analysis.compile(server, target, lib_path: lib_path, ignore_diagnostics: true, wants_doc: false, top_level: true, compiler_flags: project.flags).try { |result|
+    Analysis.compile(server, target, lib_path: lib_path, ignore_diagnostics: true, wants_doc: true, top_level: true, compiler_flags: project.flags).try { |result|
       project.dependencies = result.program.requires
+      # Build the summary and index off the event loop: they walk the whole
+      # typed program. The top-level pass gives the compiler-derived method
+      # restrictions and block contracts within seconds, before the full
+      # compile finishes.
+      summary, index = Analysis.run_dedicated do
+        {
+          Crystalline::Lightweight::Summary.from_result(result),
+          Crystalline::Lightweight::Index.from_program(result.program),
+        }
+      end
+      project.semantic_summary = summary
+      project.lightweight_index = index
+      @query_cache_lock.synchronize { @query_cache.clear }
+      warm_query_cache
     }
   rescue
     nil
@@ -106,13 +153,9 @@ class Crystalline::Workspace
     server : LSP::Server,
     file_uri : URI,
     *,
-    in_memory = false,
     ignore_diagnostics = server.client_capabilities.ignore_diagnostics?,
     ignore_cached_result = false,
-    do_not_cache_result = false,
     wants_doc = false,
-    text_overrides = nil,
-    fail_fast = false,
     top_level = false,
     discard_nil_cached_result = false,
   )
@@ -145,9 +188,18 @@ class Crystalline::Workspace
     end
 
     target_string = target.to_s
+    LSP::Log.info do
+      source_kind = if top_level
+                      "top-level"
+                    else
+                      "filesystem"
+                    end
+      "[compile] request: target=#{target.decoded_path} source=#{source_kind} ignore_cached=#{ignore_cached_result} discard_nil_cached=#{discard_nil_cached_result}"
+    end
     # Check if we can serve the result from the cache.
     if !ignore_cached_result && @result_cache.exists?(target_string) && !@result_cache.invalidated?(target_string)
       cached_result = @result_cache.get(target_string)
+      LSP::Log.info { "[compile] cache hit: #{target.decoded_path}" }
       return cached_result unless cached_result.nil? && discard_nil_cached_result
     end
 
@@ -156,41 +208,45 @@ class Crystalline::Workspace
       # Check again the cache in case some previous compilation that ran while waiting for the mutex to unlock is still valid.
       if !ignore_cached_result && @result_cache.exists?(target_string) && !@result_cache.invalidated?(target_string)
         cached_result = @result_cache.get(target_string)
+        LSP::Log.info { "[compile] cache hit after wait: #{target.decoded_path}" }
         return cached_result unless cached_result.nil? && discard_nil_cached_result
       end
 
       sync_channel = Channel(Crystal::Compiler::Result?).new
 
       progress.report(server) do
-        file_overrides = nil
-        sources = nil
         # Store the start of the compilation.
         compilation_start = @result_cache.monotonic_now
-        if in_memory
-          # Tell the compiler to load the opened files from memory, not from the filesystem.
-          file_overrides = Hash(String, String).new
-          @opened_documents.each { |uri_str, text_document|
-            contents = text_overrides.try(&.[uri_str]?) || text_document.contents
-            contents = fix_source(contents)
-
-            if target_string == uri_str
-              # If the entry point itself needs to be loaded from memory.
-              sources = [
-                Crystal::Compiler::Source.new(target.decoded_path, contents),
-              ]
-            end
-            file_path = URI.parse(uri_str).decoded_path
-            file_overrides[file_path] = contents
-          }
-        end
 
         lib_path = project.try(&.default_lib_path)
-        result = Analysis.compile(server, sources || target, lib_path: lib_path, file_overrides: file_overrides, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level, compiler_flags: project.try(&.flags) || [] of String)
+        LSP::Log.info { "[compile] analysis start: #{target.decoded_path}" }
+        result = Analysis.compile(server, target, lib_path: lib_path, ignore_diagnostics: ignore_diagnostics, wants_doc: wants_doc, top_level: top_level, compiler_flags: project.try(&.flags) || [] of String)
         # Store the result in the cache, unless a client event invalided the previous cache.
         # For instance if a compilation is running, but the user saved the document in the meantime (before completion)
         # then we discard the result because it is already outdated.
-        unless do_not_cache_result
-          @result_cache.set(target_string, result, unless_invalidated_since: compilation_start)
+        @result_cache.set(target_string, result, unless_invalidated_since: compilation_start)
+
+        if result && !top_level && !@result_cache.invalidated?(target_string)
+          # Build the summary and index off the event loop: they walk the
+          # whole typed program.
+          summary, index = Analysis.run_dedicated do
+            {
+              Crystalline::Lightweight::Summary.from_result(result),
+              Crystalline::Lightweight::Index.from_program(result.program),
+            }
+          end
+
+          # A client event may have invalidated the compile while the
+          # index/summary were being built: only publish when still relevant.
+          unless @result_cache.invalidated?(target_string)
+            @semantic_cache[target_string] = result
+            stamp_compiled_sources(result)
+            project.try &.semantic_summary = summary
+            project.try { |p| p.lightweight_index = index }
+            # The project index changed: cached lightweight queries are stale.
+            @query_cache_lock.synchronize { @query_cache.clear }
+            warm_query_cache
+          end
         end
 
         if result
@@ -217,6 +273,140 @@ class Crystalline::Workspace
     end
   end
 
+  private def project_for_file(file_uri : URI) : Project?
+    Project.best_fit_for_file(@projects, file_uri)
+  end
+
+  private def lightweight_query_for(document : TextDocument) : Crystalline::Lightweight::Query?
+    cache_key = document.uri.to_s
+    @query_cache_lock.synchronize do
+      if cached = @query_cache[cache_key]?
+        return cached[1] if cached[0] == document.version_number
+      end
+    end
+
+    query = if project = document.project? || Project.best_fit_for_file(@projects, document.uri, require_dependency: false)
+              if project_index = project.lightweight_index
+                if document.dirty? || !project.dependencies.includes?(document.uri.decoded_path)
+                  # The buffer diverges from what was compiled, or the file is
+                  # not part of the compiled program at all (e.g. a new file
+                  # not yet required): overlay the source index on top of the
+                  # project index. The overlay is a small per-file index; the
+                  # project index is shared across documents instead of being
+                  # copied per keystroke.
+                  source_index = Crystalline::Lightweight::Index.from_source(fix_source(document.contents), document.uri.decoded_path)
+                  Crystalline::Lightweight::Query.new(project_index, project.semantic_summary, secondary: Crystalline::Lightweight::PreludeIndex.get, overlay: source_index)
+                else
+                  # A clean dependency buffer matches the compiled sources:
+                  # the project index is authoritative, no overlay needed.
+                  Crystalline::Lightweight::Query.new(project_index, project.semantic_summary, secondary: Crystalline::Lightweight::PreludeIndex.get)
+                end
+              end
+            end
+
+    query ||= begin
+      source_index = Crystalline::Lightweight::Index.from_source(fix_source(document.contents), document.uri.decoded_path)
+      if source_index
+        # Before the project index exists (no compile yet), the base index
+        # is the project's own source files parsed from disk, so receivers
+        # of project types (e.g. `workspace`) resolve from the very first
+        # keystroke. The stdlib prelude is layered underneath.
+        project_index = document.project?.try(&.source_index)
+        project_index ||= Project.best_fit_for_file(@projects, document.uri, require_dependency: false).try(&.source_index)
+        if project_index
+          if prelude = Crystalline::Lightweight::PreludeIndex.get
+            Crystalline::Lightweight::Query.new(project_index, secondary: prelude, overlay: source_index)
+          else
+            Crystalline::Lightweight::Query.new(project_index, overlay: source_index)
+          end
+        elsif prelude = Crystalline::Lightweight::PreludeIndex.get
+          Crystalline::Lightweight::Query.new(prelude, overlay: source_index)
+        else
+          Crystalline::Lightweight::Query.new(source_index)
+        end
+      end
+    end
+
+    @query_cache_lock.synchronize do
+      if query
+        @query_cache[cache_key] = {document.version_number, query}
+      else
+        @query_cache.delete(cache_key)
+      end
+    end
+    query
+  end
+
+  # Rebuild the cached lightweight query of every opened document in the
+  # background, so the first interactive request after a compile does not pay
+  # the project-index merge. Runs on the compile context: snapshot the open
+  # documents under a lock before touching them.
+  private def warm_query_cache
+    spawn do
+      documents = @documents_mutex.synchronize { @opened_documents.values.dup }
+      documents.each do |document|
+        lightweight_query_for(document)
+      end
+    end
+  end
+
+  private def semantic_cache_key(file_uri : URI) : String
+    if (project = project_for_file(file_uri)) && (entry_point = project.entry_point?)
+      entry_point.to_s
+    else
+      file_uri.to_s
+    end
+  end
+
+  private def invalidate_project_caches(file_uri : URI, document : TextDocument?)
+    cache_keys = Set(String).new
+
+    document.try(&.project?).try(&.entry_point?).try { |entry|
+      cache_keys << entry.to_s
+    }
+
+    project_for_file(file_uri).try(&.entry_point?).try { |entry|
+      cache_keys << entry.to_s
+    }
+
+    # The semantic cache is intentionally kept across edits: it holds the
+    # last successful compile and semantic_cache_allowed? refuses to serve
+    # it for files that changed since.
+    cache_keys.each do |cache_key|
+      @result_cache.invalidate(cache_key)
+    end
+  end
+
+  private def semantic_cache_allowed?(file_uri : URI) : Bool
+    document = @opened_documents[file_uri.to_s]?
+    return false if document.try(&.dirty?)
+
+    # The semantic cache holds the last successful compile. Only serve it
+    # for files whose on-disk content is the one that was compiled, so a
+    # save whose compile failed (or an external edit) cannot poison other
+    # files' requests with stale results.
+    return true unless file_uri.scheme == "file"
+
+    path = file_uri.decoded_path
+    mtime = @compiled_source_mtimes[path]?
+    return true unless mtime
+
+    File.info(path).modification_time == mtime
+  rescue File::NotFoundError
+    false
+  end
+
+  private def stamp_compiled_sources(result : Crystal::Compiler::Result)
+    stamps = {} of String => Time
+    result.program.requires.each do |filename|
+      begin
+        stamps[filename] = File.info(filename).modification_time
+      rescue File::NotFoundError
+      end
+    end
+    @compiled_source_mtimes = stamps
+  end
+
   private def append_markdown_doc(contents : Array(String), doc : String?)
     if doc
       contents << "----------"
@@ -239,7 +429,33 @@ class Crystalline::Workspace
   end
 
   def hover(server : LSP::Server, file_uri : URI, position : LSP::Position)
-    result = self.compile(server, file_uri, in_memory: true, wants_doc: true)
+    if text_document = @opened_documents[file_uri.to_s]?
+      source = fix_source(text_document.contents)
+      if query = lightweight_query_for(text_document)
+        hover, reason = Crystalline::Lightweight::Hover.hover_and_reason(source, position.line, position.character, query)
+        if hover
+          LSP::Log.info { "[hover] lightweight hit: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+          return hover
+        end
+
+        LSP::Log.info { "[hover] lightweight miss: #{file_uri.decoded_path}:#{position.line}:#{position.character} reason=#{reason}" }
+      else
+        LSP::Log.info { "[hover] lightweight miss: #{file_uri.decoded_path}:#{position.line}:#{position.character} reason=no lightweight query" }
+      end
+    end
+
+    unless semantic_cache_allowed?(file_uri)
+      LSP::Log.info { "[hover] bail on dirty buffer: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    result = @semantic_cache[semantic_cache_key(file_uri)]?
+    unless result
+      LSP::Log.info { "[hover] bail without compile: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    LSP::Log.info { "[hover] semantic cache hit: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
     location = Crystal::Location.new(
       file_uri.decoded_path,
       line_number: position.line + 1,
@@ -311,7 +527,31 @@ class Crystalline::Workspace
   end
 
   def definitions(server : LSP::Server, file_uri : URI, position : LSP::Position)
-    result = self.compile(server, file_uri, in_memory: true, wants_doc: true)
+    if text_document = @opened_documents[file_uri.to_s]?
+      source = fix_source(text_document.contents)
+      query = lightweight_query_for(text_document)
+      locations, reason = Crystalline::Lightweight::Definitions.definitions_and_reason(source, file_uri, position.line, position.character, query)
+      if locations
+        LSP::Log.info { "[definitions] lightweight hit: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+        return locations
+      end
+
+      LSP::Log.info { "[definitions] lightweight miss: #{file_uri.decoded_path}:#{position.line}:#{position.character} reason=#{reason}" }
+    end
+
+    unless semantic_cache_allowed?(file_uri)
+      LSP::Log.info { "[definitions] bail on dirty buffer: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    result = @semantic_cache[semantic_cache_key(file_uri)]?
+    unless result
+      LSP::Log.info { "[definitions] bail without compile: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    LSP::Log.info { "[definitions] semantic cache hit: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+
     location = Crystal::Location.new(
       file_uri.decoded_path,
       line_number: position.line + 1,
@@ -370,11 +610,21 @@ class Crystalline::Workspace
     return unless completion_context
 
     trigger_character = completion_context.trigger_character
-    document_lines[position.line] = completion_context.rewritten_line
-    # Force the compiler load the file from this Hash.
-    text_overrides = {
-      file_uri.to_s => document_lines.join,
-    }
+
+    if query = lightweight_query_for(text_document)
+      completion_items, reason = Crystalline::Lightweight::Completion.complete_and_reason(document_lines.join, position.line, completion_context, query)
+      if completion_items
+        # A resolved completion may legitimately be empty (e.g. no ivars
+        # match a fragment): only a miss (nil) falls through to the
+        # compiled fallback.
+        LSP::Log.info { "[completion] lightweight hit: #{file_uri.decoded_path}:#{position.line}:#{position.character} items=#{completion_items.size}" }
+        return build_completion_list(completion_items)
+      end
+
+      LSP::Log.info { "[completion] lightweight miss: #{file_uri.decoded_path}:#{position.line}:#{position.character} reason=#{reason}" }
+    else
+      LSP::Log.info { "[completion] lightweight miss: #{file_uri.decoded_path}:#{position.line}:#{position.character} reason=no lightweight query" }
+    end
 
     location = Crystal::Location.new(
       file_uri.decoded_path,
@@ -382,19 +632,18 @@ class Crystalline::Workspace
       column_number: completion_context.analysis_column,
     )
 
-    # Trigger a compilation that will not fail fast.
-    result = self.compile(
-      server,
-      file_uri,
-      in_memory: true,
-      discard_nil_cached_result: true,
-      wants_doc: true,
-      text_overrides: text_overrides,
-      # Prevent showing diagnostics and caching results since the diagnostics can be inaccurate
-      ignore_diagnostics: true,
-      do_not_cache_result: true
-    )
-    return unless result
+    unless semantic_cache_allowed?(file_uri)
+      LSP::Log.info { "[completion] bail on dirty buffer: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    result = @semantic_cache[semantic_cache_key(file_uri)]?
+    unless result
+      LSP::Log.info { "[completion] bail without compile: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
+      return
+    end
+
+    LSP::Log.info { "[completion] semantic cache hit: #{file_uri.decoded_path}:#{position.line}:#{position.character}" }
 
     nodes, _ = Analysis.nodes_at_cursor(result, location)
     nodes.last?.try do |n|
@@ -527,29 +776,33 @@ class Crystalline::Workspace
         }
       end
 
-      selected_element_index = nil
-      completion_items.each_with_index do |elt, i|
-        sort_text = elt.sort_text || elt.label
-        selected_element_index ||= i
-        target = completion_items[selected_element_index].try { |e| e.sort_text || e.label }
-        if (sort_text <=> target) < 0
-          selected_element_index = i
-        end
-      end
-
-      if selected_element_index
-        selected_element = completion_items[selected_element_index]
-        selected_element.preselect = true
-        completion_items[selected_element_index] = selected_element
-      end
-
-      LSP::CompletionList.new(
-        is_incomplete: false,
-        items: completion_items,
-      )
+      build_completion_list(completion_items)
     end
   rescue
     nil
+  end
+
+  private def build_completion_list(completion_items : Array(LSP::CompletionItem)) : LSP::CompletionList
+    selected_element_index = nil
+    completion_items.each_with_index do |elt, i|
+      sort_text = elt.sort_text || elt.label
+      selected_element_index ||= i
+      target = completion_items[selected_element_index].try { |e| e.sort_text || e.label }
+      if (sort_text <=> target) < 0
+        selected_element_index = i
+      end
+    end
+
+    if selected_element_index
+      selected_element = completion_items[selected_element_index]
+      selected_element.preselect = true
+      completion_items[selected_element_index] = selected_element
+    end
+
+    LSP::CompletionList.new(
+      is_incomplete: false,
+      items: completion_items,
+    )
   end
 
   def document_symbols(server : LSP::Server, file_uri : URI)


### PR DESCRIPTION
## What this PR does

Adds a parse-only lightweight analysis engine that answers **completion, hover and go-to-definitions instantly** — before the first compile and on unsaved buffers — so interactive features no longer wait for (or trigger) a full compilation pass.

## Highlights

- **Lightweight engine** (`src/crystalline/lightweight/`)
  - Parse-only index of project sources, merged with the compiled program's top-level semantics and a disk-cached stdlib prelude (keyed by Crystal + LSP version)
  - Local/ivar/cvar/constant type inference with control-flow narrowing (`if`/`unless`/`case`/`is_a?`/`&&`/`||`/loops) under cursor bounds
  - Receiver resolution through calls, `try(&.)`, casts, nilable indexes, range slices, tuples, named tuples and generics
  - Method contracts derived from declarations; subtype-method fallback for compiler hierarchy roots (`Crystal::ASTNode` → `Var#name`)
  - Dirty buffers overlay their own parse on the shared project index — one cheap rebuild per version, not per request
- **Completion while typing** — identifier characters are advertised as completion triggers; results ranked closest-type-first (own methods before inherited)
- **Go-to definitions overhaul** — assignment targets jump to setters (`parser.filename =` → `filename=`), locals/def args/block params jump to their declaration, `require "..."` resolves through the crystal path (relative, stdlib, shard layouts), and stdlib locations are persisted in the prelude cache
- **Broken-source fixer** repairs mid-edit truncations (trailing dots, cut block headers, multi-line call tails) so analysis keeps working while typing
- **Responsive compiles** — compiles run on a dedicated execution context; the last successful compile is kept as a fallback, guarded by file mtimes

## Review

The branch went through a review loop before this PR; the defects found were fixed in place: completion overload dedup, `crystal env` value parsing, multi-line receiver chains, range-slice receivers, identifier-trigger completion detection, and formatting drift. Test coverage was extended alongside (edge cases, overloads, `||=` inference).

## Verification

- `crystal spec`: **251 examples, 0 failures** (lightweight suite 119/0)
- `shards build` clean
- End-to-end LSP smoke: hover, completion (with identifier triggers) and shutdown against the real binary
